### PR TITLE
chore(release): PaperTrench 1.2.6 with SSRF guard, armed-buy fix, and resizable trade tab

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PaperTrench",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Paper-trade Solana memecoins with live P&L, native chart fills, session replay, AI coaching, and a verifiable track record.",
   "permissions": [
     "storage",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "papertrench",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "private": true,
   "description": "Paper-trade Solana memecoins on Axiom, Padre, Photon, GMGN, BullX and more.",
   "scripts": {

--- a/site/index.html
+++ b/site/index.html
@@ -39,7 +39,7 @@
     <h1 class="reveal d1">Trade the trenches.<br><span class="grad-orange">Keep your SOL.</span></h1>
     <p class="hero-sub reveal d2">PaperTrench overlays a <strong>paper-trading terminal</strong> on the memecoin sites you already use — real charts, real live prices, <strong>fake money</strong> — then shows you exactly what you did and why. <span style="color:var(--green)">Learn in an afternoon what usually costs a wallet.</span></p>
     <div class="hero-ctas reveal d3">
-      <a class="btn btn-primary" href="https://github.com/OnlyTerp/papertrench/releases/download/v1.2.5/papertrench-1.2.5.zip" target="_blank" rel="noopener">⬇ Get the extension</a>
+      <a class="btn btn-primary" href="https://github.com/OnlyTerp/papertrench/releases/download/v1.2.6/papertrench-1.2.6.zip" target="_blank" rel="noopener">⬇ Get the extension</a>
       <a class="btn btn-ghost" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">★ Star on GitHub</a>
     </div>
     <div class="hero-stats reveal d3">
@@ -340,7 +340,7 @@
       <p class="sec-sub reveal d2" style="margin:0 auto">Not on the Chrome Web Store yet — loading it unpacked is quick.</p>
     </div>
     <div class="install-steps">
-      <div class="step reveal"><div class="n">01</div><h4>Download</h4><p>Grab the latest <a href="https://github.com/OnlyTerp/papertrench/releases/download/v1.2.5/papertrench-1.2.5.zip" target="_blank" rel="noopener" style="color:var(--orange2)">release zip</a> and unzip it.</p></div>
+      <div class="step reveal"><div class="n">01</div><h4>Download</h4><p>Grab the latest <a href="https://github.com/OnlyTerp/papertrench/releases/download/v1.2.6/papertrench-1.2.6.zip" target="_blank" rel="noopener" style="color:var(--orange2)">release zip</a> and unzip it.</p></div>
       <div class="step reveal d1"><div class="n">02</div><h4>Open extensions</h4><p>Go to <code>chrome://extensions</code> and flip on <b>Developer mode</b>.</p></div>
       <div class="step reveal d2"><div class="n">03</div><h4>Load unpacked</h4><p>Select the folder containing <code>manifest.json</code>.</p></div>
       <div class="step reveal d3"><div class="n">04</div><h4>Trade</h4><p>Open any supported token page — the overlay appears within seconds.</p></div>
@@ -361,7 +361,7 @@
     <h2 class="reveal d1" style="margin-top:24px">Blow up a fake account<br><span class="grad-orange" style="background:linear-gradient(100deg,var(--orange2),var(--orange-deep));-webkit-background-clip:text;background-clip:text;color:transparent">before you blow up a real one.</span></h2>
     <p class="sec-sub reveal d2" style="text-align:center;margin-top:16px">The usual way people learn this market is losing money finding out they chase, oversize, and round-trip their winners. PaperTrench tells you that in an afternoon instead.</p>
     <div class="hero-ctas reveal d3" style="margin-top:36px">
-      <a class="btn btn-primary" href="https://github.com/OnlyTerp/papertrench/releases/download/v1.2.5/papertrench-1.2.5.zip" target="_blank" rel="noopener">⬇ Download PaperTrench</a>
+      <a class="btn btn-primary" href="https://github.com/OnlyTerp/papertrench/releases/download/v1.2.6/papertrench-1.2.6.zip" target="_blank" rel="noopener">⬇ Download PaperTrench</a>
       <a class="btn btn-ghost" href="https://github.com/OnlyTerp/papertrench#readme" target="_blank" rel="noopener">Read the docs</a>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Release the latest `main` changes as **v1.2.6**:

- `ba4a2ec` / `e1e9130` — validate AI endpoint URLs to prevent SSRF (blocks private/loopback/cloud-metadata IPs, IPv6, encoded IPs, and credentials; adds `aiAllowLocalEndpoint` opt-in).
- `566a217` — fix armed buys dropping on pair-URL sites and wallet state loss.
- `e505b03` — make the trade tab resizable with persisted width/height.

- `extension/manifest.json` and `extension/package.json`: `1.2.5` → `1.2.6`
- `site/index.html`: all three download CTAs now point to the `v1.2.6` release zip.

No functional code changes beyond the version/site bump.

Link to Devin session: https://app.devin.ai/sessions/2fa579dc1a994d02ba4fcaf2fc9b289c
Requested by: @OnlyTerp