### PR TITLE
feat(streams): on-site streamer signup + moderator queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 Stream-style log of what shipped, newest first. User-facing wording; the gory
 details live in the commit messages.
 
+## Unreleased
+
+**Streamer signup lives on the site now.** "Sign up as a streamer" used to
+hand you off to a Google Form; it now opens **papertrench.com/streamer-signup**
+— the same questions, on the site, in the site's own styling. Applications go
+straight into the leaderboard database instead of a spreadsheet.
+
+**A moderator queue that isn't a shared password.** `/admin` lists every
+application with Approve / Reject, gated on X sign-in against a list of
+moderator accounts the server checks on every request. There is no password in
+the page to leak, and no version of the page you can edit your way past.
+
+**Approving somebody actually publishes them.** An approved Twitch application
+becomes a card on the streams page within a minute — no deploy, no spreadsheet
+cell, no republish interval. Channels that can't be embedded can't be approved
+into a card that would never appear, so the button says so instead.
+
+**Public answers and private ones are kept apart.** Every field on the form is
+labelled Public or Private where you type it. The one-line blurb is the roster
+card's text; your Discord handle, contact details and free-text notes are
+served to moderators only — the public roster query doesn't select those
+columns at all. We store a one-way hash of your IP for abuse triage, never the
+address.
+
 ## v3.12.1 — 2026-08-22
 
 **Lute is in the Instant-links list** (Terp: "instant link loading needs to

--- a/docs/STREAMS.md
+++ b/docs/STREAMS.md
@@ -5,49 +5,92 @@ touches lives in the CONFIG block at the top of `streams.js`:
 
 | Constant | What it does |
 | --- | --- |
-| `STREAMERS` | Hand-maintained roster. Always shown; wins over a sheet row with the same login. |
-| `SIGNUP_URL` | Where "Sign up as a streamer" points. Currently a prefilled GitHub issue; swap for the Google Form link. |
-| `ROSTER_CSV_URL` | Published-CSV URL of the approval sheet. Empty = disabled. |
+| `STREAMERS` | Hand-maintained roster. Always shown; wins over an approved application with the same login. |
+| `SIGNUP_URL` | Where "Sign up as a streamer" points — the on-site form, `streamer-signup.html`. |
+| `API` | Worker origin the approved roster is read from. Same value as `arena.js`. |
+| `ROSTER_CSV_URL` | Legacy Google-Sheet CSV roster. Empty = disabled, and it should stay empty on a new deploy. |
 
-## Signup + approval pipeline (Google Form → Sheet → site)
+## Signup + approval pipeline (on-site form → D1 → mod queue → site)
 
-One-time setup, ~5 minutes:
+Signups are a page on this site, not a Google Form. Three moving parts:
 
-1. **Create a Google Form** (forms.google.com) with these questions:
-   - *Twitch channel* — short answer, required. (Any format works: URL, @name, or bare handle — the site normalizes it.)
-   - *Display name* — short answer, required.
-   - *About you (shown on the site, one line)* — short answer.
-   - *When do you stream?* — short answer (for your planning; not shown on the site).
-   - Anything else you want to ask (contact handle, etc.) — extra columns are ignored by the site.
-2. In the form's **Responses** tab → **Link to Sheets**. This creates the response spreadsheet.
-3. In that sheet, **add a column headed `Approved`** to the right of the response columns.
-4. **File → Share → Publish to web** → pick the response tab (not "Entire document") → format **CSV** → Publish. Copy the URL.
-5. Paste into `streams.js`:
-   - the form's share link → `SIGNUP_URL`
-   - the published CSV URL → `ROSTER_CSV_URL`
-   Deploy the site once. Done — from here on, no deploys are needed to manage the roster.
+| Piece | Where |
+| --- | --- |
+| The form a streamer fills in | `site/streamer-signup.html` + `.js` |
+| The moderator queue | `site/admin.html` + `.js` |
+| Storage, validation, and the gate | `server/core/streamer.js`, `server/worker/index.js`, table `streamer_applications` |
+
+Routes on the Worker:
+
+| Route | Who can call it |
+| --- | --- |
+| `POST /api/streamer/apply` | Anyone. Rate-limited to 5/hour per IP. |
+| `GET /api/streamer/applications?status=` | Moderators only (403 otherwise). |
+| `POST /api/streamer/review` | Moderators only (403 otherwise). |
+| `GET /api/streamer/roster` | Anyone. Approved rows, public columns only. |
+
+### One-time setup
+
+1. **Apply the schema** so the new table exists:
+   ```
+   wrangler d1 execute papertrench --file=server/schema.sql --remote
+   ```
+2. **Name your moderators.** `ADMIN_X_IDS` in `wrangler.toml` is a
+   comma-separated list of **X user ids**, not handles. To find yours: sign in
+   on the site, open `/admin`, and the page prints your own id. Paste it in and
+   `wrangler deploy`.
+3. That's it. Nothing to configure on the site side — `streams.js` already
+   points at the form and reads the approved roster.
+
+> An empty `ADMIN_X_IDS` authorises **nobody**. That is deliberate: the queue
+> holds applicants' Discord handles and contact details, so a deploy that
+> forgets the var closes the queue rather than opening it to every signed-in
+> visitor. If `/admin` says you are not a moderator, this is usually why.
 
 ### Day-to-day approval
 
-Open the response sheet. Each signup is a row. Type `yes` in its **Approved**
-cell and the streamer appears on papertrench.com within ~5 minutes (Google's
-republish interval). Clear the cell to unlist them. Accepted approval values:
-`yes`, `y`, `true`, `1`, `x`, `approved`, `✓` (any case). Blank or anything
-else = not shown.
+Open `/admin` and sign in with an allowlisted X account. Pending applications
+are listed newest first, with **Approve** / **Reject** on each. Approving a
+Twitch application publishes its card on the streams page within ~60 s (the
+edge cache window). **Move back to pending** undoes a decision.
 
-Rules the site applies to sheet rows:
+Rules the pipeline applies:
 
-- Twitch handles are normalized (`https://twitch.tv/Name?x=1` → `name`); rows
-  whose handle can't be normalized to a valid Twitch login are skipped.
-- Duplicate logins are deduped; `STREAMERS` entries win over sheet rows.
-- If the sheet is unreachable or malformed, the page silently falls back to
-  `STREAMERS` (a `console.warn` is the only trace). The sheet can never break
-  the page.
+- Twitch logins are normalized (`https://twitch.tv/Name?x=1` → `name`) by the
+  same rule `streams.js` uses; an application whose URL can't be normalized to
+  a valid login is stored but **cannot be approved** — the streams page embeds
+  Twitch, so approving it would set a status that never becomes a card. The
+  Approve button is disabled on those, with a tooltip saying why.
+- Duplicate logins are deduped and `STREAMERS` entries win, same as before.
+- One application per channel URL may sit in the queue at a time (a partial
+  unique index). A rejected applicant can reapply later.
+- If the API is unreachable the page falls back to `STREAMERS` and logs
+  `PaperTrench: roster API unavailable` — it can never break the page.
 
-> After first publishing the sheet, load the streams page once with DevTools
-> open: if you see `PaperTrench: roster sheet unavailable`, the publish step
-> isn't right (usually "Entire document" was selected instead of the tab, or
-> the format isn't CSV).
+### What is published and what is not
+
+The form labels every field **Public** or **Private**, and the split is
+enforced in the SQL rather than in a convention:
+
+| Published on approval | Never leaves the mod queue |
+| --- | --- |
+| Creator name, channel URL, Twitch login, the one-line blurb | Discord username, viewer count, contact method, profile link, best time to reach, and the free-text notes |
+
+The one that matters is **blurb vs. notes**. "One line about your stream" says
+it will be shown publicly and is the roster card's text. "Anything else you'd
+like us to know?" is a message to moderators and is *never* served by a public
+route — `GET /api/streamer/roster` does not select the column. If you ever need
+a public bio, edit the blurb; do not repurpose notes.
+
+Applications also store a salted one-way hash of the applicant's IP for abuse
+triage. The raw address is never written.
+
+### Migrating off the Google Sheet
+
+`ROSTER_CSV_URL` still works and is read alongside the API, so an existing
+deployment keeps its roster on upgrade. To finish the move: re-enter any
+approved streamers via the form (or add them to `STREAMERS`), confirm they
+show, then set `ROSTER_CSV_URL` back to `''` and unpublish the sheet.
 
 ## How the page decides who's "LIVE"
 

--- a/server/core/streamer.js
+++ b/server/core/streamer.js
@@ -1,0 +1,227 @@
+/* Streamer applications — validation and normalization, pure.
+ *
+ * This replaces the Google Form + approval-sheet pipeline documented in
+ * docs/STREAMS.md. The rules live here rather than in the Worker so the
+ * suite can attack them without D1 or a fetch, same as every other core
+ * module.
+ *
+ * An approved application becomes a public roster card on the streams page,
+ * so the fields that surface there are held to the same content rule as clan
+ * names — the mod queue is a human gate, not a reason to skip the machine one.
+ */
+'use strict';
+
+const { blockedContent } = require('./clan.js');
+
+// Dropdowns are closed sets: an answer outside them did not come from our
+// form, so it is a bug or a forgery either way. Stored verbatim as shown.
+const VIEWER_BUCKETS = ['1–10', '10–50', '50–100', '100+'];
+const CONTACT_METHODS = ['Discord DM', 'Email', 'Twitter/X', 'Other'];
+
+const LIMITS = {
+  name: 40,
+  channelUrl: 200,
+  discord: 40,
+  blurb: 160,
+  notes: 1000,
+  contactLink: 200,
+  bestTime: 100,
+};
+
+// Invisible characters that are NOT whitespace: C0 controls except tab/LF/CR,
+// DEL, zero-width joiners and marks, the bidi overrides and isolates, and the
+// BOM. Written as escapes rather than literals so the intent survives an
+// editor that renders them as nothing.
+//
+// The bidi range (U+202A–U+202E, U+2066–U+2069) is the one that matters most
+// here. U+202E reverses everything after it, so a stored name and the name a
+// moderator reads on screen can be different strings — the trick that makes
+// "exe.txt" out of "txt.exe". These names render on a public roster card and
+// in the mod queue, and a moderator approving what they see must be approving
+// what is stored.
+//
+// Whitespace is deliberately left in for the caller to collapse. Deleting a
+// newline outright would weld two words into one ("First\nLast" -> "FirstLast");
+// collapsing it to a space keeps what the applicant meant.
+const STRIP_INVISIBLE = new RegExp(
+  '[\\u0000-\\u0008\\u000B\\u000C\\u000E-\\u001F\\u007F'
+  + '\\u200B-\\u200F\\u202A-\\u202E\\u2060-\\u2064\\u2066-\\u2069\\uFEFF]', 'g');
+
+const trim = (v) => String(v == null ? '' : v).trim();
+
+/**
+ * Collapse whitespace and strip invisible characters.
+ *
+ * Applications are typed by hand and pasted from Discord, so they arrive with
+ * newlines inside single-line fields and the occasional zero-width character
+ * carried in from a nickname. Both render as something other than what the
+ * applicant sees in the box, and one of these fields ends up on a public card.
+ */
+function clean(value, max) {
+  return trim(value)
+    .replace(STRIP_INVISIBLE, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, max);
+}
+
+/** Same as clean() but keeps paragraph breaks — the notes field is a textarea. */
+function cleanMultiline(value, max) {
+  return trim(value)
+    .replace(STRIP_INVISIBLE, '')
+    // U+2028 / U+2029 are line separators the browser renders as breaks; fold
+    // them into real newlines rather than leaving two spellings in the data.
+    .replace(/\r\n?|[\u2028\u2029]/g, '\n')
+    .replace(/[^\S\n]+/g, ' ')
+    .replace(/ *\n */g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+    .slice(0, max);
+}
+
+/**
+ * A URL we are willing to store and later render as a link.
+ *
+ * Returns the normalized href, or null. The scheme allowlist is the point:
+ * these strings become `href` on the mod page, and `javascript:` in an href
+ * is a click away from running in a moderator's session. Rejecting at the
+ * door means no downstream renderer has to remember.
+ */
+function safeUrl(raw, max) {
+  let text = clean(raw, max);
+  if (!text) return null;
+  // A bare "twitch.tv/name" is what people actually type; assume https rather
+  // than failing them for it.
+  if (!/^[a-z][a-z0-9+.-]*:/i.test(text)) text = 'https://' + text;
+  let url;
+  try { url = new URL(text); } catch { return null; }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+  if (!url.hostname.includes('.')) return null;
+  return url.toString().slice(0, max);
+}
+
+/** Which platform a channel URL points at — a label for the mod queue. */
+function platformOf(channelUrl) {
+  let host = '';
+  try {
+    host = new URL(channelUrl).hostname.toLowerCase().replace(/^www\./, '');
+  } catch { return 'other'; }
+  if (host === 'twitch.tv' || host.endsWith('.twitch.tv')) return 'twitch';
+  if (host === 'youtube.com' || host.endsWith('.youtube.com') || host === 'youtu.be') return 'youtube';
+  if (host === 'kick.com' || host.endsWith('.kick.com')) return 'kick';
+  return 'other';
+}
+
+/**
+ * The Twitch login inside a channel URL, or null.
+ *
+ * Only Twitch gets a login because only Twitch is embeddable on the streams
+ * page — a YouTube or Kick application is still valid, it just cannot become
+ * a player card. Deliberately the same rules as normalizeLogin() in
+ * site/streams.js: 3–25 chars of [a-z0-9_], nothing salvaged.
+ */
+function twitchLogin(channelUrl) {
+  if (platformOf(channelUrl) !== 'twitch') return null;
+  let path = '';
+  try { path = new URL(channelUrl).pathname; } catch { return null; }
+  const first = path.split('/').filter(Boolean)[0];
+  if (!first) return null;
+  const lower = first.toLowerCase();
+  return /^[a-z0-9_]{3,25}$/.test(lower) ? lower : null;
+}
+
+/**
+ * Why this application cannot be accepted, or null when it can.
+ *
+ * Reason codes, not sentences: the page owns the wording, and the tests
+ * assert on something that does not move when the copy is edited.
+ */
+function applyProblem(fields) {
+  const f = fields || {};
+  const name = clean(f.name, LIMITS.name);
+  if (name.length < 2) return 'name-required';
+  // The creator name is what a public roster card is titled with.
+  if (blockedContent(name)) return 'name-blocked';
+
+  if (!safeUrl(f.channelUrl, LIMITS.channelUrl)) return 'channel-url-invalid';
+
+  const discord = clean(f.discord, LIMITS.discord);
+  if (discord.length < 2) return 'discord-required';
+
+  if (!VIEWER_BUCKETS.includes(trim(f.viewers))) return 'viewers-invalid';
+
+  // Optional from here down: absent is fine, present-and-wrong is not.
+
+  // The blurb is the other field that becomes a public roster card, so it
+  // faces the same content rule as the name. `notes` deliberately does not:
+  // it is a private message to the mod queue and is never published.
+  if (blockedContent(clean(f.blurb, LIMITS.blurb))) return 'blurb-blocked';
+
+  const method = trim(f.contactMethod);
+  if (method && !CONTACT_METHODS.includes(method)) return 'contact-method-invalid';
+
+  if (trim(f.contactLink) && !safeUrl(f.contactLink, LIMITS.contactLink)) {
+    return 'contact-link-invalid';
+  }
+  return null;
+}
+
+/**
+ * The row to store. Call only after applyProblem() returns null — it assumes
+ * the shape is already legal and does not re-check.
+ */
+function normalizeApplication(fields) {
+  const f = fields || {};
+  const channelUrl = safeUrl(f.channelUrl, LIMITS.channelUrl);
+  return {
+    name: clean(f.name, LIMITS.name),
+    channelUrl,
+    platform: platformOf(channelUrl),
+    twitchLogin: twitchLogin(channelUrl),
+    discord: clean(f.discord, LIMITS.discord),
+    viewers: trim(f.viewers),
+    // blurb is published on approval; notes is mod-queue-only. Two fields,
+    // because one field cannot be both consented-to-publish and confidential.
+    blurb: clean(f.blurb, LIMITS.blurb),
+    notes: cleanMultiline(f.notes, LIMITS.notes),
+    contactMethod: trim(f.contactMethod) || null,
+    contactLink: trim(f.contactLink) ? safeUrl(f.contactLink, LIMITS.contactLink) : null,
+    bestTime: clean(f.bestTime, LIMITS.bestTime),
+  };
+}
+
+const STATUSES = ['pending', 'approved', 'rejected'];
+const isStatus = (s) => STATUSES.includes(trim(s));
+
+/**
+ * Is this X user id a moderator?
+ *
+ * Matched on x_id, never on handle: schema.sql calls x_id "immutable X user
+ * id; handles can change", and a handle that changes is a handle someone else
+ * can register. Allowlisting @somemod would hand the mod queue to whoever
+ * claims that name after they drop it.
+ */
+function isAdmin(xId, allowlist) {
+  const id = trim(xId);
+  if (!id) return false;
+  return String(allowlist || '')
+    .split(/[\s,]+/)
+    .filter(Boolean)
+    .includes(id);
+}
+
+module.exports = {
+  VIEWER_BUCKETS,
+  CONTACT_METHODS,
+  LIMITS,
+  STATUSES,
+  clean,
+  cleanMultiline,
+  safeUrl,
+  platformOf,
+  twitchLogin,
+  applyProblem,
+  normalizeApplication,
+  isStatus,
+  isAdmin,
+};

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -208,3 +208,43 @@ CREATE TABLE IF NOT EXISTS x_feed_cache (
   fetched_at INTEGER NOT NULL,
   posts_json TEXT NOT NULL
 );
+
+-- Streamer applications (site/streamer-signup.html), replacing the Google
+-- Form + published-sheet pipeline. Rows land as 'pending'; a moderator moves
+-- them to 'approved' or 'rejected' from site/admin.html.
+--
+-- This is the one table in the schema holding contact details for people who
+-- are not users — a Discord handle, maybe an email in contact_link, and when
+-- they are reachable. Nothing here is served by a public route: the roster
+-- endpoint selects only name/twitch_login/notes from approved rows, and
+-- everything else leaves D1 solely through the moderator-gated read.
+CREATE TABLE IF NOT EXISTS streamer_applications (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,               -- creator / channel name, public once approved
+  channel_url TEXT NOT NULL,        -- normalized https URL
+  platform TEXT NOT NULL,           -- twitch | youtube | kick | other
+  twitch_login TEXT,                -- embeddable login, Twitch URLs only
+  discord TEXT NOT NULL,
+  viewers TEXT NOT NULL,            -- one of the form's buckets, verbatim
+  blurb TEXT,                       -- one-liner the applicant agreed to publish
+  notes TEXT,                       -- private message to the mod queue; NEVER served publicly
+  contact_method TEXT,
+  contact_link TEXT,
+  best_time TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  reviewed_by INTEGER,              -- users.id of the moderator who decided
+  reviewed_at INTEGER,
+  created_at INTEGER NOT NULL,
+  ip_hash TEXT                      -- salted hash, for abuse triage only
+);
+
+-- The roster read is "approved rows, newest first"; the mod queue is the same
+-- shape per status. One index serves both.
+CREATE INDEX IF NOT EXISTS idx_streamer_applications_status
+  ON streamer_applications(status, created_at DESC);
+
+-- A channel may only sit in the queue once. Partial index so a rejected
+-- applicant can reapply later, but nobody can flood the queue with one URL.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_streamer_applications_open_channel
+  ON streamer_applications(channel_url)
+  WHERE status IN ('pending', 'approved');

--- a/server/test/streamer.test.js
+++ b/server/test/streamer.test.js
@@ -1,0 +1,262 @@
+/* Streamer applications are the first thing in this product that takes
+ * personal contact details from people who are not users, and the first form
+ * whose output a moderator reads in a browser. So every test here is an attack
+ * on one of those two seams: get a script into the mod page, forge an answer
+ * the form could not have produced, publish something the applicant wrote in
+ * private, or reach the queue without being a moderator.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const S = require('../core/streamer.js');
+const { HATE_CODE } = require('../core/clan.js');
+
+/** A minimal application that passes, so each test changes exactly one thing. */
+const VALID = Object.freeze({
+  name: 'ProfitableDegen',
+  channelUrl: 'https://twitch.tv/ProfitableDegen',
+  discord: 'degen',
+  viewers: S.VIEWER_BUCKETS[1],
+});
+const withField = (patch) => Object.assign({}, VALID, patch);
+
+test('the baseline application is accepted — otherwise every test below is vacuous', () => {
+  assert.equal(S.applyProblem(VALID), null);
+});
+
+/* ---------------------------------------------------------------- the href */
+
+test('a channel URL cannot carry a scheme that executes when a moderator clicks it', () => {
+  // These strings become href on the mod page. The rejection has to happen
+  // here, at the door, so no downstream renderer has to remember.
+  for (const hostile of [
+    'javascript:alert(1)',
+    'JavaScript:alert(1)',
+    '  javascript:alert(1)  ',
+    'data:text/html,<script>alert(1)</script>',
+    'vbscript:msgbox(1)',
+    'file:///etc/passwd',
+  ]) {
+    assert.equal(
+      S.applyProblem(withField({ channelUrl: hostile })), 'channel-url-invalid',
+      `${hostile} must not survive validation`);
+    assert.equal(S.safeUrl(hostile, 200), null);
+  }
+});
+
+test('the same scheme check guards the optional contact link', () => {
+  // A second URL field is a second door; it was not obvious it had a lock.
+  assert.equal(
+    S.applyProblem(withField({ contactLink: 'javascript:alert(1)' })),
+    'contact-link-invalid');
+  // ...but leaving it blank is still fine, because it is optional.
+  assert.equal(S.applyProblem(withField({ contactLink: '' })), null);
+});
+
+test('a bare host is assumed https rather than failed, and comes back normalized', () => {
+  const url = S.safeUrl('twitch.tv/SomeName', 200);
+  assert.equal(new URL(url).protocol, 'https:');
+  assert.equal(new URL(url).hostname, 'twitch.tv');
+});
+
+test('a string with no dot in the host is not a channel', () => {
+  assert.equal(S.safeUrl('notaurl', 200), null);
+  assert.equal(S.safeUrl('https://localhost/x', 200), null);
+});
+
+/* ------------------------------------------------------------ closed sets */
+
+test('viewer counts outside the form’s own dropdown are refused', () => {
+  // Every accepted value is one the form can actually emit...
+  for (const bucket of S.VIEWER_BUCKETS) {
+    assert.equal(S.applyProblem(withField({ viewers: bucket })), null);
+  }
+  // ...and anything else did not come from our form.
+  for (const forged of ['1000000', '', 'lots', '1-10', null]) {
+    assert.equal(S.applyProblem(withField({ viewers: forged })), 'viewers-invalid');
+  }
+});
+
+test('contact method is optional, but a present one must be from the dropdown', () => {
+  for (const method of S.CONTACT_METHODS) {
+    assert.equal(S.applyProblem(withField({ contactMethod: method })), null);
+  }
+  assert.equal(S.applyProblem(withField({ contactMethod: '' })), null);
+  assert.equal(
+    S.applyProblem(withField({ contactMethod: 'Carrier pigeon' })),
+    'contact-method-invalid');
+});
+
+/* ------------------------------------------------------- invisible input */
+
+test('invisible characters cannot make two names look identical', () => {
+  // A zero-width space between letters renders as nothing, so "Deg<ZWSP>en"
+  // and "Degen" are one name to a reader and two rows to a database.
+  assert.equal(S.clean('Deg​en', 40), 'Degen');
+  assert.equal(S.clean('﻿Degen', 40), 'Degen');
+  assert.equal(S.clean('Deg‮en', 40), 'Degen');
+});
+
+test('a newline inside a single-line field becomes a space, not nothing', () => {
+  // Deleting it outright welds two words together and silently changes the
+  // name the applicant typed.
+  assert.equal(S.clean('First\nLast', 40), 'First Last');
+  assert.equal(S.clean('First\tLast', 40), 'First Last');
+});
+
+test('the notes field keeps its paragraphs but not a runaway of them', () => {
+  assert.equal(S.cleanMultiline('a\n\n\n\n\nb', 100), 'a\n\nb');
+  assert.equal(S.cleanMultiline('a b', 100), 'a\nb');
+  assert.equal(S.cleanMultiline('  padded  ', 100), 'padded');
+});
+
+test('every field is capped at its declared limit', () => {
+  const long = 'x'.repeat(5000);
+  const app = S.normalizeApplication(withField({
+    name: long, discord: long, blurb: long, notes: long, bestTime: long,
+  }));
+  assert.equal(app.name.length, S.LIMITS.name);
+  assert.equal(app.discord.length, S.LIMITS.discord);
+  assert.equal(app.blurb.length, S.LIMITS.blurb);
+  assert.equal(app.notes.length, S.LIMITS.notes);
+  assert.equal(app.bestTime.length, S.LIMITS.bestTime);
+});
+
+test('a name that is only whitespace is not a name', () => {
+  for (const empty of ['', '   ', '\n\n', '​​', null, undefined]) {
+    assert.equal(S.applyProblem(withField({ name: empty })), 'name-required');
+  }
+});
+
+/* ------------------------------------------- what is public vs. what is not */
+
+test('the two fields that get published face the content rule; the private one does not', () => {
+  // name and blurb become a roster card on papertrench.com...
+  assert.equal(S.applyProblem(withField({ name: `Stream ${HATE_CODE}` })), 'name-blocked');
+  assert.equal(S.applyProblem(withField({ blurb: `gm ${HATE_CODE}` })), 'blurb-blocked');
+
+  // ...notes is a message to the moderators, who are the ones deciding. It is
+  // never published, so it is not filtered — if that ever stops being true,
+  // this assertion is the thing that should fail first.
+  assert.equal(S.applyProblem(withField({ notes: `gm ${HATE_CODE}` })), null);
+});
+
+test('notes and blurb are separate fields, so one cannot leak as the other', () => {
+  // The roster serves `blurb`; the mod queue serves both. If normalization
+  // ever folded notes into blurb, an applicant's private message would ship
+  // to the public page the moment a moderator approved them.
+  const app = S.normalizeApplication(withField({
+    blurb: 'Daily challenge runs',
+    notes: 'Please do not publish: my real name is redacted and I am 15.',
+  }));
+  assert.equal(app.blurb, 'Daily challenge runs');
+  assert.notEqual(app.blurb, app.notes);
+  assert.ok(!app.blurb.includes('redacted'));
+});
+
+/* ------------------------------------------------------------ twitch logins */
+
+test('only Twitch URLs yield an embeddable login', () => {
+  assert.equal(S.twitchLogin('https://twitch.tv/SomeName'), 'somename');
+  assert.equal(S.twitchLogin('https://www.twitch.tv/SomeName?x=1'), 'somename');
+  // Valid applications, but nothing the page can put in a Twitch player.
+  assert.equal(S.twitchLogin('https://youtube.com/@someone'), null);
+  assert.equal(S.twitchLogin('https://kick.com/someone'), null);
+});
+
+test('a login that is not a login is dropped, never salvaged', () => {
+  // Same rule as normalizeLogin() in site/streams.js: if the two disagree,
+  // the roster and the player disagree about who a card points at.
+  assert.equal(S.twitchLogin('https://twitch.tv/ab'), null);        // too short
+  assert.equal(S.twitchLogin('https://twitch.tv/' + 'a'.repeat(26)), null);
+  assert.equal(S.twitchLogin('https://twitch.tv/has spaces'), null);
+  assert.equal(S.twitchLogin('https://twitch.tv/'), null);
+});
+
+test('platform labels follow the host, not the text of the URL', () => {
+  assert.equal(S.platformOf('https://twitch.tv/x'), 'twitch');
+  assert.equal(S.platformOf('https://m.twitch.tv/x'), 'twitch');
+  assert.equal(S.platformOf('https://youtu.be/x'), 'youtube');
+  assert.equal(S.platformOf('https://kick.com/x'), 'kick');
+  assert.equal(S.platformOf('https://example.com/twitch.tv'), 'other');
+  assert.equal(S.platformOf('not a url'), 'other');
+});
+
+/* ------------------------------------------------------------- the mod gate */
+
+test('an empty or missing allowlist authorises nobody', () => {
+  // A deploy that forgets ADMIN_X_IDS must close the queue, not open it to
+  // every signed-in visitor.
+  for (const list of ['', '   ', null, undefined]) {
+    assert.equal(S.isAdmin('123', list), false);
+  }
+});
+
+test('moderator identity is matched whole, never as a prefix', () => {
+  assert.equal(S.isAdmin('123', '123'), true);
+  assert.equal(S.isAdmin('123', '123,456'), true);
+  assert.equal(S.isAdmin('456', '123, 456'), true);
+  assert.equal(S.isAdmin('123', '123456'), false);   // not a prefix
+  assert.equal(S.isAdmin('12', '123'), false);       // not a substring
+  assert.equal(S.isAdmin('', '123'), false);         // absent id is not a match
+  assert.equal(S.isAdmin(null, '123'), false);
+});
+
+test('the allowlist tolerates the spellings a human will actually write', () => {
+  const list = ' 111 , 222,333\n444 ';
+  for (const id of ['111', '222', '333', '444']) assert.equal(S.isAdmin(id, list), true);
+  assert.equal(S.isAdmin('555', list), false);
+});
+
+/* ------------------------------------------------- the page/server contract */
+
+/* The form's dropdowns and this module's closed sets are the same list written
+ * twice, in two files, in two languages. Nothing but this test connects them.
+ *
+ * The failure it exists for is silent and total: the buckets are spelled with
+ * an EN DASH (U+2013), and a hyphen typed into the HTML looks identical in an
+ * editor, in a diff, and in a browser. Every application would then fail
+ * `viewers-invalid` on a value the applicant picked from our own menu, and the
+ * form would reject everyone with a message about a field they cannot fix.
+ */
+const FORM_HTML = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'site', 'streamer-signup.html'), 'utf8');
+
+/** The <option> texts of one named <select> in the signup form. */
+function optionsOf(selectName) {
+  const select = new RegExp(
+    `<select[^>]*name="${selectName}"[^>]*>([\\s\\S]*?)</select>`).exec(FORM_HTML);
+  assert.ok(select, `the form has no <select name="${selectName}">`);
+  return [...select[1].matchAll(/<option(?![^>]*\b(?:disabled|value=""))[^>]*>([^<]*)<\/option>/g)]
+    .map((m) => m[1].trim());
+}
+
+test('the viewer dropdown offers exactly the buckets the server accepts', () => {
+  assert.deepEqual(optionsOf('viewers'), S.VIEWER_BUCKETS);
+});
+
+test('the contact-method dropdown offers exactly the methods the server accepts', () => {
+  assert.deepEqual(optionsOf('contactMethod'), S.CONTACT_METHODS);
+});
+
+test('every form field stops at the length the server would truncate it to', () => {
+  // A maxlength longer than the server's cap silently eats the tail of what
+  // someone typed; shorter, and the form refuses input the server would take.
+  const attrs = Object.fromEntries(
+    [...FORM_HTML.matchAll(/name="(\w+)"[^>]*maxlength="(\d+)"/g)].map((m) => [m[1], Number(m[2])]));
+  for (const [field, cap] of Object.entries(S.LIMITS)) {
+    assert.equal(attrs[field], cap, `maxlength for ${field} must match LIMITS.${field}`);
+  }
+});
+
+test('review statuses are a closed set, and pending is one of them', () => {
+  // 'pending' has to be assignable: it is how a moderator undoes a decision.
+  for (const status of ['pending', 'approved', 'rejected']) {
+    assert.equal(S.isStatus(status), true);
+  }
+  for (const bogus of ['deleted', 'APPROVED', '', null, 'approved; DROP TABLE']) {
+    assert.equal(S.isStatus(bogus), false);
+  }
+});

--- a/server/worker/index.js
+++ b/server/worker/index.js
@@ -17,6 +17,7 @@ import { windowEntry } from '../core/window.js';
 import { awarded } from '../core/achievements.js';
 import * as duel from '../core/duel.js';
 import * as clan from '../core/clan.js';
+import * as streamer from '../core/streamer.js';
 // Default-imported, not named: core/chain.js re-exports attest.js by property
 // assignment (`GENESIS: AT.GENESIS`), which Node's CJS named-export lexer
 // cannot see through — unlike the other cores, whose exports are literals.
@@ -30,6 +31,9 @@ const SEG_SIZE = 500;
 const SUBMITS_PER_HOUR = 6;
 const DUELS_PER_HOUR = 10;
 const CLAN_ACTIONS_PER_HOUR = 12;
+// Streamer signups need no account, so the leash is per-IP and deliberately
+// low: a person applies once, and the only reason to send six is abuse.
+const STREAMER_APPLIES_PER_HOUR = 5;
 // The X feed endpoint: only cache MISSES cost an upstream fetch, so the
 // per-IP leash sits on those, not on reads a cache can answer.
 const XFEED_PER_HOUR = 120;
@@ -1403,6 +1407,178 @@ async function drainPricing(env) {
     .run();
 }
 
+/* ---------------- streamer applications ---------------- */
+
+/**
+ * The moderator behind a request, or null.
+ *
+ * Two gates, both required: a valid session, and an x_id on the ADMIN_X_IDS
+ * allowlist. An unset or empty allowlist authorises nobody — a deploy that
+ * forgets the var must close the mod queue, not open it to every signed-in
+ * visitor, and "no admins configured" is the safe reading of an absent list.
+ */
+async function moderator(request, env) {
+  const user = await sessionUser(request, env);
+  if (!user) return null;
+  return streamer.isAdmin(user.x_id, env.ADMIN_X_IDS) ? user : null;
+}
+
+/**
+ * A salted, one-way trace of the applicant's IP.
+ *
+ * The raw address is never stored: applications come from members of the
+ * public, and an IP column would be a standing log of where they live for a
+ * feature whose actual need is only "did these six submissions come from one
+ * person". A SESSION_SECRET-salted digest answers that and nothing else, and
+ * it cannot be reversed or joined against anything outside this table.
+ */
+async function ipTrace(request, env) {
+  const ip = request.headers.get('CF-Connecting-IP');
+  if (!ip || !env.SESSION_SECRET) return null;
+  const bytes = new TextEncoder().encode(env.SESSION_SECRET + ':' + ip);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return [...new Uint8Array(digest)].slice(0, 8)
+    .map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+async function handleStreamerApply(request, env) {
+  const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
+  if (!(await allowRate(env, 'streamerapply:' + ip, STREAMER_APPLIES_PER_HOUR))) {
+    return json({ ok: false, reason: 'rate-limited' }, 429);
+  }
+  let body = {};
+  try { body = await request.json(); } catch {}
+
+  const problem = streamer.applyProblem(body);
+  if (problem) return json({ ok: false, reason: problem }, 422);
+
+  const app = streamer.normalizeApplication(body);
+  try {
+    await env.DB.prepare(`
+      INSERT INTO streamer_applications
+        (name, channel_url, platform, twitch_login, discord, viewers, blurb,
+         notes, contact_method, contact_link, best_time, status, created_at, ip_hash)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)`)
+      .bind(app.name, app.channelUrl, app.platform, app.twitchLogin, app.discord,
+        app.viewers, app.blurb || null, app.notes || null, app.contactMethod,
+        app.contactLink, app.bestTime || null, Date.now(), await ipTrace(request, env))
+      .run();
+  } catch {
+    // The partial unique index on channel_url is what decides, not a prior
+    // SELECT: two tabs submitted together would both pass a check-then-act.
+    return json({ ok: false, reason: 'already-applied' }, 409);
+  }
+  return json({ ok: true });
+}
+
+/**
+ * The mod queue. Every column, including contact details — which is exactly
+ * why it is behind moderator() and why nothing else selects from this table.
+ */
+async function handleStreamerApplications(request, env) {
+  const mod = await moderator(request, env);
+  if (!mod) return json({ ok: false, reason: 'not-a-moderator' }, 403);
+
+  const url = new URL(request.url);
+  const status = url.searchParams.get('status') || 'pending';
+  if (!streamer.isStatus(status)) return json({ ok: false, reason: 'bad-status' }, 422);
+
+  const { results } = await env.DB.prepare(`
+    SELECT a.id, a.name, a.channel_url, a.platform, a.twitch_login, a.discord,
+           a.viewers, a.blurb, a.notes, a.contact_method, a.contact_link,
+           a.best_time, a.status, a.created_at, a.reviewed_at, u.handle AS reviewed_by
+      FROM streamer_applications a
+      LEFT JOIN users u ON u.id = a.reviewed_by
+     WHERE a.status = ?
+     ORDER BY a.created_at DESC
+     LIMIT 200`)
+    .bind(status).all();
+
+  const counts = await env.DB.prepare(
+    'SELECT status, COUNT(*) AS n FROM streamer_applications GROUP BY status').all();
+
+  return json({
+    ok: true,
+    applications: (results || []).map((r) => ({
+      id: r.id,
+      name: r.name,
+      channelUrl: r.channel_url,
+      platform: r.platform,
+      twitchLogin: r.twitch_login,
+      discord: r.discord,
+      viewers: r.viewers,
+      blurb: r.blurb || '',
+      notes: r.notes || '',
+      contactMethod: r.contact_method || '',
+      contactLink: r.contact_link || '',
+      bestTime: r.best_time || '',
+      status: r.status,
+      createdAt: r.created_at,
+      reviewedAt: r.reviewed_at,
+      reviewedBy: r.reviewed_by || null,
+    })),
+    counts: Object.fromEntries((counts.results || []).map((r) => [r.status, Number(r.n)])),
+  });
+}
+
+async function handleStreamerReview(request, env) {
+  const mod = await moderator(request, env);
+  if (!mod) return json({ ok: false, reason: 'not-a-moderator' }, 403);
+
+  let body = {};
+  try { body = await request.json(); } catch {}
+  const id = Number(body.id);
+  if (!Number.isInteger(id) || id <= 0) return json({ ok: false, reason: 'bad-id' }, 422);
+  // 'pending' is a legal target: it is how a decision gets undone.
+  if (!streamer.isStatus(body.status)) return json({ ok: false, reason: 'bad-status' }, 422);
+
+  try {
+    const result = await env.DB.prepare(`
+      UPDATE streamer_applications SET status = ?, reviewed_by = ?, reviewed_at = ?
+       WHERE id = ?`)
+      .bind(body.status, mod.id, Date.now(), id)
+      .run();
+    if (!result.meta || result.meta.changes === 0) {
+      return json({ ok: false, reason: 'not-found' }, 404);
+    }
+  } catch {
+    // Approving a channel that already holds the approved/pending slot trips
+    // the partial unique index — a duplicate application, not a server fault.
+    return json({ ok: false, reason: 'already-listed' }, 409);
+  }
+  return json({ ok: true });
+}
+
+/**
+ * The public roster: approved applications, as streams.js consumes them.
+ *
+ * Deliberately a different column list from the mod queue above. An approved
+ * applicant agreed to appear on the streams page — they did not agree to
+ * publish the Discord handle and availability they gave us to be contacted
+ * with, so those columns are simply not in this SELECT.
+ *
+ * `blurb` is here and `notes` is not, and that is the whole distinction: the
+ * blurb is the field whose label promises it will be shown publicly, while
+ * notes answers "anything else you'd like us to know?" — a message to the
+ * moderators. Serving notes here would publish something written in private.
+ */
+async function handleStreamerRoster(env) {
+  const { results } = await env.DB.prepare(`
+    SELECT name, twitch_login, blurb
+      FROM streamer_applications
+     WHERE status = 'approved' AND twitch_login IS NOT NULL
+     ORDER BY created_at DESC
+     LIMIT 60`).all();
+  return json({
+    ok: true,
+    streamers: (results || []).map((r) => ({
+      login: r.twitch_login,
+      name: r.name,
+      blurb: r.blurb || '',
+    })),
+  });
+}
+
 /* ---------------- entry ---------------- */
 
 export default {
@@ -1430,8 +1606,18 @@ export default {
       else if (path === '/api/auth/logout' && request.method === 'POST') response = logout(request, env);
       else if (path === '/api/me') {
         const user = await sessionUser(request, env);
+        // xId is the caller's OWN X id — public on X, and the value an owner
+        // needs to put in ADMIN_X_IDS. Without it, standing up the first
+        // moderator means digging a numeric id out of a third-party lookup.
         response = user
-          ? json({ signedIn: true, handle: user.handle, displayName: user.display_name, avatarUrl: user.avatar_url })
+          ? json({
+            signedIn: true,
+            handle: user.handle,
+            displayName: user.display_name,
+            avatarUrl: user.avatar_url,
+            xId: user.x_id,
+            isMod: streamer.isAdmin(user.x_id, env.ADMIN_X_IDS),
+          })
           : json({ signedIn: false });
       }
       else if (path === '/api/me/delete' && request.method === 'POST') {
@@ -1501,6 +1687,21 @@ export default {
         const tag = clan.normalizeTag(url.searchParams.get('tag') || '');
         response = await edgeCached(cacheKey(url, { tag }), ctx, BOARD_CACHE_SEC,
           () => handleClanGet(env, tag));
+      }
+      else if (path === '/api/streamer/apply' && request.method === 'POST') {
+        response = await handleStreamerApply(request, env);
+      }
+      // Never edge-cached, unlike the boards: the response is scoped to a
+      // moderator session, and a shared cache would serve the queue to the
+      // next visitor who asked for the same URL.
+      else if (path === '/api/streamer/applications') {
+        response = await handleStreamerApplications(request, env);
+      }
+      else if (path === '/api/streamer/review' && request.method === 'POST') {
+        response = await handleStreamerReview(request, env);
+      }
+      else if (path === '/api/streamer/roster') {
+        response = await edgeCached(request, ctx, BOARD_CACHE_SEC, () => handleStreamerRoster(env));
       }
       else response = json({ ok: false, reason: 'not-found' }, 404);
     } catch (err) {

--- a/server/wrangler.toml
+++ b/server/wrangler.toml
@@ -57,5 +57,20 @@ SITE_ORIGIN_ALT = "https://www.papertrench.com"
 X_CLIENT_ID = "N1BucEctX2dwVkNhSVRXSGRnWks6MTpjaQ"
 X_REDIRECT_URI = "https://papertrench-api.onerobby.workers.dev/api/auth/x/callback"
 
+# Who can read and decide streamer applications (site/admin.html). A
+# comma-separated list of X USER IDS — not handles: schema.sql calls x_id
+# "immutable X user id; handles can change", and a handle that changes is a
+# handle somebody else can register. Allowlisting @somemod would hand the mod
+# queue to whoever claims that name next.
+#
+# Left EMPTY on purpose. An empty or unset list authorises nobody, which is the
+# safe reading of "no admins configured" — the queue holds applicants' Discord
+# handles and contact details, so a deploy that forgets this var must close it,
+# not open it to every signed-in visitor.
+#
+# To add the first moderator: sign in on the site, open /admin, and the page
+# prints your own X user id for exactly this purpose. Paste it here, redeploy.
+ADMIN_X_IDS = ""
+
 # Secrets (never in this file):
 #   wrangler secret put SESSION_SECRET     # 32+ random bytes

--- a/site/admin.html
+++ b/site/admin.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PaperTrench — Moderator queue</title>
+<!-- Not a public page: keep it out of search results and out of previews.
+     This is presentation only — the queue itself is gated server-side. -->
+<meta name="robots" content="noindex, nofollow">
+<meta name="referrer" content="no-referrer">
+<link rel="icon" type="image/png" href="assets/icon128.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;700;800&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+<link rel="stylesheet" href="arena.css">
+<style>
+  .admin-head { padding: 130px 0 22px; }
+  .admin-head h1 { font-size: clamp(30px, 4vw, 44px); font-weight: 900; letter-spacing: -0.5px; }
+  .admin-head p { font-size: 14px; color: var(--muted); margin-top: 10px; max-width: 640px; line-height: 1.6; }
+
+  .gate { max-width: 560px; margin: 0 auto 90px; text-align: center;
+    background: var(--panel); border: 1px solid var(--line2); border-radius: var(--radius); padding: 40px 32px; }
+  .gate .big { font-size: 42px; margin-bottom: 14px; }
+  .gate h2 { font-size: 20px; font-weight: 800; margin-bottom: 10px; }
+  .gate p { font-size: 13.5px; color: var(--muted); line-height: 1.65; margin-bottom: 18px; }
+  .gate code { font-family: var(--mono); font-size: 12.5px; color: var(--orange2);
+    background: rgba(0,0,0,0.3); border: 1px solid var(--line); border-radius: 6px; padding: 3px 7px; }
+
+  .tabs { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 22px; }
+  .tab {
+    font: inherit; font-size: 13px; font-weight: 750; cursor: pointer;
+    color: var(--muted); background: rgba(255,255,255,0.04);
+    border: 1px solid var(--line2); border-radius: 999px; padding: 8px 16px;
+    transition: color .15s, background .15s, border-color .15s;
+  }
+  .tab:hover { color: var(--text); background: rgba(255,255,255,0.08); }
+  .tab.on { color: #2a1a05; background: var(--grad-heat); border-color: transparent; font-weight: 800; }
+  .tab .n { opacity: 0.7; margin-left: 5px; font-variant-numeric: tabular-nums; }
+
+  .apps { display: grid; gap: 14px; padding-bottom: 90px; }
+  .app {
+    background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 20px 22px;
+  }
+  .app-top { display: flex; align-items: flex-start; gap: 12px; flex-wrap: wrap; margin-bottom: 14px; }
+  .app-name { font-size: 16.5px; font-weight: 800; }
+  .app-chan { font-size: 12.5px; margin-top: 2px; }
+  .app-chan a { color: var(--orange2); word-break: break-all; }
+  .app-when { margin-left: auto; font-size: 11.5px; color: var(--dim); white-space: nowrap; }
+
+  .plat {
+    display: inline-block; font-size: 9.5px; font-weight: 800; letter-spacing: 0.9px;
+    text-transform: uppercase; padding: 3px 8px; border-radius: 999px; vertical-align: middle;
+  }
+  .plat.twitch { color: #bf94ff; background: rgba(145,70,255,0.13); border: 1px solid rgba(145,70,255,0.32); }
+  .plat.youtube { color: #ff8a80; background: rgba(224,67,58,0.11); border: 1px solid rgba(224,67,58,0.3); }
+  .plat.kick { color: var(--green2); background: rgba(52,211,153,0.10); border: 1px solid rgba(52,211,153,0.28); }
+  .plat.other { color: var(--muted); background: rgba(255,255,255,0.05); border: 1px solid var(--line2); }
+
+  .rows { display: grid; grid-template-columns: 132px minmax(0,1fr); gap: 7px 16px; font-size: 13.5px; }
+  @media (max-width: 620px) { .rows { grid-template-columns: 1fr; gap: 2px; } .rows dt { margin-top: 9px; } }
+  .rows dt { color: var(--dim); font-size: 11.5px; font-weight: 750; letter-spacing: 0.5px; text-transform: uppercase; padding-top: 2px; }
+  .rows dd { color: var(--text); word-break: break-word; white-space: pre-wrap; }
+  .rows dd a { color: var(--orange2); word-break: break-all; }
+  .rows dd.empty { color: var(--dim); font-style: italic; }
+
+  /* Private answers are visually separated from the ones the applicant knows
+     will be published, so a moderator never pastes the wrong one somewhere. */
+  .private-note { margin-top: 14px; padding: 13px 15px; border-radius: 12px;
+    background: rgba(0,0,0,0.24); border: 1px solid var(--line); }
+  .private-note .cap { font-size: 10px; font-weight: 800; letter-spacing: 1.1px;
+    text-transform: uppercase; color: var(--green2); margin-bottom: 7px; }
+
+  .app-acts { display: flex; gap: 9px; flex-wrap: wrap; align-items: center; margin-top: 17px;
+    padding-top: 15px; border-top: 1px solid var(--line); }
+  .ar-btn.good { background: rgba(52,211,153,0.13); border-color: rgba(52,211,153,0.35); color: var(--green2); }
+  .ar-btn.bad { background: rgba(224,67,58,0.11); border-color: rgba(224,67,58,0.32); color: #ff8a80; }
+  .act-msg { font-size: 12.5px; font-weight: 650; color: var(--muted); }
+  .act-msg.err { color: #ff8a80; }
+
+  .state { text-align: center; padding: 60px 20px; color: var(--muted); font-size: 14px; }
+  .state .big { font-size: 38px; margin-bottom: 12px; opacity: 0.8; }
+
+  .who { display: flex; align-items: center; gap: 10px; font-size: 13px; color: var(--muted); margin-bottom: 20px; }
+  .who img { width: 26px; height: 26px; border-radius: 50%; }
+  .who b { color: var(--text); font-weight: 750; }
+  .who button { margin-left: auto; }
+</style>
+</head>
+<body>
+<div class="bg-glow"></div>
+<div class="bg-grid"></div>
+
+<nav>
+  <div class="nav-inner">
+    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <div class="nav-links">
+      <a href="leaderboard.html">Leaderboard</a>
+      <a href="sprint.html">Sprint</a>
+      <a href="duels.html">Duels</a>
+      <a href="clans.html">Clans</a>
+      <a href="streamer-signup.html">Streamer signup</a>
+      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
+    </div>
+  </div>
+</nav>
+
+<header class="admin-head">
+  <div class="wrap">
+    <h1>Moderator queue</h1>
+    <p>Streamer applications from <a href="streamer-signup.html" style="color:var(--orange2)">the signup form</a>. Approving a Twitch application puts a card on the streams page within a minute; everything on this page is visible to moderators only.</p>
+  </div>
+</header>
+
+<section style="padding-top:0">
+  <div class="wrap">
+    <!-- One of these is shown at a time; admin.js decides which. -->
+    <div id="loading" class="state"><div class="big">⏳</div>Checking your access…</div>
+
+    <div id="gateSignedOut" class="gate" hidden>
+      <div class="big">🔒</div>
+      <h2>Moderators only</h2>
+      <p>Sign in with the X account on the moderator list to open the queue.</p>
+      <a class="btn btn-primary" id="signInBtn" href="#">Sign in with X</a>
+      <p style="margin:16px 0 0;font-size:12.5px">Sign-in returns you to the leaderboard — come back here afterwards and the queue will open.</p>
+    </div>
+
+    <div id="gateNotMod" class="gate" hidden>
+      <div class="big">🚧</div>
+      <h2>Not on the moderator list</h2>
+      <p>You're signed in as <b id="notModHandle"></b>, but that account isn't a PaperTrench moderator.</p>
+      <p>To be added, send an owner your X user id:<br><code id="notModId"></code><br>
+         they add it to <code>ADMIN_X_IDS</code> and redeploy the Worker.</p>
+      <a class="btn btn-ghost" href="index.html">Back to the site</a>
+    </div>
+
+    <div id="queue" hidden>
+      <div class="who">
+        <img id="whoAvatar" src="" alt="" hidden>
+        <span>Signed in as <b id="whoHandle"></b> · moderator</span>
+        <button class="ar-btn" type="button" id="refreshBtn">Refresh</button>
+      </div>
+
+      <div class="tabs" id="tabs">
+        <button class="tab on" type="button" data-status="pending">Pending<span class="n" id="nPending"></span></button>
+        <button class="tab" type="button" data-status="approved">Approved<span class="n" id="nApproved"></span></button>
+        <button class="tab" type="button" data-status="rejected">Rejected<span class="n" id="nRejected"></span></button>
+      </div>
+
+      <div class="apps" id="apps"></div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    <div class="foot-inner">
+      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <div class="foot-links">
+        <a href="index.html">Home</a>
+        <a href="streams.html">Watch Live</a>
+        <a href="streamer-signup.html">Streamer signup</a>
+        <a href="privacy.html">Privacy</a>
+      </div>
+    </div>
+    <div class="foot-note">Applicant contact details on this page are private — handle them like the personal data they are.</div>
+  </div>
+</footer>
+
+<script src="admin.js"></script>
+</body>
+</html>

--- a/site/admin.js
+++ b/site/admin.js
@@ -1,0 +1,264 @@
+/* PaperTrench — moderator queue for streamer applications.
+ *
+ * This page is a VIEW of a server-side decision, never the decision itself.
+ * The Worker checks the caller's x_id against ADMIN_X_IDS on every request
+ * (/api/streamer/applications, /api/streamer/review) and returns 403 to
+ * everyone else, so hiding the queue here is a courtesy to the user — not the
+ * control. Editing this file, or the DOM, gets an attacker exactly nothing.
+ *
+ * Operator setup: docs/STREAMS.md.
+ */
+(() => {
+  'use strict';
+
+  // Same API origin and session transport as arena.js — see the comments there
+  // on why the API is cross-site and why the token rides in localStorage as
+  // well as a cookie.
+  const API = 'https://papertrench-api.onerobby.workers.dev';
+  const TOKEN_KEY = 'pt_session_token';
+
+  const $ = (id) => document.getElementById(id);
+
+  const esc = (s) => String(s == null ? '' : s).replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ));
+
+  /**
+   * An href we are willing to put in the DOM.
+   *
+   * The server already rejects non-http(s) schemes at submission time, so this
+   * is the second lock on the same door: every string here was typed by a
+   * member of the public and is about to become a link a moderator clicks. If
+   * the server-side check is ever loosened, this is what keeps `javascript:`
+   * out of the mod page.
+   */
+  function safeHref(raw) {
+    try {
+      const url = new URL(String(raw));
+      return (url.protocol === 'https:' || url.protocol === 'http:') ? url.toString() : null;
+    } catch { return null; }
+  }
+
+  function sessionToken() {
+    try { return localStorage.getItem(TOKEN_KEY) || null; } catch { return null; }
+  }
+
+  async function api(path, options) {
+    const opts = Object.assign({ credentials: 'include' }, options || {});
+    const token = sessionToken();
+    if (token) opts.headers = Object.assign({}, opts.headers, { Authorization: 'Bearer ' + token });
+    const res = await fetch(API + path, opts);
+    const body = await res.json().catch(() => null);
+    return { status: res.status, body };
+  }
+
+  // The OAuth callback lands on the leaderboard, not here — but the token it
+  // stores is per-origin, so arriving with one already in hand is the norm.
+  // Handle the fragment anyway in case a future callback returns to this page.
+  const authReturn = window.location.hash.match(/^#authed(?:=(.+))?$/);
+  if (authReturn) {
+    if (authReturn[1]) { try { localStorage.setItem(TOKEN_KEY, authReturn[1]); } catch {} }
+    history.replaceState(null, '', window.location.pathname + window.location.search);
+  }
+
+  $('signInBtn').href = API + '/api/auth/x/start';
+
+  function show(paneId) {
+    for (const id of ['loading', 'gateSignedOut', 'gateNotMod', 'queue']) {
+      $(id).hidden = (id !== paneId);
+    }
+  }
+
+  /* ---------------- rendering ---------------- */
+
+  const when = (ms) => {
+    if (!ms) return '';
+    const d = new Date(Number(ms));
+    return Number.isNaN(d.getTime()) ? '' : d.toLocaleString(undefined, {
+      year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+    });
+  };
+
+  /** A <dd>, or an italic "not answered" — never a blank row that reads as data. */
+  function value(text) {
+    const clean = String(text == null ? '' : text).trim();
+    return clean ? `<dd>${esc(clean)}</dd>` : '<dd class="empty">not answered</dd>';
+  }
+
+  function linkValue(raw) {
+    const href = safeHref(raw);
+    if (!href) return value(raw);
+    return `<dd><a href="${esc(href)}" target="_blank" rel="noopener noreferrer">${esc(href)}</a></dd>`;
+  }
+
+  function cardFor(app) {
+    const platform = ['twitch', 'youtube', 'kick'].includes(app.platform) ? app.platform : 'other';
+    const chan = safeHref(app.channelUrl);
+    const chanHtml = chan
+      ? `<a href="${esc(chan)}" target="_blank" rel="noopener noreferrer">${esc(chan)}</a>`
+      : esc(app.channelUrl || '');
+
+    // Approve is offered only where it can do something. A YouTube or Kick
+    // application is perfectly valid, but the streams page embeds Twitch, so
+    // approving one would set a status that never becomes a card — a button
+    // that silently does nothing is worse than a button that isn't there.
+    const embeddable = Boolean(app.twitchLogin);
+
+    const actions = [];
+    if (app.status !== 'approved') {
+      actions.push(`<button class="ar-btn good" type="button" data-act="approved" data-id="${app.id}"
+        ${embeddable ? '' : 'disabled title="Only Twitch channels can be embedded on the streams page"'}>✓ Approve</button>`);
+    }
+    if (app.status !== 'rejected') {
+      actions.push(`<button class="ar-btn bad" type="button" data-act="rejected" data-id="${app.id}">✕ Reject</button>`);
+    }
+    if (app.status !== 'pending') {
+      actions.push(`<button class="ar-btn" type="button" data-act="pending" data-id="${app.id}">↩ Move back to pending</button>`);
+    }
+
+    const reviewed = app.reviewedAt
+      ? `<span class="act-msg">${esc(app.status)} by @${esc(app.reviewedBy || 'a moderator')} · ${esc(when(app.reviewedAt))}</span>`
+      : '';
+
+    return `
+      <article class="app" data-card="${app.id}">
+        <div class="app-top">
+          <div>
+            <div class="app-name">${esc(app.name)} <span class="plat ${platform}">${esc(platform)}</span></div>
+            <div class="app-chan">${chanHtml}</div>
+          </div>
+          <div class="app-when">${esc(when(app.createdAt))}</div>
+        </div>
+
+        <dl class="rows">
+          <dt>Public blurb</dt>${value(app.blurb)}
+          <dt>Twitch login</dt>${app.twitchLogin
+            ? `<dd>${esc(app.twitchLogin)}</dd>`
+            : '<dd class="empty">not a Twitch channel — cannot be embedded</dd>'}
+          <dt>Avg. viewers</dt>${value(app.viewers)}
+        </dl>
+
+        <div class="private-note">
+          <div class="cap">Private — moderators only</div>
+          <dl class="rows">
+            <dt>Discord</dt>${value(app.discord)}
+            <dt>Contact via</dt>${value(app.contactMethod)}
+            <dt>Profile link</dt>${linkValue(app.contactLink)}
+            <dt>Best time</dt>${value(app.bestTime)}
+            <dt>Notes</dt>${value(app.notes)}
+          </dl>
+        </div>
+
+        <div class="app-acts">${actions.join('')}${reviewed}</div>
+      </article>`;
+  }
+
+  /* ---------------- state ---------------- */
+
+  let current = 'pending';
+
+  function setCounts(counts) {
+    $('nPending').textContent = counts.pending ? ` ${counts.pending}` : '';
+    $('nApproved').textContent = counts.approved ? ` ${counts.approved}` : '';
+    $('nRejected').textContent = counts.rejected ? ` ${counts.rejected}` : '';
+  }
+
+  const EMPTY = {
+    pending: ['📭', 'Nothing waiting. New applications land here.'],
+    approved: ['🎬', 'No approved streamers yet.'],
+    rejected: ['🗂️', 'Nothing rejected.'],
+  };
+
+  async function loadQueue() {
+    const box = $('apps');
+    box.innerHTML = '<div class="state"><div class="big">⏳</div>Loading…</div>';
+
+    const { status, body } = await api('/api/streamer/applications?status=' + encodeURIComponent(current));
+
+    if (status === 403) { await boot(); return; }   // access changed under us
+    if (status < 200 || status >= 300 || !body || !body.ok) {
+      // Say the read failed. "No applications" would be an affirmative claim
+      // about the queue, made while we cannot see it.
+      box.innerHTML = '<div class="state"><div class="big">⚠️</div>'
+        + 'Couldn’t load the queue. Refresh to try again.</div>';
+      return;
+    }
+
+    setCounts(body.counts || {});
+    const apps = body.applications || [];
+    if (!apps.length) {
+      const [icon, text] = EMPTY[current] || EMPTY.pending;
+      box.innerHTML = `<div class="state"><div class="big">${icon}</div>${text}</div>`;
+      return;
+    }
+    box.innerHTML = apps.map(cardFor).join('');
+  }
+
+  $('apps').addEventListener('click', async (event) => {
+    const button = event.target.closest('button[data-act]');
+    if (!button || button.disabled) return;
+
+    const card = button.closest('[data-card]');
+    const buttons = card ? card.querySelectorAll('button[data-act]') : [button];
+    buttons.forEach((b) => { b.disabled = true; });
+
+    const { status, body } = await api('/api/streamer/review', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: Number(button.dataset.id), status: button.dataset.act }),
+    });
+
+    if (status >= 200 && status < 300 && body && body.ok) { await loadQueue(); return; }
+
+    buttons.forEach((b) => { b.disabled = false; });
+    const note = card && card.querySelector('.act-msg');
+    const text = body && body.reason === 'already-listed'
+      ? 'That channel is already on the roster.'
+      : 'That didn’t save — try again.';
+    if (note) { note.textContent = text; note.className = 'act-msg err'; }
+    else if (card) {
+      card.querySelector('.app-acts').insertAdjacentHTML('beforeend',
+        `<span class="act-msg err">${esc(text)}</span>`);
+    }
+  });
+
+  $('tabs').addEventListener('click', (event) => {
+    const tab = event.target.closest('.tab');
+    if (!tab) return;
+    current = tab.dataset.status;
+    $('tabs').querySelectorAll('.tab').forEach((t) => t.classList.toggle('on', t === tab));
+    loadQueue();
+  });
+
+  $('refreshBtn').addEventListener('click', loadQueue);
+
+  /* ---------------- boot ---------------- */
+
+  async function boot() {
+    let session = null;
+    try {
+      const reply = await api('/api/me');
+      session = reply.body;
+    } catch (_) { session = null; }
+
+    if (!session || !session.signedIn) { show('gateSignedOut'); return; }
+
+    if (!session.isMod) {
+      $('notModHandle').textContent = '@' + (session.handle || 'unknown');
+      // Their own X id, so getting added does not require a third-party lookup.
+      $('notModId').textContent = session.xId || 'unavailable';
+      show('gateNotMod');
+      return;
+    }
+
+    $('whoHandle').textContent = '@' + (session.handle || 'you');
+    if (session.avatarUrl && safeHref(session.avatarUrl)) {
+      $('whoAvatar').src = session.avatarUrl;
+      $('whoAvatar').hidden = false;
+    }
+    show('queue');
+    loadQueue();
+  }
+
+  boot();
+})();

--- a/site/streamer-signup.html
+++ b/site/streamer-signup.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PaperTrench — Streamer application</title>
+<meta name="description" content="Apply to become a featured PaperTrench streamer — get the Streamer role in Discord, an announcement to the community, automated live alerts, and a card on the streams page.">
+<meta property="og:title" content="PaperTrench — Streamer application">
+<meta property="og:description" content="Apply to join the PaperTrench Challenge roster. Featured on the streams page, Streamer role in Discord, and automated live alerts.">
+<meta property="og:image" content="https://papertrench.com/assets/video-poster.jpg">
+<link rel="icon" type="image/png" href="assets/icon128.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;700;800&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+<link rel="stylesheet" href="arena.css">
+<style>
+  :root { --twitch: #9146FF; --twitch2: #bf94ff; }
+  .k-twitch { color: var(--twitch2); background: rgba(145,70,255,0.10); border: 1px solid rgba(145,70,255,0.32); }
+  .hero.compact { padding: 140px 0 24px; }
+  .hero.compact h1 { font-size: clamp(34px, 5vw, 58px); }
+  .grad-twitch {
+    background: linear-gradient(100deg, var(--twitch2) 10%, var(--twitch) 70%);
+    -webkit-background-clip: text; background-clip: text; color: transparent;
+  }
+
+  .apply-wrap { display: grid; grid-template-columns: minmax(0,1fr) 320px; gap: 28px; align-items: start; padding-bottom: 90px; }
+  @media (max-width: 900px) { .apply-wrap { grid-template-columns: 1fr; } }
+
+  .apply-card {
+    background: var(--panel); border: 1px solid var(--line2);
+    border-radius: var(--radius); padding: 26px 28px 28px;
+  }
+  .apply-card h2 { font-size: 19px; font-weight: 800; margin-bottom: 6px; }
+  .apply-card .lede { font-size: 13.5px; color: var(--muted); line-height: 1.6; margin-bottom: 22px; }
+
+  .req { color: var(--orange2); font-weight: 800; }
+  .ar-field { margin-bottom: 17px; }
+  textarea.ar-input { min-height: 96px; resize: vertical; line-height: 1.55; }
+  select.ar-input { appearance: none; cursor: pointer;
+    background-image: linear-gradient(45deg, transparent 50%, var(--muted) 50%), linear-gradient(135deg, var(--muted) 50%, transparent 50%);
+    background-position: calc(100% - 17px) 51%, calc(100% - 12px) 51%;
+    background-size: 5px 5px, 5px 5px; background-repeat: no-repeat; padding-right: 34px; }
+  select.ar-input option { background: var(--panel2); color: var(--text); }
+
+  /* A field whose answer becomes public says so where the answer is typed —
+     not in a policy page nobody opens. */
+  .vis {
+    display: inline-flex; align-items: center; gap: 5px; margin-left: 8px;
+    font-size: 9.5px; font-weight: 800; letter-spacing: 0.8px; text-transform: uppercase;
+    padding: 2px 7px; border-radius: 999px; vertical-align: middle;
+  }
+  .vis.public { color: var(--twitch2); background: rgba(145,70,255,0.12); border: 1px solid rgba(145,70,255,0.3); }
+  .vis.private { color: var(--green2); background: rgba(52,211,153,0.10); border: 1px solid rgba(52,211,153,0.28); }
+
+  .apply-actions { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; margin-top: 22px; }
+  .form-msg { font-size: 13px; font-weight: 650; line-height: 1.55; }
+  .form-msg.err { color: #ff8a80; }
+  .form-msg.ok { color: var(--green2); }
+
+  .done { text-align: center; padding: 26px 10px 10px; }
+  .done .big { font-size: 44px; margin-bottom: 12px; }
+  .done h2 { font-size: 21px; margin-bottom: 8px; }
+  .done p { font-size: 14px; color: var(--muted); line-height: 1.65; max-width: 420px; margin: 0 auto 20px; }
+
+  .side { display: grid; gap: 16px; position: sticky; top: 96px; }
+  @media (max-width: 900px) { .side { position: static; } }
+  .side-card { background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius); padding: 20px 22px; }
+  .side-card h3 { font-size: 12px; font-weight: 800; letter-spacing: 1.3px; text-transform: uppercase; color: var(--dim); margin-bottom: 13px; }
+  .perk { display: flex; gap: 11px; align-items: flex-start; margin-bottom: 13px; font-size: 13.5px; line-height: 1.5; }
+  .perk:last-child { margin-bottom: 0; }
+  .perk .ico { font-size: 16px; flex: none; line-height: 1.35; }
+  .perk b { font-weight: 750; }
+  .perk span { color: var(--muted); }
+</style>
+</head>
+<body>
+<div class="bg-glow"></div>
+<div class="bg-grid"></div>
+
+<nav>
+  <div class="nav-inner">
+    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <div class="nav-links">
+      <a href="index.html#bubbles">Chart bubbles</a>
+      <a href="index.html#replay">Replay</a>
+      <a href="leaderboard.html">Leaderboard</a>
+      <a href="sprint.html">Sprint</a>
+      <a href="duels.html">Duels</a>
+      <a href="clans.html">Clans</a>
+      <a href="news.html">News</a>
+      <a href="index.html#install">Install</a>
+      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
+    </div>
+  </div>
+</nav>
+
+<header class="hero compact">
+  <div class="wrap">
+    <span class="sec-kicker k-twitch reveal">Streamer application</span>
+    <h1 class="reveal d1">Get featured <span class="grad-twitch">in the trench.</span></h1>
+    <p class="hero-sub reveal d2">Any creator running the PaperTrench Challenge can apply. Approved streamers get a card on the <a href="streams.html" style="color:var(--twitch2)">streams page</a>, the Streamer role in Discord, and automated live alerts.</p>
+  </div>
+</header>
+
+<section style="padding-top:14px">
+  <div class="wrap apply-wrap">
+    <div class="apply-card reveal">
+      <!-- The form and the thank-you state swap in place; JS toggles them. -->
+      <div id="formPane">
+        <h2>Tell us about your channel</h2>
+        <p class="lede">Fields marked <span class="req">*</span> are required. We review applications by hand — expect a Discord DM once a moderator has looked at yours.</p>
+
+        <form id="applyForm" novalidate>
+          <label class="ar-field">
+            <span class="lbl">Creator / Channel Name <span class="req">*</span><span class="vis public">Public</span></span>
+            <input class="ar-input" type="text" name="name" maxlength="40" autocomplete="off" required>
+          </label>
+
+          <label class="ar-field">
+            <span class="lbl">Main Channel URL <span class="req">*</span><span class="vis public">Public</span></span>
+            <input class="ar-input" type="text" name="channelUrl" maxlength="200" inputmode="url" placeholder="twitch.tv/yourname" autocomplete="off" required>
+            <span class="hint">Twitch, YouTube, Kick, etc. Twitch channels can be embedded and played directly on the streams page.</span>
+          </label>
+
+          <label class="ar-field">
+            <span class="lbl">Discord Username <span class="req">*</span><span class="vis private">Private</span></span>
+            <input class="ar-input" type="text" name="discord" maxlength="40" autocomplete="off" required>
+            <span class="hint">So we can assign your Streamer role and post your live alerts.</span>
+          </label>
+
+          <label class="ar-field">
+            <span class="lbl">Average Live Viewers <span class="req">*</span><span class="vis private">Private</span></span>
+            <select class="ar-input" name="viewers" required>
+              <option value="" selected disabled>Choose one…</option>
+              <option>1–10</option>
+              <option>10–50</option>
+              <option>50–100</option>
+              <option>100+</option>
+            </select>
+          </label>
+
+          <label class="ar-field">
+            <span class="lbl">One line about your stream<span class="vis public">Public</span></span>
+            <input class="ar-input" type="text" name="blurb" maxlength="160" autocomplete="off" placeholder="Weekend challenge runs — fresh eyes on the trenches.">
+            <span class="hint">This is the blurb printed on your roster card if you're approved. Leave it blank and your card just shows your name.</span>
+          </label>
+
+          <label class="ar-field">
+            <span class="lbl">Anything else you'd like us to know?<span class="vis private">Private</span></span>
+            <textarea class="ar-input" name="notes" maxlength="1000" rows="4"></textarea>
+            <span class="hint">Only the moderator team reads this — it is never shown on the site.</span>
+          </label>
+
+          <label class="ar-field">
+            <span class="lbl">Preferred Contact Method<span class="vis private">Private</span></span>
+            <select class="ar-input" name="contactMethod">
+              <option value="" selected>No preference</option>
+              <option>Discord DM</option>
+              <option>Email</option>
+              <option>Twitter/X</option>
+              <option>Other</option>
+            </select>
+          </label>
+
+          <label class="ar-field">
+            <span class="lbl">Profile link<span class="vis private">Private</span></span>
+            <input class="ar-input" type="text" name="contactLink" maxlength="200" inputmode="url" autocomplete="off" placeholder="https://…">
+            <span class="hint">If you picked Discord, Twitter/X, or Other above, drop the profile link here.</span>
+          </label>
+
+          <label class="ar-field">
+            <span class="lbl">Best Day/Time to Reach You<span class="vis private">Private</span></span>
+            <input class="ar-input" type="text" name="bestTime" maxlength="100" autocomplete="off" placeholder="Weeknights after 8pm ET">
+          </label>
+
+          <div class="apply-actions">
+            <button class="ar-btn primary" type="submit" id="submitBtn">Send application</button>
+            <span class="form-msg" id="formMsg" role="status" aria-live="polite"></span>
+          </div>
+        </form>
+
+        <p class="ar-note" style="margin-top:20px">
+          What we store: the answers above, and a one-way hash of your IP for
+          abuse triage. Your Discord handle and contact details are visible only
+          to PaperTrench moderators — never published, never sold. Ask a
+          moderator to delete your application and it's gone.
+        </p>
+      </div>
+
+      <div class="done" id="donePane" hidden>
+        <div class="big">🎥</div>
+        <h2>Application received</h2>
+        <p>A moderator will look it over and reach out on Discord. If you're approved, your card goes up on the streams page automatically.</p>
+        <a class="btn btn-primary" href="streams.html">Back to the streams page</a>
+      </div>
+    </div>
+
+    <aside class="side reveal d1">
+      <div class="side-card">
+        <h3>What approved streamers get</h3>
+        <div class="perk"><span class="ico">🌟</span><span><b>Streamer role</b> in the PaperTrench Discord.</span></div>
+        <div class="perk"><span class="ico">📢</span><span><b>Featured announcement</b> introducing you to the community.</span></div>
+        <div class="perk"><span class="ico">🔴</span><span><b>Automated live notifications</b> when you go live.</span></div>
+        <div class="perk"><span class="ico">🎬</span><span><b>A card on the streams page</b> — Twitch channels play inline.</span></div>
+      </div>
+      <div class="side-card">
+        <h3>Before you apply</h3>
+        <div class="perk"><span class="ico">⬇</span><span>Install the extension from the <a href="index.html#install" style="color:var(--orange2)">install guide</a> — free, open source, no signup.</span></div>
+        <div class="perk"><span class="ico">🟩</span><span>Open <code>🎥 Stream overlay</code> from the popup and add it to OBS with a chroma key.</span></div>
+        <div class="perk"><span class="ico">⛓️</span><span>Your record is a <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener" style="color:var(--orange2)">hash-chained</a> paper wallet — same rules as everyone.</span></div>
+      </div>
+    </aside>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    <div class="foot-inner">
+      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <div class="foot-links">
+        <a href="index.html">Home</a>
+        <a href="streams.html">Watch Live</a>
+        <a href="news.html">News</a>
+        <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
+        <a href="privacy.html">Privacy</a>
+      </div>
+    </div>
+    <div class="foot-note">Paper trading only · not financial advice · every P&amp;L on this site is simulated, and proud of it.</div>
+  </div>
+</footer>
+
+<script src="streamer-signup.js"></script>
+</body>
+</html>

--- a/site/streamer-signup.js
+++ b/site/streamer-signup.js
@@ -1,0 +1,131 @@
+/* PaperTrench — streamer application form.
+ *
+ * Posts to the leaderboard Worker (POST /api/streamer/apply), which validates
+ * with the same core module the server tests exercise. Nothing is validated
+ * *only* here: this file exists to tell the applicant what went wrong without
+ * a round trip, and the server re-checks every field regardless.
+ *
+ * Operator notes: docs/STREAMS.md.
+ */
+(() => {
+  'use strict';
+
+  // Same API origin as arena.js — see the comment there on why the API lives
+  // on workers.dev rather than api.papertrench.com.
+  const API = 'https://papertrench-api.onerobby.workers.dev';
+
+  const $ = (id) => document.getElementById(id);
+  const form = $('applyForm');
+  const msg = $('formMsg');
+  const button = $('submitBtn');
+
+  /* ---------- scroll reveal (same behaviour as main.js) ---------- */
+  const io = new IntersectionObserver((entries) => {
+    for (const e of entries) {
+      if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); }
+    }
+  }, { threshold: 0.12 });
+  document.querySelectorAll('.reveal').forEach((el) => io.observe(el));
+
+  /**
+   * Server reason code -> what the applicant should read.
+   *
+   * The server returns codes, not sentences, so the wording lives here and can
+   * change without touching validation. An unmapped code must still say
+   * something true, which is what the fallback is for — never a blank toast
+   * that leaves someone staring at a form that did nothing.
+   */
+  const REASONS = {
+    'name-required': 'Add the name your channel goes by.',
+    'name-blocked': 'That channel name can’t be used here.',
+    'blurb-blocked': 'That one-line blurb can’t be used here.',
+    'channel-url-invalid': 'That channel link doesn’t look like a URL — try twitch.tv/yourname.',
+    'discord-required': 'Add your Discord username so we can reach you.',
+    'viewers-invalid': 'Pick an average viewer count.',
+    'contact-method-invalid': 'Pick a contact method from the list.',
+    'contact-link-invalid': 'That profile link doesn’t look like a URL.',
+    'already-applied': 'That channel already has an application in the queue.',
+    'rate-limited': 'Too many applications from this connection. Try again in an hour.',
+  };
+
+  const FIELD_FOR = {
+    'name-required': 'name',
+    'name-blocked': 'name',
+    'blurb-blocked': 'blurb',
+    'channel-url-invalid': 'channelUrl',
+    'discord-required': 'discord',
+    'viewers-invalid': 'viewers',
+    'contact-method-invalid': 'contactMethod',
+    'contact-link-invalid': 'contactLink',
+    'already-applied': 'channelUrl',
+  };
+
+  function say(text, kind) {
+    msg.textContent = text || '';
+    msg.className = 'form-msg' + (kind ? ' ' + kind : '');
+  }
+
+  /** Put the cursor where the problem is — a message alone makes them hunt. */
+  function focusField(reason) {
+    const name = FIELD_FOR[reason];
+    if (!name) return;
+    const el = form.elements[name];
+    if (el && el.focus) el.focus();
+  }
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (button.disabled) return;
+
+    const data = Object.fromEntries(new FormData(form).entries());
+
+    // A cheap local pass on the three required text fields, so the obvious
+    // omission does not cost a round trip. The server owns the real verdict.
+    if (!String(data.name || '').trim()) {
+      say(REASONS['name-required'], 'err'); focusField('name-required'); return;
+    }
+    if (!String(data.channelUrl || '').trim()) {
+      say(REASONS['channel-url-invalid'], 'err'); focusField('channel-url-invalid'); return;
+    }
+    if (!String(data.discord || '').trim()) {
+      say(REASONS['discord-required'], 'err'); focusField('discord-required'); return;
+    }
+    if (!String(data.viewers || '').trim()) {
+      say(REASONS['viewers-invalid'], 'err'); focusField('viewers-invalid'); return;
+    }
+
+    button.disabled = true;
+    say('Sending…');
+
+    let status = 0;
+    let body = null;
+    try {
+      const res = await fetch(API + '/api/streamer/apply', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      status = res.status;
+      body = await res.json().catch(() => null);
+    } catch (_) {
+      // Network-level failure: the application did NOT land, and saying
+      // anything else would be inventing an outcome.
+      button.disabled = false;
+      say('Couldn’t reach the server. Check your connection and try again.', 'err');
+      return;
+    }
+
+    if (status >= 200 && status < 300 && body && body.ok) {
+      $('formPane').hidden = true;
+      $('donePane').hidden = false;
+      $('donePane').scrollIntoView({ behavior: 'smooth', block: 'center' });
+      return;
+    }
+
+    button.disabled = false;
+    const reason = body && body.reason;
+    say(REASONS[reason] || 'Something went wrong sending that — try again in a moment.', 'err');
+    focusField(reason);
+  });
+})();

--- a/site/streams.html
+++ b/site/streams.html
@@ -202,7 +202,7 @@
         <h3>Streaming the challenge? Get featured here.</h3>
         <p>Any Twitch streamer running PaperTrench can join the roster — we link your stream on this page and you compete for the giveaway with a record nobody can fake.</p>
       </div>
-      <a class="btn btn-twitch" id="signupBtn" href="#" target="_blank" rel="noopener">Sign up as a streamer</a>
+      <a class="btn btn-twitch" id="signupBtn" href="streamer-signup.html">Sign up as a streamer</a>
     </div>
   </div>
 </section>

--- a/site/streams.js
+++ b/site/streams.js
@@ -1,9 +1,11 @@
 /* PaperTrench — Live on Twitch page.
  *
- * The roster comes from two places: the hand-maintained STREAMERS list below,
- * plus (optionally) the approval Google Sheet behind the signup form — rows
- * whose Approved column says yes appear on the page without a deploy. Full
- * setup walkthrough: docs/STREAMS.md.
+ * The roster is the hand-maintained STREAMERS list below, plus every
+ * application a moderator approved in site/admin.html (read from the Worker's
+ * /api/streamer/roster). A legacy Google-Sheet CSV is still honoured for
+ * deployments that ran on one, but nothing new needs it. Neither remote source
+ * can break the page: on any failure the hand-maintained list stands alone.
+ * Full setup walkthrough: docs/STREAMS.md.
  */
 (() => {
   'use strict';
@@ -37,20 +39,20 @@
     },
   ];
 
-  // Where "Sign up as a streamer" points. Paste the Google Form share link
-  // here once it exists (see docs/STREAMS.md); until then, GitHub issues.
-  const SIGNUP_URL = 'https://github.com/OnlyTerp/papertrench/issues/new'
-    + '?title=' + encodeURIComponent('Streamer signup: <your twitch handle>')
-    + '&body=' + encodeURIComponent(
-      'Twitch channel: https://twitch.tv/\n'
-      + 'When do you stream the challenge?: \n'
-      + 'Anything else we should know?: \n');
+  // Where "Sign up as a streamer" points — the on-site form, which posts to
+  // the leaderboard Worker and lands in the moderator queue (site/admin.html).
+  const SIGNUP_URL = 'streamer-signup.html';
 
-  // Approval-sheet roster (optional). Paste the "Publish to web → CSV" URL of
-  // the Google Sheet behind the signup form and the page pulls every row whose
-  // Approved column says yes — approving a streamer is typing "yes" in a cell,
-  // no deploy needed. Empty string disables it; on any fetch/parse failure the
-  // page just runs on STREAMERS above. Setup walkthrough: docs/STREAMS.md.
+  // The API roster: every application a moderator approved in site/admin.html.
+  // This is the pipeline the signup form feeds, and it needs no configuration —
+  // approving a streamer publishes their card within the 60s edge cache.
+  const API = 'https://papertrench-api.onerobby.workers.dev';
+
+  // Legacy approval-sheet roster (optional, and superseded by the API above).
+  // Paste the "Publish to web → CSV" URL of a Google Sheet and the page pulls
+  // every row whose Approved column says yes. Empty string disables it; on any
+  // fetch/parse failure the page just runs on STREAMERS above. Kept so a
+  // deployment already running on a sheet does not lose its roster on upgrade.
   const ROSTER_CSV_URL = '';
 
   const LIVE_POLL_MS = 60000;
@@ -139,6 +141,39 @@
 
   function findCol(headers, ...needles) {
     return headers.findIndex((h) => needles.some((n) => h.includes(n)));
+  }
+
+  /**
+   * Approved applications from the Worker.
+   *
+   * Same contract as the sheet loader below: enhancement, never load-bearing.
+   * A dead API leaves the hand-maintained STREAMERS list on the page rather
+   * than emptying the roster — an empty grid would state "nobody streams this"
+   * on the strength of a failed fetch.
+   */
+  async function loadApiRoster() {
+    try {
+      const res = await fetch(API + '/api/streamer/roster', { cache: 'no-store' });
+      if (!res.ok) throw new Error('HTTP ' + res.status);
+      const body = await res.json();
+      if (!body || !body.ok || !Array.isArray(body.streamers)) return;
+
+      const seen = new Set(roster.map((s) => s.login));
+      for (const row of body.streamers) {
+        // The server normalizes these, but the page owns what it renders:
+        // re-run the same login rule rather than trusting the shape.
+        const login = normalizeLogin(row && row.login);
+        if (!login || seen.has(login)) continue;
+        seen.add(login);
+        roster.push({
+          login,
+          name: String((row && row.name) || '').trim() || login,
+          blurb: String((row && row.blurb) || '').trim(),
+        });
+      }
+    } catch (err) {
+      console.warn('PaperTrench: roster API unavailable —', err.message);
+    }
   }
 
   async function loadSheetRoster() {
@@ -266,7 +301,7 @@
   const OPEN_SLOTS = 3;
   function openSlot() {
     return `
-        <a class="s-card" href="${esc(SIGNUP_URL)}" target="_blank" rel="noopener"
+        <a class="s-card" href="${esc(SIGNUP_URL)}"
            style="display:block;border-style:dashed;border-color:rgba(145,70,255,0.35)">
           <div class="s-thumb"><div class="ph">?</div></div>
           <div class="s-body">
@@ -348,7 +383,8 @@
     renderGrid();
 
     const before = `${featured}:${roster.length}`;
-    await loadSheetRoster();
+    // Both are optional and independent; neither can fail the page.
+    await Promise.all([loadApiRoster(), loadSheetRoster()]);
     pickFeatured();
     if (`${featured}:${roster.length}` !== before) {
       renderFeatured();


### PR DESCRIPTION
`docs/STREAMS.md` describes a Google Form → published-Sheet pipeline as the intended home for streamer signups, and `SIGNUP_URL` currently points at a prefilled GitHub issue until that exists. This builds it on the site instead.

| | |
| --- | --- |
| `site/streamer-signup.html` + `.js` | the form, in the site's own styling |
| `site/admin.html` + `.js` | the moderator queue |
| `server/core/streamer.js` | validation, pure and tested |
| `streamer_applications` | D1 table behind both |

Questions are carried over from the existing form, plus one addition explained below.

### Routes

| Route | Who |
| --- | --- |
| `POST /api/streamer/apply` | anyone, 5/hour per IP |
| `GET /api/streamer/applications?status=` | moderators only |
| `POST /api/streamer/review` | moderators only |
| `GET /api/streamer/roster` | anyone — approved rows, public columns |

Approving a Twitch application publishes its card on the streams page within the 60 s edge cache. No deploy, no spreadsheet cell, no republish interval.

## The mod gate is server-side, and keyed on `x_id`

`ADMIN_X_IDS` holds X **user ids**, not handles. `schema.sql` already notes that `x_id` is immutable while handles change — and a handle that changes is one somebody else can register, so allowlisting `@somemod` would hand the queue to whoever claims that name next.

**An empty or unset list authorises nobody.** The queue holds applicants' Discord handles and contact details, so a deploy that forgets the var should close it, not open it to every signed-in visitor. `admin.js` hides the queue as a courtesy to the user; the Worker is what decides and returns 403 to everyone else — editing the page or the DOM gets an attacker nothing.

To bootstrap the first moderator, `/api/me` now returns the caller's own `xId`, and `/admin` prints it. Otherwise standing one up means digging a numeric id out of a third-party lookup.

## Public answers and private ones are separate columns

This is the part I'd most like reviewed.

The form labels every field **Public** or **Private** where it is typed. `GET /api/streamer/roster` selects `name`, `twitch_login`, `blurb` — and not `notes`, `discord`, `contact_link` or `best_time`. The split is enforced in the SQL rather than by convention.

The distinction that matters is **blurb vs. notes**. I added "One line about your stream", labelled as published, because the roster card needs text an applicant has *agreed* to publish — the existing form's closest field is "anything else you'd like us to know?", which is a message to moderators. Serving that as a public bio would publish something written in confidence, so it is the one question here that isn't carried over from the current form. (`docs/STREAMS.md` anticipated this field: *"About you (shown on the site, one line)"*.)

Applications also store a salted one-way hash of the IP for abuse triage, never the address.

## Tests

`server/test/streamer.test.js` — 24 cases, attacking both seams: hostile URL schemes (these strings become `href` in a moderator's browser), forged dropdown values, invisible-character spoofing, and the allowlist.

Two earned their keep during the change:

- The **bidi test** caught `U+202E` missing from the strip set. It reverses everything after it, so the stored name and the name a moderator reads can be different strings — and a moderator approving what they see must be approving what is stored.
- The **page/server contract test** catches an en dash (`U+2013`) in the form's `<select>` being retyped as a hyphen. Identical in an editor, in a diff, and in a browser — and every application would then fail `viewers-invalid` on a value picked from our own menu. I verified it goes red by making exactly that edit.

Also ran: `node --test` in `server/` (185 pass), `check-schema-drift.js`, and preflight's nav check.

`extension/test/perpswiring.test.js` fails on `main` before this change and is untouched by it.

## Notes for the maintainer

1. Needs `wrangler d1 execute papertrench --file=server/schema.sql --remote` before deploy.
2. `ADMIN_X_IDS` ships empty — the queue stays closed until you set it.
3. `ROSTER_CSV_URL` still works and is read alongside the API, so a deployment already running on a sheet keeps its roster. Migration note is in `docs/STREAMS.md`.
4. `CHANGELOG.md` gets an **Unreleased** section — I didn't touch `manifest.json`/`package.json`, since the version bump is your release call.

A follow-up PR converts the site to extensionless URLs (`/streams` rather than `/streams.html`). GitHub Pages already serves those today, so it's link updates only — kept separate from this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
