### PR TITLE
docs(skills): Chrome E2E skill notes for version and extension ID

### DIFF
--- a/.agents/skills/papertrench-chrome-e2e/SKILL.md
+++ b/.agents/skills/papertrench-chrome-e2e/SKILL.md
@@ -51,6 +51,18 @@ if (Test-Path $prefs) {
 ## Navigation workaround
 Typing `chrome://` or `file://` URLs in the omnibox can be routed to Google search. Use a local redirect file or CDP `/json/new` instead.
 
+## Verifying the loaded version
+The extension does not render its version inside the popup or dashboard. The authoritative visible version is on `chrome://extensions`. Open the details page directly with the extension ID (from the `service_worker` target URL):
+
+```powershell
+curl.exe -s -X PUT 'http://127.0.0.1:9222/json/new?chrome://extensions/?id=<id>'
+```
+
+The details page shows the **Version** field from `manifest.json`. Do not click **Remove** by mistake; the buttons are adjacent.
+
+## Checking the extension ID
+Look at the `service_worker` target returned by `http://127.0.0.1:9222/json`. Its `url` is `chrome-extension://<id>/background.js`. Use `<id>` when opening `chrome://extensions/?id=<id>`.
+
 ## Token page to test
 - Dexscreener: `https://dexscreener.com/solana/DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263`
 - Birdeye: `https://birdeye.so/token/DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263?chain=solana`
@@ -59,7 +71,7 @@ Typing `chrome://` or `file://` URLs in the omnibox can be routed to Google sear
 
 ## Overlay selectors (Shadow DOM host: `#papertrench-host`)
 - `#pt-token-name` — token name
-- `#pt-price` — native price
+- `#pt-price` — headline price (native price or market cap depending on token/site); the secondary unit is in `#pt-price-usd`
 - `#pt-balance` — paper balance
 - `#pt-buy-presets .pt-preset` — quick-buy amounts
 - `#pt-buy` — primary buy button


### PR DESCRIPTION
## Summary
Adds two practical notes to `.agents/skills/papertrench-chrome-e2e/SKILL.md` discovered while verifying the v1.2.0 release:

- How to read the loaded extension version from `chrome://extensions/?id=<id>` (the version is not shown in the popup/dashboard).
- How to extract the extension ID from the `service_worker` CDP target URL.
- Clarifies that `#pt-price` shows the headline price (native or market-cap depending on token/site) and the secondary unit lives in `#pt-price-usd`.

No source code changes.

Link to Devin session: https://app.devin.ai/sessions/2fa579dc1a994d02ba4fcaf2fc9b289c
Requested by: @OnlyTerp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/papertrench/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->