### PR TITLE
Bump version to 1.1.1 for re-packaged release

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PaperTrench",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Paper-trade Solana memecoins with live P&L, native chart fills, session replay, AI coaching, and a verifiable track record.",
   "permissions": [
     "storage",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "papertrench",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "private": true,
   "description": "Paper-trade Solana memecoins on Axiom, Padre, Photon, GMGN, BullX and more.",
   "scripts": {

--- a/extension/test/load.test.js
+++ b/extension/test/load.test.js
@@ -260,7 +260,9 @@ test('the manifest requests only the permissions the extension actually uses', (
     ['activeTab', 'offscreen', 'storage', 'tabs', 'unlimitedStorage'].sort());
   assert.ok(!manifest.permissions.includes('alarms'),
     'the alarm was only used for external polling, which this build does not do');
-  assert.equal(manifest.version, '1.1.0');
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+  assert.equal(manifest.version, pkg.version,
+    'manifest.json and package.json must agree on the version');
 });
 
 /* ---------------- message contract ---------------- */


### PR DESCRIPTION
## Summary
The v1.1.0 release asset on GitHub still has the broken nested `extension/` layout, so downloaders keep hitting "Manifest file is missing or unreadable". Bumps `manifest.json` and `package.json` to 1.1.1 so a `v1.1.1` tag can be pushed after merge — the release workflow from #2 will then publish a correctly packaged zip (manifest at the root).

Link to Devin session: https://app.devin.ai/sessions/7d29ffd61ec5489cac15977fcb682470
Requested by: @OnlyTerp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/papertrench/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->