### PR TITLE
Fix "Manifest file is missing or unreadable" for release zip installs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Package extension
+        # Zip the *contents* of extension/ so manifest.json sits at the zip
+        # root. Chrome's "Load unpacked" needs manifest.json at the top level
+        # of the selected folder, so the unzipped folder must be loadable
+        # directly.
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          cd extension
+          zip -r "../papertrench-${VERSION}.zip" . -x 'test/*' -x 'package.json'
+          cd ..
+          sha256sum "papertrench-${VERSION}.zip" > SHA256SUMS.txt
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          gh release create "$GITHUB_REF_NAME" \
+            "papertrench-${VERSION}.zip" SHA256SUMS.txt \
+            --title "PaperTrench ${VERSION}" \
+            --generate-notes

--- a/README.md
+++ b/README.md
@@ -81,8 +81,10 @@ PaperTrench is not on the Chrome Web Store yet. Loading it unpacked takes about 
 
 1. **Download** — grab the latest [release zip](../../releases) and unzip it, or clone this repo.
 2. Open **`chrome://extensions`** and turn on **Developer mode** (top right).
-3. Click **Load unpacked** and select the **`extension/`** folder.
+3. Click **Load unpacked** and select the folder that contains **`manifest.json`** — the unzipped release folder itself, or the **`extension/`** folder if you cloned the repo.
 4. Pin PaperTrench so the popup is one click away.
+
+> **Getting "Manifest file is missing or unreadable"?** The folder you selected doesn't have `manifest.json` at its top level. Open the folder you unzipped and select the level where `manifest.json` sits.
 
 Open any supported token page and the overlay appears within a second or two.
 


### PR DESCRIPTION
## Summary
Users installing from the release zip hit Chrome's "Manifest file is missing or unreadable. Could not load manifest." error because `papertrench-1.1.0.zip` nests everything under an `extension/` subfolder — so pointing "Load unpacked" at the unzipped folder finds no `manifest.json` at its top level.

- New `.github/workflows/release.yml`: on `v*` tag push, zips the *contents* of `extension/` (manifest at zip root, `test/` and `package.json` excluded), generates `SHA256SUMS.txt`, and creates the GitHub release — so future release zips can be loaded directly after unzipping.
- README install step now says to select the folder containing `manifest.json`, with a troubleshooting note for this exact error.

Note: the existing v1.1.0 asset on the release still has the nested layout; it should be replaced with a re-packaged zip (or the tag re-cut once this merges).

Link to Devin session: https://app.devin.ai/sessions/7d29ffd61ec5489cac15977fcb682470
Requested by: @OnlyTerp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/papertrench/pull/2" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->