### PR TITLE
fix: validate AI endpoint URLs to prevent SSRF (supersedes #8)

### DIFF
--- a/.agents/skills/papertrench-chrome-e2e/SKILL.md
+++ b/.agents/skills/papertrench-chrome-e2e/SKILL.md
@@ -92,6 +92,11 @@ document.getElementById('papertrench-host').shadowRoot.getElementById('pt-buy').
 
 For UI gestures that do not respond well to real mouse drags (e.g. the v1.2.3 positions-bar drag grip), use CDP `Input.dispatchMouseEvent`. The `x`/`y` coordinates are relative to the main frame's viewport, so derive them from `element.getBoundingClientRect()`.
 
+## Windows-specific testing notes
+
+- Screenshot and video artifacts are written to `C:\Users\Administrator\screenshots\` and `C:\tmp\devin-recordings\`. `upload_attachment` does not accept `C:\...` paths directly; copy files to `C:\tmp\...` and reference them with `/tmp/...` POSIX-style paths.
+- The `computer` typing tool may mangle bracket/colon strings such as `http://[::]:8080/v1` or `http://localhost.:8765/v1`. For these cases use CDP `Runtime.evaluate` to set `document.getElementById('set-endpoint').value` and trigger `document.getElementById('test-ai').click()`, then read `document.getElementById('ai-test-result').textContent` for the visible outcome.
+
 ## Common gotchas
 - Dexscreener/Birdeye/GMGN may show Cloudflare or login walls; the service worker still resolves the token via Dexscreener API because the overlay uses background price resolution, not the page DOM.
 - The overlay is taller than the default 1024x768 capture area; drag the `#pt-drag` header up or maximize the browser to reveal buy/sell buttons.

--- a/extension/background.js
+++ b/extension/background.js
@@ -34,10 +34,11 @@ const DEFAULTS = {
   profitAlertPct: 10,
   averagePriceLinesEnabled: true,
   positionsBarEnabled: true,
-  settingsRevision: 3,
-  aiEndpoint: 'http://127.0.0.1:8765/v1',
+  settingsRevision: 4,
+  aiEndpoint: '',
   aiModel: '',
   aiApiKey: '',
+  aiAllowLocalEndpoint: false,
 };
 
 const FRAME_CAP = 80;
@@ -46,9 +47,27 @@ let frameInterval = null;
 let recActive = false;
 let replayMutation = Promise.resolve();
 
+const OLD_LOCAL_AI_ENDPOINT = 'http://127.0.0.1:8765/v1';
+
+function migrateBackgroundSettings(settings) {
+  const revision = Number(settings.settingsRevision) || 0;
+  if (revision < 4) {
+    // The default AI endpoint used to point at a local BYOK shim. Treat an
+    // unchanged install as empty so the new validator does not immediately
+    // block it, and require an explicit opt-in before local/private endpoints
+    // are reachable from the background script.
+    if (settings.aiEndpoint === OLD_LOCAL_AI_ENDPOINT) {
+      settings.aiEndpoint = '';
+    }
+    settings.aiAllowLocalEndpoint = false;
+    settings.settingsRevision = 4;
+  }
+  return settings;
+}
+
 function getSettings() {
   return new Promise((resolve) =>
-    chrome.storage.local.get(['pt_settings'], (value) => resolve({ ...DEFAULTS, ...(value.pt_settings || {}) }))
+    chrome.storage.local.get(['pt_settings'], (value) => resolve(migrateBackgroundSettings({ ...DEFAULTS, ...(value.pt_settings || {}) })))
   );
 }
 
@@ -236,10 +255,84 @@ function recordReplay(sessionValue, roundValue = null) {
 
 /* -------------------- AI proxy -------------------- */
 
+function isForbiddenIPv4(a, b, c, d, allowLocal) {
+  if (a === 0) return true;                                 // 0.0.0.0/8
+  if (a === 10) return !allowLocal;                         // 10.0.0.0/8
+  if (a === 127) return !allowLocal;                        // 127.0.0.0/8
+  if (a === 169 && b === 254) return true;                  // 169.254.0.0/16 link-local / cloud metadata
+  if (a === 172 && b >= 16 && b <= 31) return !allowLocal;  // 172.16.0.0/12
+  if (a === 192 && b === 168) return !allowLocal;           // 192.168.0.0/16
+  if (a === 100 && b >= 64 && b <= 127) return !allowLocal; // 100.64.0.0/10 CGNAT
+  if ((a === 192 && b === 0 && c === 0) ||                  // 192.0.0.0/24
+      (a === 192 && b === 0 && c === 2) ||                  // 192.0.2.0/24 TEST-NET-1
+      (a === 198 && b === 51 && c === 100) ||               // 198.51.100.0/24 TEST-NET-2
+      (a === 203 && b === 0 && c === 113) ||                // 203.0.113.0/24 TEST-NET-3
+      (a === 198 && (b === 18 || b === 19))) {             // 198.18.0.0/15 benchmark
+    return !allowLocal;
+  }
+  if (a >= 224 && a <= 239) return true;                    // 224.0.0.0/4 multicast
+  if (a >= 240) return true;                                // 240.0.0.0/4 + 255.255.255.255
+  return false;
+}
+
+function isForbiddenIPv6(ip, allowLocal) {
+  if (ip === '::1') return !allowLocal;
+  const lower = ip.toLowerCase();
+  if (lower.startsWith('::ffff:') || lower.startsWith('::ffff:0:')) {
+    const rest = lower.replace(/^::ffff(:0)?:/, '');
+    if (rest.includes('.')) {
+      const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(rest);
+      if (ipv4) return isForbiddenIPv4(Number(ipv4[1]), Number(ipv4[2]), Number(ipv4[3]), Number(ipv4[4]), allowLocal);
+    }
+    const parts = rest.split(':').filter(Boolean);
+    if (parts.length) {
+      const lastTwo = parts.slice(-2);
+      const high = parseInt(lastTwo[0] || '0', 16);
+      const low = parseInt(lastTwo[1] || '0', 16);
+      return isForbiddenIPv4((high >> 8) & 255, high & 255, (low >> 8) & 255, low & 255, allowLocal);
+    }
+  }
+  if (/^fe[89ab][0-9a-f]{0,2}:/i.test(ip) || /^fe[89ab][0-9a-f]{0,2}$/i.test(ip)) return true;    // fe80::/10 link-local
+  if (/^f[c-d][0-9a-f]{0,2}:/i.test(ip) || /^f[c-d][0-9a-f]{0,2}$/i.test(ip)) return !allowLocal;   // fc00::/7 unique local
+  if (/^fe[c-f][0-9a-f]{0,2}:/i.test(ip) || /^fe[c-f][0-9a-f]{0,2}$/i.test(ip)) return !allowLocal; // fec0::/10 site-local (deprecated)
+  if (/^ff[0-9a-f]{0,2}:/i.test(ip) || /^ff[0-9a-f]{0,2}$/i.test(ip)) return true;                  // ff00::/8 multicast
+  return false;
+}
+
+function isForbiddenHost(host, allowLocal) {
+  const lower = host.toLowerCase();
+  if (lower === 'localhost' || lower === 'localhost.localdomain' || lower.endsWith('.localhost')) {
+    return !allowLocal;
+  }
+  if (lower.includes(':')) {
+    const ip = lower.replace(/^\[|\]$/g, '');
+    return isForbiddenIPv6(ip, allowLocal);
+  }
+  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(lower);
+  if (ipv4) {
+    return isForbiddenIPv4(Number(ipv4[1]), Number(ipv4[2]), Number(ipv4[3]), Number(ipv4[4]), allowLocal);
+  }
+  return false;
+}
+
+function isAllowedEndpoint(url, allowLocal = false) {
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+    if (parsed.username || parsed.password) return false;
+    return !isForbiddenHost(parsed.hostname, allowLocal);
+  } catch (_) {
+    return false;
+  }
+}
+
 async function aiChat({ messages, maxTokens }) {
   const settings = await getSettings();
   const endpoint = (settings.aiEndpoint || '').replace(/\/+$/, '');
   if (!endpoint) return { error: 'No AI endpoint configured (open the dashboard → Settings)' };
+  if (!isAllowedEndpoint(endpoint, settings.aiAllowLocalEndpoint)) {
+    return { error: 'AI endpoint URL is not allowed. Enable local/private endpoints in Settings if you run a self-hosted endpoint, otherwise use a public endpoint.' };
+  }
   const body = {
     model: settings.aiModel || 'default',
     messages,
@@ -254,6 +347,7 @@ async function aiChat({ messages, maxTokens }) {
         ...(settings.aiApiKey ? { Authorization: 'Bearer ' + settings.aiApiKey } : {}),
       },
       body: JSON.stringify(body),
+      redirect: 'error',
     });
     if (!response.ok) return { error: `AI endpoint returned ${response.status}` };
     const json = await response.json();
@@ -263,12 +357,18 @@ async function aiChat({ messages, maxTokens }) {
   }
 }
 
+
 async function aiModels() {
   const settings = await getSettings();
   const endpoint = (settings.aiEndpoint || '').replace(/\/+$/, '');
+  if (!endpoint) return { models: [] };
+  if (!isAllowedEndpoint(endpoint, settings.aiAllowLocalEndpoint)) {
+    return { models: [], error: 'AI endpoint URL is not allowed. Enable local/private endpoints in Settings if you run a self-hosted endpoint, otherwise use a public endpoint.' };
+  }
   try {
     const response = await fetch(endpoint + '/models', {
       headers: settings.aiApiKey ? { Authorization: 'Bearer ' + settings.aiApiKey } : {},
+      redirect: 'error',
     });
     if (!response.ok) return { models: [] };
     const json = await response.json();

--- a/extension/background.js
+++ b/extension/background.js
@@ -276,6 +276,9 @@ function isForbiddenIPv4(a, b, c, d, allowLocal) {
 }
 
 function isForbiddenIPv6(ip, allowLocal) {
+  // The unspecified address resolves to loopback on many systems; block it
+  // unconditionally just like 0.0.0.0/8.
+  if (ip === '::') return true;
   if (ip === '::1') return !allowLocal;
   const lower = ip.toLowerCase();
   if (lower.startsWith('::ffff:') || lower.startsWith('::ffff:0:')) {
@@ -300,7 +303,9 @@ function isForbiddenIPv6(ip, allowLocal) {
 }
 
 function isForbiddenHost(host, allowLocal) {
-  const lower = host.toLowerCase();
+  // Strip an optional trailing dot (FQDN form) so "localhost." is treated the
+  // same as "localhost" by the literal and IP checks.
+  const lower = host.toLowerCase().replace(/\.$/, '');
   if (lower === 'localhost' || lower === 'localhost.localdomain' || lower.endsWith('.localhost')) {
     return !allowLocal;
   }

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -1872,7 +1872,8 @@ function renderSettings(el) {
       </div>
       <div class="card">
         <h3>AI &amp; Recording</h3>
-        <div class="field"><label for="set-endpoint">AI endpoint (OpenAI-compatible)</label><input id="set-endpoint" type="text" value="${esc(settings.aiEndpoint)}"></div>
+        <div class="field"><label for="set-endpoint">AI endpoint (OpenAI-compatible)</label><input id="set-endpoint" type="text" value="${esc(settings.aiEndpoint)}" placeholder="https://api.openai.com/v1 or http://127.0.0.1:8765/v1"></div>
+        <div class="field field-check"><label><input type="checkbox" id="set-ai-allow-local" ${settings.aiAllowLocalEndpoint ? 'checked' : ''}> Allow local/private AI endpoints</label><small>Enable only if you run a self-hosted (localhost, 127.0.0.1, or LAN) OpenAI-compatible shim. Off blocks SSRF to internal addresses.</small></div>
         <div class="field"><label for="set-model">AI model</label><input id="set-model" type="text" value="${esc(settings.aiModel || '')}" placeholder="endpoint default"><small>Optional override. Blank uses the endpoint's own default.</small></div>
         <div class="field"><label for="set-key">API key</label><input id="set-key" type="password" value="${esc(settings.aiApiKey || '')}" autocomplete="off" placeholder="optional"><small>Only needed if your BYOK setup requires a bearer token.</small></div>
         <div class="field field-check"><label><input type="checkbox" id="set-rec" ${settings.recordingEnabled ? 'checked' : ''}> Record screen while a position is open</label><small>Chrome asks for screen permission once per session.</small></div>
@@ -1931,7 +1932,8 @@ function bindSettings() {
     await store.set({ pt_settings: settingsNow });
     settings = settingsNow;
     const models = await chrome.runtime.sendMessage({ type: 'pt_ai_models' });
-    if (models?.models?.length) out.textContent = `OK — ${models.models.length} model(s) found: ${models.models.slice(0, 3).join(', ')}`;
+    if (models?.error) out.textContent = `Error: ${models.error}`;
+    else if (models?.models?.length) out.textContent = `OK — ${models.models.length} model(s) found: ${models.models.slice(0, 3).join(', ')}`;
     else out.textContent = 'No models reachable. Check endpoint and that your BYOK shim is running.';
   });
 }
@@ -1950,6 +1952,7 @@ function gatherSettingsFromForm() {
     listQuickBuySize: Math.max(0.6, Math.min(1.5, Number(document.getElementById('set-list-quick-buy-size').value) || 1)),
     sellPcts: sellPcts.length ? sellPcts : [25, 50, 75, 100],
     aiEndpoint: document.getElementById('set-endpoint').value.trim() || DEFAULTS.aiEndpoint,
+    aiAllowLocalEndpoint: document.getElementById('set-ai-allow-local').checked,
     aiModel: document.getElementById('set-model').value.trim(),
     aiApiKey: document.getElementById('set-key').value.trim(),
     recordingEnabled: document.getElementById('set-rec').checked,

--- a/extension/engine.js
+++ b/extension/engine.js
@@ -54,17 +54,19 @@
     profitAlertsEnabled: false,
     profitAlertPct: 10,
     averagePriceLinesEnabled: true,
-    settingsRevision: 2,
+    settingsRevision: 4,
     // Padre-style top rail listing every open paper position.
     positionsBarEnabled: true,
     // Saved left/top offsets for the draggable positions bar. null means the
     // bar should auto-measure against the host site header on first paint.
     positionsBarLeft: null,
     positionsBarTop: null,
-    // AI backend (OpenAI-compatible). Defaults to the local BYOK shim.
-    aiEndpoint: 'http://127.0.0.1:8765/v1',
+    // AI backend (OpenAI-compatible). Empty by default; the user must set a
+    // public endpoint or opt-in to local/private endpoints below.
+    aiEndpoint: '',
     aiModel: '',
     aiApiKey: '',
+    aiAllowLocalEndpoint: false,
     // Optional private Solana RPC. Empty means "use the built-in keyless
     // public pool", which is the default and needs no signup from anyone.
     // Public RPC limits are per IP, so the pool scales across every install.
@@ -79,7 +81,7 @@
   // Bumped when a default changes in a way existing users should receive.
   // Stored settings normally win over defaults, so without this a user who
   // installed before the change would keep the old value forever.
-  const SETTINGS_REVISION = 3;
+  const SETTINGS_REVISION = 4;
 
   /**
    * Merge stored settings over defaults, applying one-time migrations.
@@ -91,7 +93,12 @@
    * deliberate opt-out afterwards is never overridden.
    *
    * Revision 3 starts hiding the overlay on pages without a detected token.
+   *
+   * Revision 4 removes the insecure default local AI endpoint and adds an
+   * explicit opt-in for local/private AI endpoints. Existing installs that still
+   * carry the old default have it cleared, and local/private access defaults off.
    */
+  const OLD_LOCAL_AI_ENDPOINT = 'http://127.0.0.1:8765/v1';
   function mergeSettings(stored) {
     const merged = Object.assign(defaultSettings(), stored || {});
     if (!stored) return merged;
@@ -104,6 +111,12 @@
     }
     if (revision < 3) {
       merged.overlayHideWhenNoToken = DEFAULT_SETTINGS.overlayHideWhenNoToken;
+    }
+    if (revision < 4) {
+      if (merged.aiEndpoint === OLD_LOCAL_AI_ENDPOINT) {
+        merged.aiEndpoint = '';
+      }
+      merged.aiAllowLocalEndpoint = false;
     }
     merged.settingsRevision = SETTINGS_REVISION;
     return merged;

--- a/extension/test/background.test.js
+++ b/extension/test/background.test.js
@@ -207,9 +207,11 @@ test('isAllowedEndpoint blocks SSRF targets and allows public endpoints', () => 
   assert.equal(allow('http://0x7f000001:8765/v1'), false);
   assert.equal(allow('http://2130706433:8765/v1'), false);
   assert.equal(allow('http://localhost:8765/v1'), false);
+  assert.equal(allow('http://localhost.:8765/v1'), false, 'trailing-dot localhost must be treated as localhost');
   assert.equal(allow('http://localhost.localdomain:8765/v1'), false);
   assert.equal(allow('http://127.0.0.1:8765/v1', true), true);
   assert.equal(allow('http://localhost:8765/v1', true), true);
+  assert.equal(allow('http://localhost.:8765/v1', true), true);
 
   // Private ranges blocked by default, allowed with opt-in.
   assert.equal(allow('http://10.0.0.1/v1'), false);
@@ -224,6 +226,8 @@ test('isAllowedEndpoint blocks SSRF targets and allows public endpoints', () => 
   assert.equal(allow('http://0.0.0.0/v1', true), false);
 
   // IPv6 loopback and link-local.
+  assert.equal(allow('http://[::]/v1'), false, 'unspecified IPv6 must be blocked unconditionally');
+  assert.equal(allow('http://[::]/v1', true), false);
   assert.equal(allow('http://[::1]/v1'), false);
   assert.equal(allow('http://[::1]/v1', true), true);
   assert.equal(allow('http://[fe80::1]/v1'), false);

--- a/extension/test/background.test.js
+++ b/extension/test/background.test.js
@@ -46,6 +46,7 @@ function serviceWorker() {
     Error,
     Set,
     Map,
+    URL,
     URLSearchParams,
     AbortController,
     Uint8Array,
@@ -123,7 +124,7 @@ function serviceWorker() {
     }
   };
   vm.runInContext(fs.readFileSync(path.join(ROOT, 'background.js'), 'utf8'), context, { filename: 'background.js' });
-  return { values, fetchCalls, get listener() { return messageListener; } };
+  return { values, fetchCalls, get listener() { return messageListener; }, get isAllowedEndpoint() { return context.isAllowedEndpoint; } };
 }
 
 function send(listener, message) {
@@ -175,5 +176,106 @@ test('service worker captures a real pt_trade_event into the replay store', asyn
   assert.equal(closed.ok, true);
   assert.equal(worker.values.pt_replays[0].status, 'closed');
   assert.equal(worker.values.pt_replays[0].roundId, 'round-worker');
+});
+
+test('isAllowedEndpoint blocks SSRF targets and allows public endpoints', () => {
+  const worker = serviceWorker();
+  const allow = worker.isAllowedEndpoint;
+  assert.equal(typeof allow, 'function');
+
+  // Valid public endpoints.
+  assert.equal(allow('https://api.openai.com/v1'), true);
+  assert.equal(allow('http://api.openai.com/v1'), true);
+  assert.equal(allow('https://ai.example.com:8443/path'), true);
+
+  // Non-HTTP(S) and malformed URLs.
+  assert.equal(allow('ftp://api.openai.com/v1'), false);
+  assert.equal(allow('file:///etc/passwd'), false);
+  assert.equal(allow('not a url'), false);
+  assert.equal(allow(''), false);
+
+  // URLs with credentials are rejected.
+  assert.equal(allow('https://user:pass@api.openai.com/v1'), false);
+
+  // Cloud metadata / link-local always blocked, even with local opt-in.
+  assert.equal(allow('http://169.254.169.254/latest/meta-data/'), false);
+  assert.equal(allow('http://169.254.169.254/latest/meta-data/', true), false);
+
+  // Localhost / loopback blocked by default, allowed with opt-in.
+  assert.equal(allow('http://127.0.0.1:8765/v1'), false);
+  assert.equal(allow('http://127.1:8765/v1'), false);
+  assert.equal(allow('http://0x7f000001:8765/v1'), false);
+  assert.equal(allow('http://2130706433:8765/v1'), false);
+  assert.equal(allow('http://localhost:8765/v1'), false);
+  assert.equal(allow('http://localhost.localdomain:8765/v1'), false);
+  assert.equal(allow('http://127.0.0.1:8765/v1', true), true);
+  assert.equal(allow('http://localhost:8765/v1', true), true);
+
+  // Private ranges blocked by default, allowed with opt-in.
+  assert.equal(allow('http://10.0.0.1/v1'), false);
+  assert.equal(allow('http://172.16.0.1/v1'), false);
+  assert.equal(allow('http://192.168.1.1/v1'), false);
+  assert.equal(allow('http://100.64.0.1/v1'), false);
+  assert.equal(allow('http://10.0.0.1/v1', true), true);
+  assert.equal(allow('http://192.168.1.1/v1', true), true);
+
+  // 0.0.0.0 always blocked.
+  assert.equal(allow('http://0.0.0.0/v1'), false);
+  assert.equal(allow('http://0.0.0.0/v1', true), false);
+
+  // IPv6 loopback and link-local.
+  assert.equal(allow('http://[::1]/v1'), false);
+  assert.equal(allow('http://[::1]/v1', true), true);
+  assert.equal(allow('http://[fe80::1]/v1'), false);
+  assert.equal(allow('http://[::ffff:127.0.0.1]/v1'), false);
+  assert.equal(allow('http://[::ffff:192.168.1.1]/v1', true), true);
+});
+
+test('ai proxy blocks disallowed endpoints and fetches allowed ones', async () => {
+  const worker = serviceWorker();
+
+  // Malicious cloud metadata endpoint is rejected with no network call.
+  worker.values.pt_settings = {
+    aiEndpoint: 'http://169.254.169.254/latest/meta-data/',
+    aiAllowLocalEndpoint: false,
+  };
+  const blocked = await send(worker.listener, { type: 'pt_ai_chat', messages: [], maxTokens: 100 });
+  assert.ok(blocked.error, 'blocked endpoint must return an error');
+  assert.equal(worker.fetchCalls.length, 0, 'no network call for blocked endpoint');
+
+  // Public endpoint is fetched.
+  worker.values.pt_settings = {
+    aiEndpoint: 'https://api.openai.com/v1',
+    aiAllowLocalEndpoint: false,
+  };
+  const models = await send(worker.listener, { type: 'pt_ai_models' });
+  assert.equal(Array.isArray(models.models), true);
+  assert.ok(worker.fetchCalls.some((u) => u.startsWith('https://api.openai.com/v1/models')), 'public endpoint is fetched');
+
+  // Local endpoint is rejected unless explicitly allowed.
+  worker.values.pt_settings = {
+    aiEndpoint: 'http://127.0.0.1:8765/v1',
+    aiAllowLocalEndpoint: false,
+  };
+  const localBlocked = await send(worker.listener, { type: 'pt_ai_models' });
+  assert.ok(localBlocked.error, 'local endpoint blocked when opt-in is off');
+
+  worker.values.pt_settings = {
+    aiEndpoint: 'http://127.0.0.1:8765/v1',
+    aiAllowLocalEndpoint: true,
+  };
+  worker.fetchCalls.length = 0;
+  const localAllowed = await send(worker.listener, { type: 'pt_ai_models' });
+  assert.equal(Array.isArray(localAllowed.models), true);
+  assert.ok(worker.fetchCalls.some((u) => u.startsWith('http://127.0.0.1:8765/v1/models')), 'local endpoint fetched when opt-in is on');
+
+  // Legacy default local endpoint is migrated to empty and rejected.
+  worker.values.pt_settings = {
+    aiEndpoint: 'http://127.0.0.1:8765/v1',
+    aiAllowLocalEndpoint: false,
+    settingsRevision: 3,
+  };
+  const migrated = await send(worker.listener, { type: 'pt_ai_chat', messages: [], maxTokens: 100 });
+  assert.ok(migrated.error, 'legacy default endpoint is migrated away');
 });
 

--- a/extension/test/engine.test.js
+++ b/extension/test/engine.test.js
@@ -424,4 +424,27 @@ test('mergeSettings on a fresh install just returns the defaults', () => {
   const fresh = E.mergeSettings(null);
   assert.equal(fresh.tradeEffectsEnabled, true);
   assert.equal(fresh.balanceStartSol, E.DEFAULT_SETTINGS.balanceStartSol);
+  assert.equal(fresh.aiEndpoint, '', 'fresh install ships with no AI endpoint');
+  assert.equal(fresh.aiAllowLocalEndpoint, false, 'fresh install defaults local/private AI off');
+});
+
+test('mergeSettings migrates the old default local AI endpoint away', () => {
+  const legacy = {
+    settingsRevision: 3,
+    aiEndpoint: 'http://127.0.0.1:8765/v1',
+  };
+  const migrated = E.mergeSettings(legacy);
+  assert.equal(migrated.aiEndpoint, '', 'old default local endpoint is cleared');
+  assert.equal(migrated.aiAllowLocalEndpoint, false, 'local/private opt-in defaults off');
+  assert.equal(migrated.settingsRevision, E.SETTINGS_REVISION);
+});
+
+test('mergeSettings preserves a deliberately chosen public AI endpoint', () => {
+  const custom = {
+    settingsRevision: 3,
+    aiEndpoint: 'https://ai.example.com/v1',
+  };
+  const merged = E.mergeSettings(custom);
+  assert.equal(merged.aiEndpoint, 'https://ai.example.com/v1');
+  assert.equal(merged.aiAllowLocalEndpoint, false);
 });

--- a/extension/test/load.test.js
+++ b/extension/test/load.test.js
@@ -355,7 +355,7 @@ test('the overlay visibility can be toggled between master and auto-hide control
 
   assert.match(engineSrc, /overlayHideWhenNoToken:\s*true/,
     'the default must hide the overlay when no token is detected');
-  assert.match(engineSrc, /SETTINGS_REVISION = 3/,
+  assert.match(engineSrc, /SETTINGS_REVISION = 4/,
     'settings revision must be bumped for the new overlay default');
   assert.match(contentSrc, /function updateOverlayVisibility/,
     'content.js must hide the main panel when no token is present');


### PR DESCRIPTION
## Summary
Closes #8 by replacing the narrow `169.254.*` check with a comprehensive SSRF guard on the background AI proxy.

The user-configurable `aiEndpoint` is fetched from the privileged MV3 service worker with `<all_urls>` host permission, so an attacker who can alter settings (or a maliciously shared config) could otherwise point it at `http://169.254.169.254/latest/meta-data/`, `http://127.0.0.1:8080/internal-api`, or any RFC1918/LAN address.

## What changed

- `extension/background.js`
  - Added `isAllowedEndpoint(url, allowLocal)` with protocol, credential, IPv4, IPv6, and `localhost` validation.
  - Blocks `0.0.0.0/8`, RFC1918 (`10/8`, `172.16/12`, `192.168/16`), `100.64/10`, `127/8`, `169.254/16` (always), documentation/benchmark ranges, multicast, and reserved space.
  - Handles IPv4-mapped IPv6 (`::ffff:127.0.0.1`) and encoded IP forms (`127.1`, `0x7f000001`, `2130706433`) that `new URL` normalizes.
  - `aiChat` and `aiModels` call `isAllowedEndpoint` and return a clear error for disallowed URLs.
  - `fetch(..., { redirect: 'error' })` prevents a public first hop from redirecting to an internal address.
  - `getSettings` now migrates the old default `http://127.0.0.1:8765/v1` to an empty endpoint and requires explicit opt-in for local/private AI endpoints.

- `extension/engine.js`
  - Bumped `SETTINGS_REVISION` to `4`.
  - Default `aiEndpoint` is now empty; added `aiAllowLocalEndpoint: false`.
  - `mergeSettings` clears the legacy local default and sets the local opt-in to `false` for existing installs.

- `extension/dashboard.js`
  - Added an "Allow local/private AI endpoints" checkbox.
  - Persisted `aiAllowLocalEndpoint` in `gatherSettingsFromForm`.
  - AI test button now surfaces endpoint validation errors.

- `extension/test/background.test.js`
  - Added `URL` to the service-worker VM sandbox.
  - Added tests for `isAllowedEndpoint` (public, localhost, private, cloud metadata, IPv6, credentials, malformed URLs).
  - Added integration tests for `pt_ai_chat` / `pt_ai_models` blocking malicious endpoints, fetching public endpoints, and the legacy endpoint migration.

- `extension/test/engine.test.js`
  - Added `mergeSettings` tests for the new defaults and legacy endpoint migration.

- `extension/test/load.test.js`
  - Updated `SETTINGS_REVISION` assertion to `4`.

Link to Devin session: https://app.devin.ai/sessions/68606161f0664cbca97bc1bf90420a82
Requested by: @OnlyTerp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/papertrench/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->