### PR TITLE
refactor(site): extensionless URLs (/leaderboard, not /leaderboard.html)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 Stream-style log of what shipped, newest first. User-facing wording; the gory
 details live in the commit messages.
 
+## Unreleased
+
+**Streamer signup lives on the site now.** "Sign up as a streamer" used to
+hand you off to a Google Form; it now opens **papertrench.com/streamer-signup**
+— the same questions, on the site, in the site's own styling. Applications go
+straight into the leaderboard database instead of a spreadsheet.
+
+**A moderator queue that isn't a shared password.** `/admin` lists every
+application with Approve / Reject, gated on X sign-in against a list of
+moderator accounts the server checks on every request. There is no password in
+the page to leak, and no version of the page you can edit your way past.
+
+**Approving somebody actually publishes them.** An approved Twitch application
+becomes a card on the streams page within a minute — no deploy, no spreadsheet
+cell, no republish interval. Channels that can't be embedded can't be approved
+into a card that would never appear, so the button says so instead.
+
+**Public answers and private ones are kept apart.** Every field on the form is
+labelled Public or Private where you type it. The one-line blurb is the roster
+card's text; your Discord handle, contact details and free-text notes are
+served to moderators only — the public roster query doesn't select those
+columns at all. We store a one-way hash of your IP for abuse triage, never the
+address.
+
 ## v3.12.1 — 2026-08-22
 
 **Lute is in the Instant-links list** (Terp: "instant link loading needs to

--- a/docs/STREAMS.md
+++ b/docs/STREAMS.md
@@ -99,7 +99,7 @@ channel's `live_user_<login>` thumbnail resolves; an offline one redirects to
 the `404_preview` image. Checked every 60 s. If Twitch ever changes this, the
 page degrades to showing no badges — never wrong ones. The featured player
 auto-promotes the first live streamer unless the viewer clicked a specific one
-(or arrived via `streams.html?channel=<login>`).
+(or arrived via `/streams?channel=<login>`).
 
 ## Stream overlay (what streamers use)
 

--- a/docs/STREAMS.md
+++ b/docs/STREAMS.md
@@ -5,49 +5,92 @@ touches lives in the CONFIG block at the top of `streams.js`:
 
 | Constant | What it does |
 | --- | --- |
-| `STREAMERS` | Hand-maintained roster. Always shown; wins over a sheet row with the same login. |
-| `SIGNUP_URL` | Where "Sign up as a streamer" points. Currently a prefilled GitHub issue; swap for the Google Form link. |
-| `ROSTER_CSV_URL` | Published-CSV URL of the approval sheet. Empty = disabled. |
+| `STREAMERS` | Hand-maintained roster. Always shown; wins over an approved application with the same login. |
+| `SIGNUP_URL` | Where "Sign up as a streamer" points — the on-site form, `streamer-signup.html`. |
+| `API` | Worker origin the approved roster is read from. Same value as `arena.js`. |
+| `ROSTER_CSV_URL` | Legacy Google-Sheet CSV roster. Empty = disabled, and it should stay empty on a new deploy. |
 
-## Signup + approval pipeline (Google Form → Sheet → site)
+## Signup + approval pipeline (on-site form → D1 → mod queue → site)
 
-One-time setup, ~5 minutes:
+Signups are a page on this site, not a Google Form. Three moving parts:
 
-1. **Create a Google Form** (forms.google.com) with these questions:
-   - *Twitch channel* — short answer, required. (Any format works: URL, @name, or bare handle — the site normalizes it.)
-   - *Display name* — short answer, required.
-   - *About you (shown on the site, one line)* — short answer.
-   - *When do you stream?* — short answer (for your planning; not shown on the site).
-   - Anything else you want to ask (contact handle, etc.) — extra columns are ignored by the site.
-2. In the form's **Responses** tab → **Link to Sheets**. This creates the response spreadsheet.
-3. In that sheet, **add a column headed `Approved`** to the right of the response columns.
-4. **File → Share → Publish to web** → pick the response tab (not "Entire document") → format **CSV** → Publish. Copy the URL.
-5. Paste into `streams.js`:
-   - the form's share link → `SIGNUP_URL`
-   - the published CSV URL → `ROSTER_CSV_URL`
-   Deploy the site once. Done — from here on, no deploys are needed to manage the roster.
+| Piece | Where |
+| --- | --- |
+| The form a streamer fills in | `site/streamer-signup.html` + `.js` |
+| The moderator queue | `site/admin.html` + `.js` |
+| Storage, validation, and the gate | `server/core/streamer.js`, `server/worker/index.js`, table `streamer_applications` |
+
+Routes on the Worker:
+
+| Route | Who can call it |
+| --- | --- |
+| `POST /api/streamer/apply` | Anyone. Rate-limited to 5/hour per IP. |
+| `GET /api/streamer/applications?status=` | Moderators only (403 otherwise). |
+| `POST /api/streamer/review` | Moderators only (403 otherwise). |
+| `GET /api/streamer/roster` | Anyone. Approved rows, public columns only. |
+
+### One-time setup
+
+1. **Apply the schema** so the new table exists:
+   ```
+   wrangler d1 execute papertrench --file=server/schema.sql --remote
+   ```
+2. **Name your moderators.** `ADMIN_X_IDS` in `wrangler.toml` is a
+   comma-separated list of **X user ids**, not handles. To find yours: sign in
+   on the site, open `/admin`, and the page prints your own id. Paste it in and
+   `wrangler deploy`.
+3. That's it. Nothing to configure on the site side — `streams.js` already
+   points at the form and reads the approved roster.
+
+> An empty `ADMIN_X_IDS` authorises **nobody**. That is deliberate: the queue
+> holds applicants' Discord handles and contact details, so a deploy that
+> forgets the var closes the queue rather than opening it to every signed-in
+> visitor. If `/admin` says you are not a moderator, this is usually why.
 
 ### Day-to-day approval
 
-Open the response sheet. Each signup is a row. Type `yes` in its **Approved**
-cell and the streamer appears on papertrench.com within ~5 minutes (Google's
-republish interval). Clear the cell to unlist them. Accepted approval values:
-`yes`, `y`, `true`, `1`, `x`, `approved`, `✓` (any case). Blank or anything
-else = not shown.
+Open `/admin` and sign in with an allowlisted X account. Pending applications
+are listed newest first, with **Approve** / **Reject** on each. Approving a
+Twitch application publishes its card on the streams page within ~60 s (the
+edge cache window). **Move back to pending** undoes a decision.
 
-Rules the site applies to sheet rows:
+Rules the pipeline applies:
 
-- Twitch handles are normalized (`https://twitch.tv/Name?x=1` → `name`); rows
-  whose handle can't be normalized to a valid Twitch login are skipped.
-- Duplicate logins are deduped; `STREAMERS` entries win over sheet rows.
-- If the sheet is unreachable or malformed, the page silently falls back to
-  `STREAMERS` (a `console.warn` is the only trace). The sheet can never break
-  the page.
+- Twitch logins are normalized (`https://twitch.tv/Name?x=1` → `name`) by the
+  same rule `streams.js` uses; an application whose URL can't be normalized to
+  a valid login is stored but **cannot be approved** — the streams page embeds
+  Twitch, so approving it would set a status that never becomes a card. The
+  Approve button is disabled on those, with a tooltip saying why.
+- Duplicate logins are deduped and `STREAMERS` entries win, same as before.
+- One application per channel URL may sit in the queue at a time (a partial
+  unique index). A rejected applicant can reapply later.
+- If the API is unreachable the page falls back to `STREAMERS` and logs
+  `PaperTrench: roster API unavailable` — it can never break the page.
 
-> After first publishing the sheet, load the streams page once with DevTools
-> open: if you see `PaperTrench: roster sheet unavailable`, the publish step
-> isn't right (usually "Entire document" was selected instead of the tab, or
-> the format isn't CSV).
+### What is published and what is not
+
+The form labels every field **Public** or **Private**, and the split is
+enforced in the SQL rather than in a convention:
+
+| Published on approval | Never leaves the mod queue |
+| --- | --- |
+| Creator name, channel URL, Twitch login, the one-line blurb | Discord username, viewer count, contact method, profile link, best time to reach, and the free-text notes |
+
+The one that matters is **blurb vs. notes**. "One line about your stream" says
+it will be shown publicly and is the roster card's text. "Anything else you'd
+like us to know?" is a message to moderators and is *never* served by a public
+route — `GET /api/streamer/roster` does not select the column. If you ever need
+a public bio, edit the blurb; do not repurpose notes.
+
+Applications also store a salted one-way hash of the applicant's IP for abuse
+triage. The raw address is never written.
+
+### Migrating off the Google Sheet
+
+`ROSTER_CSV_URL` still works and is read alongside the API, so an existing
+deployment keeps its roster on upgrade. To finish the move: re-enter any
+approved streamers via the form (or add them to `STREAMERS`), confirm they
+show, then set `ROSTER_CSV_URL` back to `''` and unpublish the sheet.
 
 ## How the page decides who's "LIVE"
 

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -3534,7 +3534,7 @@ function renderLeaderboard(el) {
             ever phoning a server. The board still goes by the site's word, not this
             chip.
           </p>
-          <a class="btn" href="https://papertrench.com/leaderboard.html" target="_blank" rel="noopener"
+          <a class="btn" href="https://papertrench.com/leaderboard" target="_blank" rel="noopener"
              style="margin-top:10px;display:inline-block">Sign in on papertrench.com →</a>
           `}
           <p class="dim" style="font-size:12px;line-height:1.55;margin:12px 0 0">
@@ -3545,7 +3545,7 @@ function renderLeaderboard(el) {
         ` : `
           <p class="dim" style="font-size:12.5px;line-height:1.6;margin-top:0">
             Link your X account to appear on the leaderboard. The easy way: sign in with X
-            on <a href="https://papertrench.com/leaderboard.html" target="_blank" rel="noopener"
+            on <a href="https://papertrench.com/leaderboard" target="_blank" rel="noopener"
             style="color:var(--orange2)">papertrench.com</a> and this links itself. Or type
             the handle below — stored locally, submitted with your signed chain; a server
             verifies ownership before ranking you either way.
@@ -3604,7 +3604,7 @@ function renderStandingsPlaceholder(identity, stats) {
       </span>
     </div>
     <p class="dim" style="font-size:12px;line-height:1.6;margin:14px 0 0">
-      Global standings live at <a href="https://papertrench.com/leaderboard.html" target="_blank" rel="noopener" style="color:var(--orange2)">papertrench.com/leaderboard</a>,
+      Global standings live at <a href="https://papertrench.com/leaderboard" target="_blank" rel="noopener" style="color:var(--orange2)">papertrench.com/leaderboard</a>,
       recomputed server-side from submitted chains — never from a self-reported
       number. The same chain also feeds the weekly Sprint and head-to-head
       duels; there is no second record to keep. ROI is shown next to absolute
@@ -3613,9 +3613,9 @@ function renderStandingsPlaceholder(identity, stats) {
     </p>
     <div style="display:flex;gap:10px;flex-wrap:wrap;margin-top:14px">
       <button class="btn-sec" id="lb-export" ${chain.length ? '' : 'disabled'}>Export record (JSON)</button>
-      <a class="btn-sec" href="https://papertrench.com/leaderboard.html" target="_blank" rel="noopener" style="text-decoration:none">Leaderboard ↗</a>
-      <a class="btn-sec" href="https://papertrench.com/sprint.html" target="_blank" rel="noopener" style="text-decoration:none">Weekly Sprint ↗</a>
-      <a class="btn-sec" href="https://papertrench.com/duels.html" target="_blank" rel="noopener" style="text-decoration:none">Duels ↗</a>
+      <a class="btn-sec" href="https://papertrench.com/leaderboard" target="_blank" rel="noopener" style="text-decoration:none">Leaderboard ↗</a>
+      <a class="btn-sec" href="https://papertrench.com/sprint" target="_blank" rel="noopener" style="text-decoration:none">Weekly Sprint ↗</a>
+      <a class="btn-sec" href="https://papertrench.com/duels" target="_blank" rel="noopener" style="text-decoration:none">Duels ↗</a>
     </div>
     <div class="field field-check" style="margin-top:14px"><label><input type="checkbox" id="lb-bridge" ${settings.leaderboardBridge === true ? 'checked' : ''}> Site sync</label><small>Lets papertrench.com read your verified record when you click Sync there — nothing is sent anywhere on its own, and no other site can ask. Off means the site tells you to use the exported file instead.</small></div>
     <div class="field field-check" style="margin-top:10px"><label><input type="checkbox" id="update-check" ${settings.updateCheckEnabled === false ? '' : 'checked'}> Check for new versions</label><small>Asks GitHub (api.github.com) if a newer release is out, twice a day, and shows a banner with the download link. Sends nothing but that one request. Unpacked extensions never update themselves, so this is the only way you hear about fixes. Turn it off for full no-phone-home mode.</small></div>`;

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -35,7 +35,10 @@ fi
 # navigate to, and both times it was caught by a person rather than a check.
 # Same failure mode as the version-pinned download link above: a rule that
 # lives only in someone's memory.
-NAV_DESTS="leaderboard.html sprint.html duels.html clans.html"
+# Extensionless: GitHub Pages resolves /leaderboard to leaderboard.html, and
+# the pages link that spelling. The .html form still resolves, so this list is
+# what decides which one the site is actually built out of.
+NAV_DESTS="/leaderboard /sprint /duels /clans"
 NAV_MISSING=""
 for page in site/*.html; do
   # Article pages and the Arena family all carry the same nav block.

--- a/server/DEPLOY.md
+++ b/server/DEPLOY.md
@@ -119,7 +119,7 @@ done   # every line must read 200
 
 
 - [ ] `GET /api/health` returns ok over the custom domain
-- [ ] Sign in with X on papertrench.com/leaderboard.html round-trips and
+- [ ] Sign in with X on papertrench.com/leaderboard round-trips and
       shows your handle
 - [ ] Submitting an exported record from a real install returns
       `status: pending` with replayed stats

--- a/server/core/streamer.js
+++ b/server/core/streamer.js
@@ -1,0 +1,227 @@
+/* Streamer applications — validation and normalization, pure.
+ *
+ * This replaces the Google Form + approval-sheet pipeline documented in
+ * docs/STREAMS.md. The rules live here rather than in the Worker so the
+ * suite can attack them without D1 or a fetch, same as every other core
+ * module.
+ *
+ * An approved application becomes a public roster card on the streams page,
+ * so the fields that surface there are held to the same content rule as clan
+ * names — the mod queue is a human gate, not a reason to skip the machine one.
+ */
+'use strict';
+
+const { blockedContent } = require('./clan.js');
+
+// Dropdowns are closed sets: an answer outside them did not come from our
+// form, so it is a bug or a forgery either way. Stored verbatim as shown.
+const VIEWER_BUCKETS = ['1–10', '10–50', '50–100', '100+'];
+const CONTACT_METHODS = ['Discord DM', 'Email', 'Twitter/X', 'Other'];
+
+const LIMITS = {
+  name: 40,
+  channelUrl: 200,
+  discord: 40,
+  blurb: 160,
+  notes: 1000,
+  contactLink: 200,
+  bestTime: 100,
+};
+
+// Invisible characters that are NOT whitespace: C0 controls except tab/LF/CR,
+// DEL, zero-width joiners and marks, the bidi overrides and isolates, and the
+// BOM. Written as escapes rather than literals so the intent survives an
+// editor that renders them as nothing.
+//
+// The bidi range (U+202A–U+202E, U+2066–U+2069) is the one that matters most
+// here. U+202E reverses everything after it, so a stored name and the name a
+// moderator reads on screen can be different strings — the trick that makes
+// "exe.txt" out of "txt.exe". These names render on a public roster card and
+// in the mod queue, and a moderator approving what they see must be approving
+// what is stored.
+//
+// Whitespace is deliberately left in for the caller to collapse. Deleting a
+// newline outright would weld two words into one ("First\nLast" -> "FirstLast");
+// collapsing it to a space keeps what the applicant meant.
+const STRIP_INVISIBLE = new RegExp(
+  '[\\u0000-\\u0008\\u000B\\u000C\\u000E-\\u001F\\u007F'
+  + '\\u200B-\\u200F\\u202A-\\u202E\\u2060-\\u2064\\u2066-\\u2069\\uFEFF]', 'g');
+
+const trim = (v) => String(v == null ? '' : v).trim();
+
+/**
+ * Collapse whitespace and strip invisible characters.
+ *
+ * Applications are typed by hand and pasted from Discord, so they arrive with
+ * newlines inside single-line fields and the occasional zero-width character
+ * carried in from a nickname. Both render as something other than what the
+ * applicant sees in the box, and one of these fields ends up on a public card.
+ */
+function clean(value, max) {
+  return trim(value)
+    .replace(STRIP_INVISIBLE, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, max);
+}
+
+/** Same as clean() but keeps paragraph breaks — the notes field is a textarea. */
+function cleanMultiline(value, max) {
+  return trim(value)
+    .replace(STRIP_INVISIBLE, '')
+    // U+2028 / U+2029 are line separators the browser renders as breaks; fold
+    // them into real newlines rather than leaving two spellings in the data.
+    .replace(/\r\n?|[\u2028\u2029]/g, '\n')
+    .replace(/[^\S\n]+/g, ' ')
+    .replace(/ *\n */g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+    .slice(0, max);
+}
+
+/**
+ * A URL we are willing to store and later render as a link.
+ *
+ * Returns the normalized href, or null. The scheme allowlist is the point:
+ * these strings become `href` on the mod page, and `javascript:` in an href
+ * is a click away from running in a moderator's session. Rejecting at the
+ * door means no downstream renderer has to remember.
+ */
+function safeUrl(raw, max) {
+  let text = clean(raw, max);
+  if (!text) return null;
+  // A bare "twitch.tv/name" is what people actually type; assume https rather
+  // than failing them for it.
+  if (!/^[a-z][a-z0-9+.-]*:/i.test(text)) text = 'https://' + text;
+  let url;
+  try { url = new URL(text); } catch { return null; }
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+  if (!url.hostname.includes('.')) return null;
+  return url.toString().slice(0, max);
+}
+
+/** Which platform a channel URL points at — a label for the mod queue. */
+function platformOf(channelUrl) {
+  let host = '';
+  try {
+    host = new URL(channelUrl).hostname.toLowerCase().replace(/^www\./, '');
+  } catch { return 'other'; }
+  if (host === 'twitch.tv' || host.endsWith('.twitch.tv')) return 'twitch';
+  if (host === 'youtube.com' || host.endsWith('.youtube.com') || host === 'youtu.be') return 'youtube';
+  if (host === 'kick.com' || host.endsWith('.kick.com')) return 'kick';
+  return 'other';
+}
+
+/**
+ * The Twitch login inside a channel URL, or null.
+ *
+ * Only Twitch gets a login because only Twitch is embeddable on the streams
+ * page — a YouTube or Kick application is still valid, it just cannot become
+ * a player card. Deliberately the same rules as normalizeLogin() in
+ * site/streams.js: 3–25 chars of [a-z0-9_], nothing salvaged.
+ */
+function twitchLogin(channelUrl) {
+  if (platformOf(channelUrl) !== 'twitch') return null;
+  let path = '';
+  try { path = new URL(channelUrl).pathname; } catch { return null; }
+  const first = path.split('/').filter(Boolean)[0];
+  if (!first) return null;
+  const lower = first.toLowerCase();
+  return /^[a-z0-9_]{3,25}$/.test(lower) ? lower : null;
+}
+
+/**
+ * Why this application cannot be accepted, or null when it can.
+ *
+ * Reason codes, not sentences: the page owns the wording, and the tests
+ * assert on something that does not move when the copy is edited.
+ */
+function applyProblem(fields) {
+  const f = fields || {};
+  const name = clean(f.name, LIMITS.name);
+  if (name.length < 2) return 'name-required';
+  // The creator name is what a public roster card is titled with.
+  if (blockedContent(name)) return 'name-blocked';
+
+  if (!safeUrl(f.channelUrl, LIMITS.channelUrl)) return 'channel-url-invalid';
+
+  const discord = clean(f.discord, LIMITS.discord);
+  if (discord.length < 2) return 'discord-required';
+
+  if (!VIEWER_BUCKETS.includes(trim(f.viewers))) return 'viewers-invalid';
+
+  // Optional from here down: absent is fine, present-and-wrong is not.
+
+  // The blurb is the other field that becomes a public roster card, so it
+  // faces the same content rule as the name. `notes` deliberately does not:
+  // it is a private message to the mod queue and is never published.
+  if (blockedContent(clean(f.blurb, LIMITS.blurb))) return 'blurb-blocked';
+
+  const method = trim(f.contactMethod);
+  if (method && !CONTACT_METHODS.includes(method)) return 'contact-method-invalid';
+
+  if (trim(f.contactLink) && !safeUrl(f.contactLink, LIMITS.contactLink)) {
+    return 'contact-link-invalid';
+  }
+  return null;
+}
+
+/**
+ * The row to store. Call only after applyProblem() returns null — it assumes
+ * the shape is already legal and does not re-check.
+ */
+function normalizeApplication(fields) {
+  const f = fields || {};
+  const channelUrl = safeUrl(f.channelUrl, LIMITS.channelUrl);
+  return {
+    name: clean(f.name, LIMITS.name),
+    channelUrl,
+    platform: platformOf(channelUrl),
+    twitchLogin: twitchLogin(channelUrl),
+    discord: clean(f.discord, LIMITS.discord),
+    viewers: trim(f.viewers),
+    // blurb is published on approval; notes is mod-queue-only. Two fields,
+    // because one field cannot be both consented-to-publish and confidential.
+    blurb: clean(f.blurb, LIMITS.blurb),
+    notes: cleanMultiline(f.notes, LIMITS.notes),
+    contactMethod: trim(f.contactMethod) || null,
+    contactLink: trim(f.contactLink) ? safeUrl(f.contactLink, LIMITS.contactLink) : null,
+    bestTime: clean(f.bestTime, LIMITS.bestTime),
+  };
+}
+
+const STATUSES = ['pending', 'approved', 'rejected'];
+const isStatus = (s) => STATUSES.includes(trim(s));
+
+/**
+ * Is this X user id a moderator?
+ *
+ * Matched on x_id, never on handle: schema.sql calls x_id "immutable X user
+ * id; handles can change", and a handle that changes is a handle someone else
+ * can register. Allowlisting @somemod would hand the mod queue to whoever
+ * claims that name after they drop it.
+ */
+function isAdmin(xId, allowlist) {
+  const id = trim(xId);
+  if (!id) return false;
+  return String(allowlist || '')
+    .split(/[\s,]+/)
+    .filter(Boolean)
+    .includes(id);
+}
+
+module.exports = {
+  VIEWER_BUCKETS,
+  CONTACT_METHODS,
+  LIMITS,
+  STATUSES,
+  clean,
+  cleanMultiline,
+  safeUrl,
+  platformOf,
+  twitchLogin,
+  applyProblem,
+  normalizeApplication,
+  isStatus,
+  isAdmin,
+};

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -208,3 +208,43 @@ CREATE TABLE IF NOT EXISTS x_feed_cache (
   fetched_at INTEGER NOT NULL,
   posts_json TEXT NOT NULL
 );
+
+-- Streamer applications (site/streamer-signup.html), replacing the Google
+-- Form + published-sheet pipeline. Rows land as 'pending'; a moderator moves
+-- them to 'approved' or 'rejected' from site/admin.html.
+--
+-- This is the one table in the schema holding contact details for people who
+-- are not users — a Discord handle, maybe an email in contact_link, and when
+-- they are reachable. Nothing here is served by a public route: the roster
+-- endpoint selects only name/twitch_login/notes from approved rows, and
+-- everything else leaves D1 solely through the moderator-gated read.
+CREATE TABLE IF NOT EXISTS streamer_applications (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,               -- creator / channel name, public once approved
+  channel_url TEXT NOT NULL,        -- normalized https URL
+  platform TEXT NOT NULL,           -- twitch | youtube | kick | other
+  twitch_login TEXT,                -- embeddable login, Twitch URLs only
+  discord TEXT NOT NULL,
+  viewers TEXT NOT NULL,            -- one of the form's buckets, verbatim
+  blurb TEXT,                       -- one-liner the applicant agreed to publish
+  notes TEXT,                       -- private message to the mod queue; NEVER served publicly
+  contact_method TEXT,
+  contact_link TEXT,
+  best_time TEXT,
+  status TEXT NOT NULL DEFAULT 'pending',
+  reviewed_by INTEGER,              -- users.id of the moderator who decided
+  reviewed_at INTEGER,
+  created_at INTEGER NOT NULL,
+  ip_hash TEXT                      -- salted hash, for abuse triage only
+);
+
+-- The roster read is "approved rows, newest first"; the mod queue is the same
+-- shape per status. One index serves both.
+CREATE INDEX IF NOT EXISTS idx_streamer_applications_status
+  ON streamer_applications(status, created_at DESC);
+
+-- A channel may only sit in the queue once. Partial index so a rejected
+-- applicant can reapply later, but nobody can flood the queue with one URL.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_streamer_applications_open_channel
+  ON streamer_applications(channel_url)
+  WHERE status IN ('pending', 'approved');

--- a/server/test/streamer.test.js
+++ b/server/test/streamer.test.js
@@ -1,0 +1,262 @@
+/* Streamer applications are the first thing in this product that takes
+ * personal contact details from people who are not users, and the first form
+ * whose output a moderator reads in a browser. So every test here is an attack
+ * on one of those two seams: get a script into the mod page, forge an answer
+ * the form could not have produced, publish something the applicant wrote in
+ * private, or reach the queue without being a moderator.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const S = require('../core/streamer.js');
+const { HATE_CODE } = require('../core/clan.js');
+
+/** A minimal application that passes, so each test changes exactly one thing. */
+const VALID = Object.freeze({
+  name: 'ProfitableDegen',
+  channelUrl: 'https://twitch.tv/ProfitableDegen',
+  discord: 'degen',
+  viewers: S.VIEWER_BUCKETS[1],
+});
+const withField = (patch) => Object.assign({}, VALID, patch);
+
+test('the baseline application is accepted — otherwise every test below is vacuous', () => {
+  assert.equal(S.applyProblem(VALID), null);
+});
+
+/* ---------------------------------------------------------------- the href */
+
+test('a channel URL cannot carry a scheme that executes when a moderator clicks it', () => {
+  // These strings become href on the mod page. The rejection has to happen
+  // here, at the door, so no downstream renderer has to remember.
+  for (const hostile of [
+    'javascript:alert(1)',
+    'JavaScript:alert(1)',
+    '  javascript:alert(1)  ',
+    'data:text/html,<script>alert(1)</script>',
+    'vbscript:msgbox(1)',
+    'file:///etc/passwd',
+  ]) {
+    assert.equal(
+      S.applyProblem(withField({ channelUrl: hostile })), 'channel-url-invalid',
+      `${hostile} must not survive validation`);
+    assert.equal(S.safeUrl(hostile, 200), null);
+  }
+});
+
+test('the same scheme check guards the optional contact link', () => {
+  // A second URL field is a second door; it was not obvious it had a lock.
+  assert.equal(
+    S.applyProblem(withField({ contactLink: 'javascript:alert(1)' })),
+    'contact-link-invalid');
+  // ...but leaving it blank is still fine, because it is optional.
+  assert.equal(S.applyProblem(withField({ contactLink: '' })), null);
+});
+
+test('a bare host is assumed https rather than failed, and comes back normalized', () => {
+  const url = S.safeUrl('twitch.tv/SomeName', 200);
+  assert.equal(new URL(url).protocol, 'https:');
+  assert.equal(new URL(url).hostname, 'twitch.tv');
+});
+
+test('a string with no dot in the host is not a channel', () => {
+  assert.equal(S.safeUrl('notaurl', 200), null);
+  assert.equal(S.safeUrl('https://localhost/x', 200), null);
+});
+
+/* ------------------------------------------------------------ closed sets */
+
+test('viewer counts outside the form’s own dropdown are refused', () => {
+  // Every accepted value is one the form can actually emit...
+  for (const bucket of S.VIEWER_BUCKETS) {
+    assert.equal(S.applyProblem(withField({ viewers: bucket })), null);
+  }
+  // ...and anything else did not come from our form.
+  for (const forged of ['1000000', '', 'lots', '1-10', null]) {
+    assert.equal(S.applyProblem(withField({ viewers: forged })), 'viewers-invalid');
+  }
+});
+
+test('contact method is optional, but a present one must be from the dropdown', () => {
+  for (const method of S.CONTACT_METHODS) {
+    assert.equal(S.applyProblem(withField({ contactMethod: method })), null);
+  }
+  assert.equal(S.applyProblem(withField({ contactMethod: '' })), null);
+  assert.equal(
+    S.applyProblem(withField({ contactMethod: 'Carrier pigeon' })),
+    'contact-method-invalid');
+});
+
+/* ------------------------------------------------------- invisible input */
+
+test('invisible characters cannot make two names look identical', () => {
+  // A zero-width space between letters renders as nothing, so "Deg<ZWSP>en"
+  // and "Degen" are one name to a reader and two rows to a database.
+  assert.equal(S.clean('Deg​en', 40), 'Degen');
+  assert.equal(S.clean('﻿Degen', 40), 'Degen');
+  assert.equal(S.clean('Deg‮en', 40), 'Degen');
+});
+
+test('a newline inside a single-line field becomes a space, not nothing', () => {
+  // Deleting it outright welds two words together and silently changes the
+  // name the applicant typed.
+  assert.equal(S.clean('First\nLast', 40), 'First Last');
+  assert.equal(S.clean('First\tLast', 40), 'First Last');
+});
+
+test('the notes field keeps its paragraphs but not a runaway of them', () => {
+  assert.equal(S.cleanMultiline('a\n\n\n\n\nb', 100), 'a\n\nb');
+  assert.equal(S.cleanMultiline('a b', 100), 'a\nb');
+  assert.equal(S.cleanMultiline('  padded  ', 100), 'padded');
+});
+
+test('every field is capped at its declared limit', () => {
+  const long = 'x'.repeat(5000);
+  const app = S.normalizeApplication(withField({
+    name: long, discord: long, blurb: long, notes: long, bestTime: long,
+  }));
+  assert.equal(app.name.length, S.LIMITS.name);
+  assert.equal(app.discord.length, S.LIMITS.discord);
+  assert.equal(app.blurb.length, S.LIMITS.blurb);
+  assert.equal(app.notes.length, S.LIMITS.notes);
+  assert.equal(app.bestTime.length, S.LIMITS.bestTime);
+});
+
+test('a name that is only whitespace is not a name', () => {
+  for (const empty of ['', '   ', '\n\n', '​​', null, undefined]) {
+    assert.equal(S.applyProblem(withField({ name: empty })), 'name-required');
+  }
+});
+
+/* ------------------------------------------- what is public vs. what is not */
+
+test('the two fields that get published face the content rule; the private one does not', () => {
+  // name and blurb become a roster card on papertrench.com...
+  assert.equal(S.applyProblem(withField({ name: `Stream ${HATE_CODE}` })), 'name-blocked');
+  assert.equal(S.applyProblem(withField({ blurb: `gm ${HATE_CODE}` })), 'blurb-blocked');
+
+  // ...notes is a message to the moderators, who are the ones deciding. It is
+  // never published, so it is not filtered — if that ever stops being true,
+  // this assertion is the thing that should fail first.
+  assert.equal(S.applyProblem(withField({ notes: `gm ${HATE_CODE}` })), null);
+});
+
+test('notes and blurb are separate fields, so one cannot leak as the other', () => {
+  // The roster serves `blurb`; the mod queue serves both. If normalization
+  // ever folded notes into blurb, an applicant's private message would ship
+  // to the public page the moment a moderator approved them.
+  const app = S.normalizeApplication(withField({
+    blurb: 'Daily challenge runs',
+    notes: 'Please do not publish: my real name is redacted and I am 15.',
+  }));
+  assert.equal(app.blurb, 'Daily challenge runs');
+  assert.notEqual(app.blurb, app.notes);
+  assert.ok(!app.blurb.includes('redacted'));
+});
+
+/* ------------------------------------------------------------ twitch logins */
+
+test('only Twitch URLs yield an embeddable login', () => {
+  assert.equal(S.twitchLogin('https://twitch.tv/SomeName'), 'somename');
+  assert.equal(S.twitchLogin('https://www.twitch.tv/SomeName?x=1'), 'somename');
+  // Valid applications, but nothing the page can put in a Twitch player.
+  assert.equal(S.twitchLogin('https://youtube.com/@someone'), null);
+  assert.equal(S.twitchLogin('https://kick.com/someone'), null);
+});
+
+test('a login that is not a login is dropped, never salvaged', () => {
+  // Same rule as normalizeLogin() in site/streams.js: if the two disagree,
+  // the roster and the player disagree about who a card points at.
+  assert.equal(S.twitchLogin('https://twitch.tv/ab'), null);        // too short
+  assert.equal(S.twitchLogin('https://twitch.tv/' + 'a'.repeat(26)), null);
+  assert.equal(S.twitchLogin('https://twitch.tv/has spaces'), null);
+  assert.equal(S.twitchLogin('https://twitch.tv/'), null);
+});
+
+test('platform labels follow the host, not the text of the URL', () => {
+  assert.equal(S.platformOf('https://twitch.tv/x'), 'twitch');
+  assert.equal(S.platformOf('https://m.twitch.tv/x'), 'twitch');
+  assert.equal(S.platformOf('https://youtu.be/x'), 'youtube');
+  assert.equal(S.platformOf('https://kick.com/x'), 'kick');
+  assert.equal(S.platformOf('https://example.com/twitch.tv'), 'other');
+  assert.equal(S.platformOf('not a url'), 'other');
+});
+
+/* ------------------------------------------------------------- the mod gate */
+
+test('an empty or missing allowlist authorises nobody', () => {
+  // A deploy that forgets ADMIN_X_IDS must close the queue, not open it to
+  // every signed-in visitor.
+  for (const list of ['', '   ', null, undefined]) {
+    assert.equal(S.isAdmin('123', list), false);
+  }
+});
+
+test('moderator identity is matched whole, never as a prefix', () => {
+  assert.equal(S.isAdmin('123', '123'), true);
+  assert.equal(S.isAdmin('123', '123,456'), true);
+  assert.equal(S.isAdmin('456', '123, 456'), true);
+  assert.equal(S.isAdmin('123', '123456'), false);   // not a prefix
+  assert.equal(S.isAdmin('12', '123'), false);       // not a substring
+  assert.equal(S.isAdmin('', '123'), false);         // absent id is not a match
+  assert.equal(S.isAdmin(null, '123'), false);
+});
+
+test('the allowlist tolerates the spellings a human will actually write', () => {
+  const list = ' 111 , 222,333\n444 ';
+  for (const id of ['111', '222', '333', '444']) assert.equal(S.isAdmin(id, list), true);
+  assert.equal(S.isAdmin('555', list), false);
+});
+
+/* ------------------------------------------------- the page/server contract */
+
+/* The form's dropdowns and this module's closed sets are the same list written
+ * twice, in two files, in two languages. Nothing but this test connects them.
+ *
+ * The failure it exists for is silent and total: the buckets are spelled with
+ * an EN DASH (U+2013), and a hyphen typed into the HTML looks identical in an
+ * editor, in a diff, and in a browser. Every application would then fail
+ * `viewers-invalid` on a value the applicant picked from our own menu, and the
+ * form would reject everyone with a message about a field they cannot fix.
+ */
+const FORM_HTML = fs.readFileSync(
+  path.join(__dirname, '..', '..', 'site', 'streamer-signup.html'), 'utf8');
+
+/** The <option> texts of one named <select> in the signup form. */
+function optionsOf(selectName) {
+  const select = new RegExp(
+    `<select[^>]*name="${selectName}"[^>]*>([\\s\\S]*?)</select>`).exec(FORM_HTML);
+  assert.ok(select, `the form has no <select name="${selectName}">`);
+  return [...select[1].matchAll(/<option(?![^>]*\b(?:disabled|value=""))[^>]*>([^<]*)<\/option>/g)]
+    .map((m) => m[1].trim());
+}
+
+test('the viewer dropdown offers exactly the buckets the server accepts', () => {
+  assert.deepEqual(optionsOf('viewers'), S.VIEWER_BUCKETS);
+});
+
+test('the contact-method dropdown offers exactly the methods the server accepts', () => {
+  assert.deepEqual(optionsOf('contactMethod'), S.CONTACT_METHODS);
+});
+
+test('every form field stops at the length the server would truncate it to', () => {
+  // A maxlength longer than the server's cap silently eats the tail of what
+  // someone typed; shorter, and the form refuses input the server would take.
+  const attrs = Object.fromEntries(
+    [...FORM_HTML.matchAll(/name="(\w+)"[^>]*maxlength="(\d+)"/g)].map((m) => [m[1], Number(m[2])]));
+  for (const [field, cap] of Object.entries(S.LIMITS)) {
+    assert.equal(attrs[field], cap, `maxlength for ${field} must match LIMITS.${field}`);
+  }
+});
+
+test('review statuses are a closed set, and pending is one of them', () => {
+  // 'pending' has to be assignable: it is how a moderator undoes a decision.
+  for (const status of ['pending', 'approved', 'rejected']) {
+    assert.equal(S.isStatus(status), true);
+  }
+  for (const bogus of ['deleted', 'APPROVED', '', null, 'approved; DROP TABLE']) {
+    assert.equal(S.isStatus(bogus), false);
+  }
+});

--- a/server/worker/auth.js
+++ b/server/worker/auth.js
@@ -231,7 +231,7 @@ async function finishLogin(request, env, ctx) {
   // verbatim. The bare '#authed' marker semantics remain for pages served
   // before this change: token or not, the fragment still means "a sign-in
   // just completed".
-  const headers = new Headers({ Location: env.SITE_ORIGIN + '/leaderboard.html#authed=' + session });
+  const headers = new Headers({ Location: env.SITE_ORIGIN + '/leaderboard#authed=' + session });
   headers.append('Set-Cookie', cookieHeader(SESSION_COOKIE, session, SESSION_TTL_MS / 1000, env));
   headers.append('Set-Cookie', cookieHeader(OAUTH_COOKIE, '', 0, env));
   return new Response(null, { status: 302, headers });

--- a/server/worker/index.js
+++ b/server/worker/index.js
@@ -17,6 +17,7 @@ import { windowEntry } from '../core/window.js';
 import { awarded } from '../core/achievements.js';
 import * as duel from '../core/duel.js';
 import * as clan from '../core/clan.js';
+import * as streamer from '../core/streamer.js';
 // Default-imported, not named: core/chain.js re-exports attest.js by property
 // assignment (`GENESIS: AT.GENESIS`), which Node's CJS named-export lexer
 // cannot see through — unlike the other cores, whose exports are literals.
@@ -30,6 +31,9 @@ const SEG_SIZE = 500;
 const SUBMITS_PER_HOUR = 6;
 const DUELS_PER_HOUR = 10;
 const CLAN_ACTIONS_PER_HOUR = 12;
+// Streamer signups need no account, so the leash is per-IP and deliberately
+// low: a person applies once, and the only reason to send six is abuse.
+const STREAMER_APPLIES_PER_HOUR = 5;
 // The X feed endpoint: only cache MISSES cost an upstream fetch, so the
 // per-IP leash sits on those, not on reads a cache can answer.
 const XFEED_PER_HOUR = 120;
@@ -1403,6 +1407,178 @@ async function drainPricing(env) {
     .run();
 }
 
+/* ---------------- streamer applications ---------------- */
+
+/**
+ * The moderator behind a request, or null.
+ *
+ * Two gates, both required: a valid session, and an x_id on the ADMIN_X_IDS
+ * allowlist. An unset or empty allowlist authorises nobody — a deploy that
+ * forgets the var must close the mod queue, not open it to every signed-in
+ * visitor, and "no admins configured" is the safe reading of an absent list.
+ */
+async function moderator(request, env) {
+  const user = await sessionUser(request, env);
+  if (!user) return null;
+  return streamer.isAdmin(user.x_id, env.ADMIN_X_IDS) ? user : null;
+}
+
+/**
+ * A salted, one-way trace of the applicant's IP.
+ *
+ * The raw address is never stored: applications come from members of the
+ * public, and an IP column would be a standing log of where they live for a
+ * feature whose actual need is only "did these six submissions come from one
+ * person". A SESSION_SECRET-salted digest answers that and nothing else, and
+ * it cannot be reversed or joined against anything outside this table.
+ */
+async function ipTrace(request, env) {
+  const ip = request.headers.get('CF-Connecting-IP');
+  if (!ip || !env.SESSION_SECRET) return null;
+  const bytes = new TextEncoder().encode(env.SESSION_SECRET + ':' + ip);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  return [...new Uint8Array(digest)].slice(0, 8)
+    .map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+async function handleStreamerApply(request, env) {
+  const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
+  if (!(await allowRate(env, 'streamerapply:' + ip, STREAMER_APPLIES_PER_HOUR))) {
+    return json({ ok: false, reason: 'rate-limited' }, 429);
+  }
+  let body = {};
+  try { body = await request.json(); } catch {}
+
+  const problem = streamer.applyProblem(body);
+  if (problem) return json({ ok: false, reason: problem }, 422);
+
+  const app = streamer.normalizeApplication(body);
+  try {
+    await env.DB.prepare(`
+      INSERT INTO streamer_applications
+        (name, channel_url, platform, twitch_login, discord, viewers, blurb,
+         notes, contact_method, contact_link, best_time, status, created_at, ip_hash)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)`)
+      .bind(app.name, app.channelUrl, app.platform, app.twitchLogin, app.discord,
+        app.viewers, app.blurb || null, app.notes || null, app.contactMethod,
+        app.contactLink, app.bestTime || null, Date.now(), await ipTrace(request, env))
+      .run();
+  } catch {
+    // The partial unique index on channel_url is what decides, not a prior
+    // SELECT: two tabs submitted together would both pass a check-then-act.
+    return json({ ok: false, reason: 'already-applied' }, 409);
+  }
+  return json({ ok: true });
+}
+
+/**
+ * The mod queue. Every column, including contact details — which is exactly
+ * why it is behind moderator() and why nothing else selects from this table.
+ */
+async function handleStreamerApplications(request, env) {
+  const mod = await moderator(request, env);
+  if (!mod) return json({ ok: false, reason: 'not-a-moderator' }, 403);
+
+  const url = new URL(request.url);
+  const status = url.searchParams.get('status') || 'pending';
+  if (!streamer.isStatus(status)) return json({ ok: false, reason: 'bad-status' }, 422);
+
+  const { results } = await env.DB.prepare(`
+    SELECT a.id, a.name, a.channel_url, a.platform, a.twitch_login, a.discord,
+           a.viewers, a.blurb, a.notes, a.contact_method, a.contact_link,
+           a.best_time, a.status, a.created_at, a.reviewed_at, u.handle AS reviewed_by
+      FROM streamer_applications a
+      LEFT JOIN users u ON u.id = a.reviewed_by
+     WHERE a.status = ?
+     ORDER BY a.created_at DESC
+     LIMIT 200`)
+    .bind(status).all();
+
+  const counts = await env.DB.prepare(
+    'SELECT status, COUNT(*) AS n FROM streamer_applications GROUP BY status').all();
+
+  return json({
+    ok: true,
+    applications: (results || []).map((r) => ({
+      id: r.id,
+      name: r.name,
+      channelUrl: r.channel_url,
+      platform: r.platform,
+      twitchLogin: r.twitch_login,
+      discord: r.discord,
+      viewers: r.viewers,
+      blurb: r.blurb || '',
+      notes: r.notes || '',
+      contactMethod: r.contact_method || '',
+      contactLink: r.contact_link || '',
+      bestTime: r.best_time || '',
+      status: r.status,
+      createdAt: r.created_at,
+      reviewedAt: r.reviewed_at,
+      reviewedBy: r.reviewed_by || null,
+    })),
+    counts: Object.fromEntries((counts.results || []).map((r) => [r.status, Number(r.n)])),
+  });
+}
+
+async function handleStreamerReview(request, env) {
+  const mod = await moderator(request, env);
+  if (!mod) return json({ ok: false, reason: 'not-a-moderator' }, 403);
+
+  let body = {};
+  try { body = await request.json(); } catch {}
+  const id = Number(body.id);
+  if (!Number.isInteger(id) || id <= 0) return json({ ok: false, reason: 'bad-id' }, 422);
+  // 'pending' is a legal target: it is how a decision gets undone.
+  if (!streamer.isStatus(body.status)) return json({ ok: false, reason: 'bad-status' }, 422);
+
+  try {
+    const result = await env.DB.prepare(`
+      UPDATE streamer_applications SET status = ?, reviewed_by = ?, reviewed_at = ?
+       WHERE id = ?`)
+      .bind(body.status, mod.id, Date.now(), id)
+      .run();
+    if (!result.meta || result.meta.changes === 0) {
+      return json({ ok: false, reason: 'not-found' }, 404);
+    }
+  } catch {
+    // Approving a channel that already holds the approved/pending slot trips
+    // the partial unique index — a duplicate application, not a server fault.
+    return json({ ok: false, reason: 'already-listed' }, 409);
+  }
+  return json({ ok: true });
+}
+
+/**
+ * The public roster: approved applications, as streams.js consumes them.
+ *
+ * Deliberately a different column list from the mod queue above. An approved
+ * applicant agreed to appear on the streams page — they did not agree to
+ * publish the Discord handle and availability they gave us to be contacted
+ * with, so those columns are simply not in this SELECT.
+ *
+ * `blurb` is here and `notes` is not, and that is the whole distinction: the
+ * blurb is the field whose label promises it will be shown publicly, while
+ * notes answers "anything else you'd like us to know?" — a message to the
+ * moderators. Serving notes here would publish something written in private.
+ */
+async function handleStreamerRoster(env) {
+  const { results } = await env.DB.prepare(`
+    SELECT name, twitch_login, blurb
+      FROM streamer_applications
+     WHERE status = 'approved' AND twitch_login IS NOT NULL
+     ORDER BY created_at DESC
+     LIMIT 60`).all();
+  return json({
+    ok: true,
+    streamers: (results || []).map((r) => ({
+      login: r.twitch_login,
+      name: r.name,
+      blurb: r.blurb || '',
+    })),
+  });
+}
+
 /* ---------------- entry ---------------- */
 
 export default {
@@ -1430,8 +1606,18 @@ export default {
       else if (path === '/api/auth/logout' && request.method === 'POST') response = logout(request, env);
       else if (path === '/api/me') {
         const user = await sessionUser(request, env);
+        // xId is the caller's OWN X id — public on X, and the value an owner
+        // needs to put in ADMIN_X_IDS. Without it, standing up the first
+        // moderator means digging a numeric id out of a third-party lookup.
         response = user
-          ? json({ signedIn: true, handle: user.handle, displayName: user.display_name, avatarUrl: user.avatar_url })
+          ? json({
+            signedIn: true,
+            handle: user.handle,
+            displayName: user.display_name,
+            avatarUrl: user.avatar_url,
+            xId: user.x_id,
+            isMod: streamer.isAdmin(user.x_id, env.ADMIN_X_IDS),
+          })
           : json({ signedIn: false });
       }
       else if (path === '/api/me/delete' && request.method === 'POST') {
@@ -1501,6 +1687,21 @@ export default {
         const tag = clan.normalizeTag(url.searchParams.get('tag') || '');
         response = await edgeCached(cacheKey(url, { tag }), ctx, BOARD_CACHE_SEC,
           () => handleClanGet(env, tag));
+      }
+      else if (path === '/api/streamer/apply' && request.method === 'POST') {
+        response = await handleStreamerApply(request, env);
+      }
+      // Never edge-cached, unlike the boards: the response is scoped to a
+      // moderator session, and a shared cache would serve the queue to the
+      // next visitor who asked for the same URL.
+      else if (path === '/api/streamer/applications') {
+        response = await handleStreamerApplications(request, env);
+      }
+      else if (path === '/api/streamer/review' && request.method === 'POST') {
+        response = await handleStreamerReview(request, env);
+      }
+      else if (path === '/api/streamer/roster') {
+        response = await edgeCached(request, ctx, BOARD_CACHE_SEC, () => handleStreamerRoster(env));
       }
       else response = json({ ok: false, reason: 'not-found' }, 404);
     } catch (err) {

--- a/server/wrangler.toml
+++ b/server/wrangler.toml
@@ -57,5 +57,20 @@ SITE_ORIGIN_ALT = "https://www.papertrench.com"
 X_CLIENT_ID = "N1BucEctX2dwVkNhSVRXSGRnWks6MTpjaQ"
 X_REDIRECT_URI = "https://papertrench-api.onerobby.workers.dev/api/auth/x/callback"
 
+# Who can read and decide streamer applications (site/admin.html). A
+# comma-separated list of X USER IDS — not handles: schema.sql calls x_id
+# "immutable X user id; handles can change", and a handle that changes is a
+# handle somebody else can register. Allowlisting @somemod would hand the mod
+# queue to whoever claims that name next.
+#
+# Left EMPTY on purpose. An empty or unset list authorises nobody, which is the
+# safe reading of "no admins configured" — the queue holds applicants' Discord
+# handles and contact details, so a deploy that forgets this var must close it,
+# not open it to every signed-in visitor.
+#
+# To add the first moderator: sign in on the site, open /admin, and the page
+# prints your own X user id for exactly this purpose. Paste it here, redeploy.
+ADMIN_X_IDS = ""
+
 # Secrets (never in this file):
 #   wrangler secret put SESSION_SECRET     # 32+ random bytes

--- a/site/admin.html
+++ b/site/admin.html
@@ -94,14 +94,14 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="streamer-signup.html">Streamer signup</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/streamer-signup">Streamer signup</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -110,7 +110,7 @@
 <header class="admin-head">
   <div class="wrap">
     <h1>Moderator queue</h1>
-    <p>Streamer applications from <a href="streamer-signup.html" style="color:var(--orange2)">the signup form</a>. Approving a Twitch application puts a card on the streams page within a minute; everything on this page is visible to moderators only.</p>
+    <p>Streamer applications from <a href="/streamer-signup" style="color:var(--orange2)">the signup form</a>. Approving a Twitch application puts a card on the streams page within a minute; everything on this page is visible to moderators only.</p>
   </div>
 </header>
 
@@ -133,7 +133,7 @@
       <p>You're signed in as <b id="notModHandle"></b>, but that account isn't a PaperTrench moderator.</p>
       <p>To be added, send an owner your X user id:<br><code id="notModId"></code><br>
          they add it to <code>ADMIN_X_IDS</code> and redeploy the Worker.</p>
-      <a class="btn btn-ghost" href="index.html">Back to the site</a>
+      <a class="btn btn-ghost" href="/">Back to the site</a>
     </div>
 
     <div id="queue" hidden>
@@ -157,12 +157,12 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="index.html">Home</a>
-        <a href="streams.html">Watch Live</a>
-        <a href="streamer-signup.html">Streamer signup</a>
-        <a href="privacy.html">Privacy</a>
+        <a href="/">Home</a>
+        <a href="/streams">Watch Live</a>
+        <a href="/streamer-signup">Streamer signup</a>
+        <a href="/privacy">Privacy</a>
       </div>
     </div>
     <div class="foot-note">Applicant contact details on this page are private — handle them like the personal data they are.</div>

--- a/site/admin.html
+++ b/site/admin.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PaperTrench — Moderator queue</title>
+<!-- Not a public page: keep it out of search results and out of previews.
+     This is presentation only — the queue itself is gated server-side. -->
+<meta name="robots" content="noindex, nofollow">
+<meta name="referrer" content="no-referrer">
+<link rel="icon" type="image/png" href="assets/icon128.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;700;800&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+<link rel="stylesheet" href="arena.css">
+<style>
+  .admin-head { padding: 130px 0 22px; }
+  .admin-head h1 { font-size: clamp(30px, 4vw, 44px); font-weight: 900; letter-spacing: -0.5px; }
+  .admin-head p { font-size: 14px; color: var(--muted); margin-top: 10px; max-width: 640px; line-height: 1.6; }
+
+  .gate { max-width: 560px; margin: 0 auto 90px; text-align: center;
+    background: var(--panel); border: 1px solid var(--line2); border-radius: var(--radius); padding: 40px 32px; }
+  .gate .big { font-size: 42px; margin-bottom: 14px; }
+  .gate h2 { font-size: 20px; font-weight: 800; margin-bottom: 10px; }
+  .gate p { font-size: 13.5px; color: var(--muted); line-height: 1.65; margin-bottom: 18px; }
+  .gate code { font-family: var(--mono); font-size: 12.5px; color: var(--orange2);
+    background: rgba(0,0,0,0.3); border: 1px solid var(--line); border-radius: 6px; padding: 3px 7px; }
+
+  .tabs { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 22px; }
+  .tab {
+    font: inherit; font-size: 13px; font-weight: 750; cursor: pointer;
+    color: var(--muted); background: rgba(255,255,255,0.04);
+    border: 1px solid var(--line2); border-radius: 999px; padding: 8px 16px;
+    transition: color .15s, background .15s, border-color .15s;
+  }
+  .tab:hover { color: var(--text); background: rgba(255,255,255,0.08); }
+  .tab.on { color: #2a1a05; background: var(--grad-heat); border-color: transparent; font-weight: 800; }
+  .tab .n { opacity: 0.7; margin-left: 5px; font-variant-numeric: tabular-nums; }
+
+  .apps { display: grid; gap: 14px; padding-bottom: 90px; }
+  .app {
+    background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 20px 22px;
+  }
+  .app-top { display: flex; align-items: flex-start; gap: 12px; flex-wrap: wrap; margin-bottom: 14px; }
+  .app-name { font-size: 16.5px; font-weight: 800; }
+  .app-chan { font-size: 12.5px; margin-top: 2px; }
+  .app-chan a { color: var(--orange2); word-break: break-all; }
+  .app-when { margin-left: auto; font-size: 11.5px; color: var(--dim); white-space: nowrap; }
+
+  .plat {
+    display: inline-block; font-size: 9.5px; font-weight: 800; letter-spacing: 0.9px;
+    text-transform: uppercase; padding: 3px 8px; border-radius: 999px; vertical-align: middle;
+  }
+  .plat.twitch { color: #bf94ff; background: rgba(145,70,255,0.13); border: 1px solid rgba(145,70,255,0.32); }
+  .plat.youtube { color: #ff8a80; background: rgba(224,67,58,0.11); border: 1px solid rgba(224,67,58,0.3); }
+  .plat.kick { color: var(--green2); background: rgba(52,211,153,0.10); border: 1px solid rgba(52,211,153,0.28); }
+  .plat.other { color: var(--muted); background: rgba(255,255,255,0.05); border: 1px solid var(--line2); }
+
+  .rows { display: grid; grid-template-columns: 132px minmax(0,1fr); gap: 7px 16px; font-size: 13.5px; }
+  @media (max-width: 620px) { .rows { grid-template-columns: 1fr; gap: 2px; } .rows dt { margin-top: 9px; } }
+  .rows dt { color: var(--dim); font-size: 11.5px; font-weight: 750; letter-spacing: 0.5px; text-transform: uppercase; padding-top: 2px; }
+  .rows dd { color: var(--text); word-break: break-word; white-space: pre-wrap; }
+  .rows dd a { color: var(--orange2); word-break: break-all; }
+  .rows dd.empty { color: var(--dim); font-style: italic; }
+
+  /* Private answers are visually separated from the ones the applicant knows
+     will be published, so a moderator never pastes the wrong one somewhere. */
+  .private-note { margin-top: 14px; padding: 13px 15px; border-radius: 12px;
+    background: rgba(0,0,0,0.24); border: 1px solid var(--line); }
+  .private-note .cap { font-size: 10px; font-weight: 800; letter-spacing: 1.1px;
+    text-transform: uppercase; color: var(--green2); margin-bottom: 7px; }
+
+  .app-acts { display: flex; gap: 9px; flex-wrap: wrap; align-items: center; margin-top: 17px;
+    padding-top: 15px; border-top: 1px solid var(--line); }
+  .ar-btn.good { background: rgba(52,211,153,0.13); border-color: rgba(52,211,153,0.35); color: var(--green2); }
+  .ar-btn.bad { background: rgba(224,67,58,0.11); border-color: rgba(224,67,58,0.32); color: #ff8a80; }
+  .act-msg { font-size: 12.5px; font-weight: 650; color: var(--muted); }
+  .act-msg.err { color: #ff8a80; }
+
+  .state { text-align: center; padding: 60px 20px; color: var(--muted); font-size: 14px; }
+  .state .big { font-size: 38px; margin-bottom: 12px; opacity: 0.8; }
+
+  .who { display: flex; align-items: center; gap: 10px; font-size: 13px; color: var(--muted); margin-bottom: 20px; }
+  .who img { width: 26px; height: 26px; border-radius: 50%; }
+  .who b { color: var(--text); font-weight: 750; }
+  .who button { margin-left: auto; }
+</style>
+</head>
+<body>
+<div class="bg-glow"></div>
+<div class="bg-grid"></div>
+
+<nav>
+  <div class="nav-inner">
+    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <div class="nav-links">
+      <a href="leaderboard.html">Leaderboard</a>
+      <a href="sprint.html">Sprint</a>
+      <a href="duels.html">Duels</a>
+      <a href="clans.html">Clans</a>
+      <a href="streamer-signup.html">Streamer signup</a>
+      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
+    </div>
+  </div>
+</nav>
+
+<header class="admin-head">
+  <div class="wrap">
+    <h1>Moderator queue</h1>
+    <p>Streamer applications from <a href="streamer-signup.html" style="color:var(--orange2)">the signup form</a>. Approving a Twitch application puts a card on the streams page within a minute; everything on this page is visible to moderators only.</p>
+  </div>
+</header>
+
+<section style="padding-top:0">
+  <div class="wrap">
+    <!-- One of these is shown at a time; admin.js decides which. -->
+    <div id="loading" class="state"><div class="big">⏳</div>Checking your access…</div>
+
+    <div id="gateSignedOut" class="gate" hidden>
+      <div class="big">🔒</div>
+      <h2>Moderators only</h2>
+      <p>Sign in with the X account on the moderator list to open the queue.</p>
+      <a class="btn btn-primary" id="signInBtn" href="#">Sign in with X</a>
+      <p style="margin:16px 0 0;font-size:12.5px">Sign-in returns you to the leaderboard — come back here afterwards and the queue will open.</p>
+    </div>
+
+    <div id="gateNotMod" class="gate" hidden>
+      <div class="big">🚧</div>
+      <h2>Not on the moderator list</h2>
+      <p>You're signed in as <b id="notModHandle"></b>, but that account isn't a PaperTrench moderator.</p>
+      <p>To be added, send an owner your X user id:<br><code id="notModId"></code><br>
+         they add it to <code>ADMIN_X_IDS</code> and redeploy the Worker.</p>
+      <a class="btn btn-ghost" href="index.html">Back to the site</a>
+    </div>
+
+    <div id="queue" hidden>
+      <div class="who">
+        <img id="whoAvatar" src="" alt="" hidden>
+        <span>Signed in as <b id="whoHandle"></b> · moderator</span>
+        <button class="ar-btn" type="button" id="refreshBtn">Refresh</button>
+      </div>
+
+      <div class="tabs" id="tabs">
+        <button class="tab on" type="button" data-status="pending">Pending<span class="n" id="nPending"></span></button>
+        <button class="tab" type="button" data-status="approved">Approved<span class="n" id="nApproved"></span></button>
+        <button class="tab" type="button" data-status="rejected">Rejected<span class="n" id="nRejected"></span></button>
+      </div>
+
+      <div class="apps" id="apps"></div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    <div class="foot-inner">
+      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <div class="foot-links">
+        <a href="index.html">Home</a>
+        <a href="streams.html">Watch Live</a>
+        <a href="streamer-signup.html">Streamer signup</a>
+        <a href="privacy.html">Privacy</a>
+      </div>
+    </div>
+    <div class="foot-note">Applicant contact details on this page are private — handle them like the personal data they are.</div>
+  </div>
+</footer>
+
+<script src="admin.js"></script>
+</body>
+</html>

--- a/site/admin.js
+++ b/site/admin.js
@@ -1,0 +1,264 @@
+/* PaperTrench — moderator queue for streamer applications.
+ *
+ * This page is a VIEW of a server-side decision, never the decision itself.
+ * The Worker checks the caller's x_id against ADMIN_X_IDS on every request
+ * (/api/streamer/applications, /api/streamer/review) and returns 403 to
+ * everyone else, so hiding the queue here is a courtesy to the user — not the
+ * control. Editing this file, or the DOM, gets an attacker exactly nothing.
+ *
+ * Operator setup: docs/STREAMS.md.
+ */
+(() => {
+  'use strict';
+
+  // Same API origin and session transport as arena.js — see the comments there
+  // on why the API is cross-site and why the token rides in localStorage as
+  // well as a cookie.
+  const API = 'https://papertrench-api.onerobby.workers.dev';
+  const TOKEN_KEY = 'pt_session_token';
+
+  const $ = (id) => document.getElementById(id);
+
+  const esc = (s) => String(s == null ? '' : s).replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ));
+
+  /**
+   * An href we are willing to put in the DOM.
+   *
+   * The server already rejects non-http(s) schemes at submission time, so this
+   * is the second lock on the same door: every string here was typed by a
+   * member of the public and is about to become a link a moderator clicks. If
+   * the server-side check is ever loosened, this is what keeps `javascript:`
+   * out of the mod page.
+   */
+  function safeHref(raw) {
+    try {
+      const url = new URL(String(raw));
+      return (url.protocol === 'https:' || url.protocol === 'http:') ? url.toString() : null;
+    } catch { return null; }
+  }
+
+  function sessionToken() {
+    try { return localStorage.getItem(TOKEN_KEY) || null; } catch { return null; }
+  }
+
+  async function api(path, options) {
+    const opts = Object.assign({ credentials: 'include' }, options || {});
+    const token = sessionToken();
+    if (token) opts.headers = Object.assign({}, opts.headers, { Authorization: 'Bearer ' + token });
+    const res = await fetch(API + path, opts);
+    const body = await res.json().catch(() => null);
+    return { status: res.status, body };
+  }
+
+  // The OAuth callback lands on the leaderboard, not here — but the token it
+  // stores is per-origin, so arriving with one already in hand is the norm.
+  // Handle the fragment anyway in case a future callback returns to this page.
+  const authReturn = window.location.hash.match(/^#authed(?:=(.+))?$/);
+  if (authReturn) {
+    if (authReturn[1]) { try { localStorage.setItem(TOKEN_KEY, authReturn[1]); } catch {} }
+    history.replaceState(null, '', window.location.pathname + window.location.search);
+  }
+
+  $('signInBtn').href = API + '/api/auth/x/start';
+
+  function show(paneId) {
+    for (const id of ['loading', 'gateSignedOut', 'gateNotMod', 'queue']) {
+      $(id).hidden = (id !== paneId);
+    }
+  }
+
+  /* ---------------- rendering ---------------- */
+
+  const when = (ms) => {
+    if (!ms) return '';
+    const d = new Date(Number(ms));
+    return Number.isNaN(d.getTime()) ? '' : d.toLocaleString(undefined, {
+      year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+    });
+  };
+
+  /** A <dd>, or an italic "not answered" — never a blank row that reads as data. */
+  function value(text) {
+    const clean = String(text == null ? '' : text).trim();
+    return clean ? `<dd>${esc(clean)}</dd>` : '<dd class="empty">not answered</dd>';
+  }
+
+  function linkValue(raw) {
+    const href = safeHref(raw);
+    if (!href) return value(raw);
+    return `<dd><a href="${esc(href)}" target="_blank" rel="noopener noreferrer">${esc(href)}</a></dd>`;
+  }
+
+  function cardFor(app) {
+    const platform = ['twitch', 'youtube', 'kick'].includes(app.platform) ? app.platform : 'other';
+    const chan = safeHref(app.channelUrl);
+    const chanHtml = chan
+      ? `<a href="${esc(chan)}" target="_blank" rel="noopener noreferrer">${esc(chan)}</a>`
+      : esc(app.channelUrl || '');
+
+    // Approve is offered only where it can do something. A YouTube or Kick
+    // application is perfectly valid, but the streams page embeds Twitch, so
+    // approving one would set a status that never becomes a card — a button
+    // that silently does nothing is worse than a button that isn't there.
+    const embeddable = Boolean(app.twitchLogin);
+
+    const actions = [];
+    if (app.status !== 'approved') {
+      actions.push(`<button class="ar-btn good" type="button" data-act="approved" data-id="${app.id}"
+        ${embeddable ? '' : 'disabled title="Only Twitch channels can be embedded on the streams page"'}>✓ Approve</button>`);
+    }
+    if (app.status !== 'rejected') {
+      actions.push(`<button class="ar-btn bad" type="button" data-act="rejected" data-id="${app.id}">✕ Reject</button>`);
+    }
+    if (app.status !== 'pending') {
+      actions.push(`<button class="ar-btn" type="button" data-act="pending" data-id="${app.id}">↩ Move back to pending</button>`);
+    }
+
+    const reviewed = app.reviewedAt
+      ? `<span class="act-msg">${esc(app.status)} by @${esc(app.reviewedBy || 'a moderator')} · ${esc(when(app.reviewedAt))}</span>`
+      : '';
+
+    return `
+      <article class="app" data-card="${app.id}">
+        <div class="app-top">
+          <div>
+            <div class="app-name">${esc(app.name)} <span class="plat ${platform}">${esc(platform)}</span></div>
+            <div class="app-chan">${chanHtml}</div>
+          </div>
+          <div class="app-when">${esc(when(app.createdAt))}</div>
+        </div>
+
+        <dl class="rows">
+          <dt>Public blurb</dt>${value(app.blurb)}
+          <dt>Twitch login</dt>${app.twitchLogin
+            ? `<dd>${esc(app.twitchLogin)}</dd>`
+            : '<dd class="empty">not a Twitch channel — cannot be embedded</dd>'}
+          <dt>Avg. viewers</dt>${value(app.viewers)}
+        </dl>
+
+        <div class="private-note">
+          <div class="cap">Private — moderators only</div>
+          <dl class="rows">
+            <dt>Discord</dt>${value(app.discord)}
+            <dt>Contact via</dt>${value(app.contactMethod)}
+            <dt>Profile link</dt>${linkValue(app.contactLink)}
+            <dt>Best time</dt>${value(app.bestTime)}
+            <dt>Notes</dt>${value(app.notes)}
+          </dl>
+        </div>
+
+        <div class="app-acts">${actions.join('')}${reviewed}</div>
+      </article>`;
+  }
+
+  /* ---------------- state ---------------- */
+
+  let current = 'pending';
+
+  function setCounts(counts) {
+    $('nPending').textContent = counts.pending ? ` ${counts.pending}` : '';
+    $('nApproved').textContent = counts.approved ? ` ${counts.approved}` : '';
+    $('nRejected').textContent = counts.rejected ? ` ${counts.rejected}` : '';
+  }
+
+  const EMPTY = {
+    pending: ['📭', 'Nothing waiting. New applications land here.'],
+    approved: ['🎬', 'No approved streamers yet.'],
+    rejected: ['🗂️', 'Nothing rejected.'],
+  };
+
+  async function loadQueue() {
+    const box = $('apps');
+    box.innerHTML = '<div class="state"><div class="big">⏳</div>Loading…</div>';
+
+    const { status, body } = await api('/api/streamer/applications?status=' + encodeURIComponent(current));
+
+    if (status === 403) { await boot(); return; }   // access changed under us
+    if (status < 200 || status >= 300 || !body || !body.ok) {
+      // Say the read failed. "No applications" would be an affirmative claim
+      // about the queue, made while we cannot see it.
+      box.innerHTML = '<div class="state"><div class="big">⚠️</div>'
+        + 'Couldn’t load the queue. Refresh to try again.</div>';
+      return;
+    }
+
+    setCounts(body.counts || {});
+    const apps = body.applications || [];
+    if (!apps.length) {
+      const [icon, text] = EMPTY[current] || EMPTY.pending;
+      box.innerHTML = `<div class="state"><div class="big">${icon}</div>${text}</div>`;
+      return;
+    }
+    box.innerHTML = apps.map(cardFor).join('');
+  }
+
+  $('apps').addEventListener('click', async (event) => {
+    const button = event.target.closest('button[data-act]');
+    if (!button || button.disabled) return;
+
+    const card = button.closest('[data-card]');
+    const buttons = card ? card.querySelectorAll('button[data-act]') : [button];
+    buttons.forEach((b) => { b.disabled = true; });
+
+    const { status, body } = await api('/api/streamer/review', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: Number(button.dataset.id), status: button.dataset.act }),
+    });
+
+    if (status >= 200 && status < 300 && body && body.ok) { await loadQueue(); return; }
+
+    buttons.forEach((b) => { b.disabled = false; });
+    const note = card && card.querySelector('.act-msg');
+    const text = body && body.reason === 'already-listed'
+      ? 'That channel is already on the roster.'
+      : 'That didn’t save — try again.';
+    if (note) { note.textContent = text; note.className = 'act-msg err'; }
+    else if (card) {
+      card.querySelector('.app-acts').insertAdjacentHTML('beforeend',
+        `<span class="act-msg err">${esc(text)}</span>`);
+    }
+  });
+
+  $('tabs').addEventListener('click', (event) => {
+    const tab = event.target.closest('.tab');
+    if (!tab) return;
+    current = tab.dataset.status;
+    $('tabs').querySelectorAll('.tab').forEach((t) => t.classList.toggle('on', t === tab));
+    loadQueue();
+  });
+
+  $('refreshBtn').addEventListener('click', loadQueue);
+
+  /* ---------------- boot ---------------- */
+
+  async function boot() {
+    let session = null;
+    try {
+      const reply = await api('/api/me');
+      session = reply.body;
+    } catch (_) { session = null; }
+
+    if (!session || !session.signedIn) { show('gateSignedOut'); return; }
+
+    if (!session.isMod) {
+      $('notModHandle').textContent = '@' + (session.handle || 'unknown');
+      // Their own X id, so getting added does not require a third-party lookup.
+      $('notModId').textContent = session.xId || 'unavailable';
+      show('gateNotMod');
+      return;
+    }
+
+    $('whoHandle').textContent = '@' + (session.handle || 'you');
+    if (session.avatarUrl && safeHref(session.avatarUrl)) {
+      $('whoAvatar').src = session.avatarUrl;
+      $('whoAvatar').hidden = false;
+    }
+    show('queue');
+    loadQueue();
+  }
+
+  boot();
+})();

--- a/site/arena.js
+++ b/site/arena.js
@@ -122,7 +122,7 @@
     const title = esc(opts.title || ('Clan ' + tag));
     if (opts.plain) return `<span class="ar-clan-tag" style="${style}" title="${title}">${label}</span>`;
     return `<a class="ar-clan-tag" style="${style}" title="${title}"
-      href="clan.html?tag=${encodeURIComponent(tag)}">${label}</a>`;
+      href="/clan?tag=${encodeURIComponent(tag)}">${label}</a>`;
   }
 
   /* ------------------------------------------------- clan label floor ---

--- a/site/clan.html
+++ b/site/clan.html
@@ -22,15 +22,15 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -76,13 +76,13 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="clans.html">All clans</a>
-        <a href="leaderboard.html">Leaderboard</a>
-        <a href="sprint.html">Weekly Sprint</a>
-        <a href="duels.html">Duels</a>
-        <a href="privacy.html">Privacy</a>
+        <a href="/clans">All clans</a>
+        <a href="/leaderboard">Leaderboard</a>
+        <a href="/sprint">Weekly Sprint</a>
+        <a href="/duels">Duels</a>
+        <a href="/privacy">Privacy</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener">Leaderboard protocol</a>
       </div>
     </div>
@@ -132,7 +132,7 @@
               <span class="ar-clan-tag" style="margin-right:6px">[${L.clanLabel(clan.tag)}]</span>
               ${clan.open ? 'Open to anyone signed in' : 'Invite only'} ·
               founded ${esc(day(clan.createdAt))} by
-              <a href="profile.html?handle=${encodeURIComponent(clan.founder)}">@${esc(clan.founder)}</a>
+              <a href="/profile?handle=${encodeURIComponent(clan.founder)}">@${esc(clan.founder)}</a>
             </p>
             ${clan.motto ? `<p style="margin-top:10px;font-size:14.5px;color:var(--muted)">“${L.clanLabel(clan.motto)}”</p>` : ''}
           </div>
@@ -167,18 +167,18 @@
     if (mine && mine.inClan && mine.tag === clan.tag) {
       box.innerHTML = `<p class="ar-note" style="text-align:right">You are in this clan since
         <strong>${esc(day(mine.joinedAt))}</strong>.<br>
-        <a href="clans.html">Manage membership →</a></p>`;
+        <a href="/clans">Manage membership →</a></p>`;
       return;
     }
     if (mine && mine.inClan) {
       box.innerHTML = `<p class="ar-note" style="text-align:right">You are in
-        <a href="clan.html?tag=${encodeURIComponent(mine.tag)}">[${esc(mine.tag)}]</a>.
+        <a href="/clan?tag=${encodeURIComponent(mine.tag)}">[${esc(mine.tag)}]</a>.
         One clan at a time — leave that one first.</p>`;
       return;
     }
     if (!signedIn) {
       box.innerHTML = `<p class="ar-note" style="text-align:right">
-        <a href="clans.html">Sign in to join a clan →</a></p>`;
+        <a href="/clans">Sign in to join a clan →</a></p>`;
       return;
     }
     if (!mine) {
@@ -190,7 +190,7 @@
     }
     if (!clan.open) {
       box.innerHTML = `<p class="ar-note" style="text-align:right">Invite only. Ask a member for the
-        code, then join from <a href="clans.html">the clan board</a>.</p>`;
+        code, then join from <a href="/clans">the clan board</a>.</p>`;
       return;
     }
     box.innerHTML = `<button class="ar-btn primary" id="join-btn" style="width:100%">Join [${esc(clan.tag)}]</button>
@@ -239,7 +239,7 @@
       </div>
       <div style="display:grid;gap:8px">
         ${standing.counting.map((m, i) => `
-          <a href="profile.html?handle=${encodeURIComponent(m.handle)}"
+          <a href="/profile?handle=${encodeURIComponent(m.handle)}"
              style="display:flex;align-items:center;gap:9px;padding:8px 10px;border:var(--edge);border-radius:10px;background:var(--pane-lo)">
             <span style="font-family:var(--mono);font-size:11px;font-weight:800;color:var(--dim);width:14px">${i + 1}</span>
             ${face({ handle: m.handle }, 'ar-face')}
@@ -289,7 +289,7 @@
         <span class="mark"></span>
         <span class="ar-who">
           ${face(member)}
-          <a class="ar-handle" href="profile.html?handle=${encodeURIComponent(member.handle)}">@${esc(member.handle)}</a>
+          <a class="ar-handle" href="/profile?handle=${encodeURIComponent(member.handle)}">@${esc(member.handle)}</a>
           ${member.role === 'founder' ? '<span class="ar-role">founder</span>' : ''}
         </span>
         <span class="c-status">${chipFor(member.status)}</span>
@@ -304,7 +304,7 @@
       <span class="mark" title="${counts ? 'One of the five this clan\'s score is the mean of' : ''}">${counts ? '★' : ''}</span>
       <span class="ar-who">
         ${face(member)}
-        <a class="ar-handle" href="profile.html?handle=${encodeURIComponent(member.handle)}">@${esc(member.handle)}</a>
+        <a class="ar-handle" href="/profile?handle=${encodeURIComponent(member.handle)}">@${esc(member.handle)}</a>
         ${member.role === 'founder' ? '<span class="ar-role">founder</span>' : ''}
       </span>
       <span class="c-status">${chipFor(member.status)}</span>
@@ -456,7 +456,7 @@
   (async () => {
     if (!tag) {
       headEl.innerHTML = '<section class="ar-pane"><div class="pad">' +
-        L.empty('⚔', 'No clan named.', 'Pick one from <a href="clans.html">the clan board</a>.') +
+        L.empty('⚔', 'No clan named.', 'Pick one from <a href="/clans">the clan board</a>.') +
         '</div></section>';
       return;
     }
@@ -470,7 +470,7 @@
       headEl.innerHTML = '<section class="ar-pane"><div class="pad">' + (
         String(err && err.message) === 'api 404'
           ? L.empty('⚔', 'No clan with that tag.',
-              'It may have disbanded — a clan whose last member leaves is removed rather than left as an empty shell. <a href="clans.html">See the clans that exist</a>.')
+              'It may have disbanded — a clan whose last member leaves is removed rather than left as an empty shell. <a href="/clans">See the clans that exist</a>.')
           : L.errorState('The verifier is unreachable right now, so this clan is not shown. Nothing here is cached or guessed.')
       ) + '</div></section>';
       rosterEl.innerHTML = '';

--- a/site/clans.html
+++ b/site/clans.html
@@ -22,15 +22,15 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html" aria-current="page">Clans</a>
-      <a href="news.html">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans" aria-current="page">Clans</a>
+      <a href="/news">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -193,14 +193,14 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="leaderboard.html">Leaderboard</a>
-        <a href="sprint.html">Weekly Sprint</a>
-        <a href="duels.html">Duels</a>
-        <a href="clans.html">Clans</a>
-        <a href="news.html">News &amp; patch notes</a>
-        <a href="privacy.html">Privacy</a>
+        <a href="/leaderboard">Leaderboard</a>
+        <a href="/sprint">Weekly Sprint</a>
+        <a href="/duels">Duels</a>
+        <a href="/clans">Clans</a>
+        <a href="/news">News &amp; patch notes</a>
+        <a href="/privacy">Privacy</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
       </div>
     </div>
@@ -254,7 +254,7 @@
     const isYours = myTag && entry.tag === myTag;
     return `<a class="ar-clan-row ${isYours ? 'is-yours' : ''}"
        style="animation-delay:${Math.min(index * 26, 320)}ms"
-       href="clan.html?tag=${encodeURIComponent(entry.tag)}">
+       href="/clan?tag=${encodeURIComponent(entry.tag)}">
       <span class="pos" style="font-family:var(--mono);font-weight:800;color:var(--muted)"
         >${position ? '#' + position : '—'}</span>
       <span class="ar-clan-id">
@@ -476,7 +476,7 @@
       <p class="ar-note" style="margin-bottom:14px">Anyone with this code can join. Members only —
         it is not on the public clan page.</p>
       <div style="display:flex;gap:10px;flex-wrap:wrap">
-        <a class="ar-btn primary" href="clan.html?tag=${encodeURIComponent(mine.tag)}">Open clan page</a>
+        <a class="ar-btn primary" href="/clan?tag=${encodeURIComponent(mine.tag)}">Open clan page</a>
         <button class="ar-btn" id="leave-btn">Leave</button>
       </div>
       <div id="mine-status" style="margin-top:12px"></div>`);

--- a/site/duel.html
+++ b/site/duel.html
@@ -313,15 +313,15 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html" aria-current="page">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels" aria-current="page">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -455,8 +455,8 @@
           <p class="ar-note" style="margin-bottom:12px">Duels cost nothing and risk nothing — no entry, no real money,
             no wallet. You trade real charts on the real sites with paper size, and the server replays both chains.</p>
           <div class="ar-actions">
-            <a class="ar-btn primary" href="duels.html">Open a duel invite</a>
-            <a class="ar-btn" href="index.html#install">Install the extension</a>
+            <a class="ar-btn primary" href="/duels">Open a duel invite</a>
+            <a class="ar-btn" href="/#install">Install the extension</a>
           </div>
         </div>
       </section>
@@ -468,13 +468,13 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="sprint.html">Weekly Sprint</a>
-        <a href="duels.html">Duels</a>
-        <a href="clans.html">Clans</a>
-        <a href="news.html">News &amp; patch notes</a>
-        <a href="privacy.html">Privacy</a>
+        <a href="/sprint">Weekly Sprint</a>
+        <a href="/duels">Duels</a>
+        <a href="/clans">Clans</a>
+        <a href="/news">News &amp; patch notes</a>
+        <a href="/privacy">Privacy</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener">Leaderboard protocol</a>
       </div>
@@ -685,7 +685,7 @@
     return `<div class="${classes.join(' ')}">
       <div class="ar-corner">${esc(corner)}</div>
       ${face(side, 'face')}
-      <a class="who" href="profile.html?handle=${encodeURIComponent(side.handle)}">@${esc(side.handle)}</a>
+      <a class="who" href="/profile?handle=${encodeURIComponent(side.handle)}">@${esc(side.handle)}</a>
       <div style="margin-top:9px">${chipFor(side.status)}</div>
       ${roi}
       <div class="meta">${meta}</div>
@@ -802,7 +802,7 @@
       <p class="ar-note" style="margin-top:10px">Whoever never submits after the close <strong>forfeits</strong>. If
         neither does, the duel is recorded as a no-contest and nobody gets a win.</p>
       <div class="ar-actions" style="margin-top:14px">
-        <a class="ar-btn primary" href="leaderboard.html">Submit my record</a>
+        <a class="ar-btn primary" href="/leaderboard">Submit my record</a>
       </div>
     </div>`;
   }
@@ -810,7 +810,7 @@
   function slotActions(v) {
     if (v.status === 'expired') {
       return `<p class="ar-note" style="margin-top:12px">This invite lapsed with nobody in the other corner.</p>
-        <a class="ar-btn" href="duels.html" style="margin-top:14px">Open a fresh invite</a>`;
+        <a class="ar-btn" href="/duels" style="margin-top:14px">Open a fresh invite</a>`;
     }
     const msg = acceptMsg ? `<p class="ar-note" style="margin-top:12px;color:var(--down)">${esc(acceptMsg)}</p>` : '';
     if (accepting) return '<button class="ar-btn primary" disabled>Accepting…</button>' + msg;
@@ -842,7 +842,7 @@
         <div class="ar-duel-side">
           <div class="ar-corner">Challenger</div>
           ${face(a, 'face')}
-          <a class="who" href="profile.html?handle=${encodeURIComponent(a.handle)}">@${esc(a.handle)}</a>
+          <a class="who" href="/profile?handle=${encodeURIComponent(a.handle)}">@${esc(a.handle)}</a>
           <div style="margin-top:9px">${chipFor(a.status)}</div>
           <p class="meta" style="margin-top:14px">No window has run, so this player has no duel numbers yet — and
             none are invented here.</p>
@@ -1053,7 +1053,7 @@
       ${face(session, 'ar-face')}
       <div style="min-width:0">
         <div style="font-weight:800">@${esc(session.handle)}</div>
-        <a class="ar-note" style="color:var(--orange2)" href="profile.html?handle=${encodeURIComponent(session.handle)}">View public profile →</a>
+        <a class="ar-note" style="color:var(--orange2)" href="/profile?handle=${encodeURIComponent(session.handle)}">View public profile →</a>
       </div></div>`;
 
     let body;
@@ -1079,18 +1079,18 @@
           'dashboard → Leaderboard tab → Sync from site (or Export record) and submit it on the leaderboard page. ' +
           'Your post-close chain carries every fill from inside the window, which is exactly why it is the only ' +
           'thing allowed to settle this.</p><div class="ar-actions" style="margin-top:12px">' +
-          '<a class="ar-btn primary" href="leaderboard.html">Submit my record</a></div>';
+          '<a class="ar-btn primary" href="/leaderboard">Submit my record</a></div>';
     } else if (v.status === 'settled') {
       body = '<p class="ar-note">This one is in the books and will read the same forever — the result was written ' +
         'the first time it became decidable.</p><div class="ar-actions" style="margin-top:12px">' +
-        '<a class="ar-btn" href="duels.html">Start another</a></div>';
+        '<a class="ar-btn" href="/duels">Start another</a></div>';
     } else {
       body = role === 'challenger'
         ? '<p class="ar-note">Your invite lapsed before anyone accepted it. Nothing ran and nothing was recorded — ' +
           'opening a new one takes a click.</p><div class="ar-actions" style="margin-top:12px">' +
-          '<a class="ar-btn primary" href="duels.html">Open a new invite</a></div>'
+          '<a class="ar-btn primary" href="/duels">Open a new invite</a></div>'
         : '<p class="ar-note">This invite lapsed before anyone accepted it. There is nothing to join here.</p>' +
-          '<div class="ar-actions" style="margin-top:12px"><a class="ar-btn" href="duels.html">Open your own</a></div>';
+          '<div class="ar-actions" style="margin-top:12px"><a class="ar-btn" href="/duels">Open your own</a></div>';
     }
     seatEl.innerHTML = you + body;
   }
@@ -1321,7 +1321,7 @@
       'A duel link carries its code in the address, like ' +
       '<code style="font-family:var(--mono);color:var(--orange2)">duel.html?code=TRENCH-XXXXXX</code>. ' +
       'Without one there is no duel to look up, and nothing is invented to fill the page. ' +
-      '<a href="duels.html" style="color:var(--orange2)">Your duels are here</a>.'));
+      '<a href="/duels" style="color:var(--orange2)">Your duels are here</a>.'));
     seatEl.innerHTML = '<p class="ar-note">Nothing to join without a code.</p>';
   } else {
     document.getElementById('spec-code').textContent = CODE;

--- a/site/duels.html
+++ b/site/duels.html
@@ -464,15 +464,15 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html" aria-current="page">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels" aria-current="page">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -562,9 +562,9 @@
       <h2 id="you-h">Your side</h2>
       <span class="spacer"></span>
       <div class="ar-tabs">
-        <a class="ar-tab" href="leaderboard.html">All-time</a>
-        <a class="ar-tab" href="sprint.html">This week</a>
-        <a class="ar-tab" href="duels.html" aria-current="page">Duels</a>
+        <a class="ar-tab" href="/leaderboard">All-time</a>
+        <a class="ar-tab" href="/sprint">This week</a>
+        <a class="ar-tab" href="/duels" aria-current="page">Duels</a>
       </div>
     </div>
     <div class="pad">
@@ -792,13 +792,13 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="leaderboard.html">Leaderboard</a>
-        <a href="sprint.html">Weekly Sprint</a>
-        <a href="clans.html">Clans</a>
-        <a href="news.html">News &amp; patch notes</a>
-        <a href="privacy.html">Privacy</a>
+        <a href="/leaderboard">Leaderboard</a>
+        <a href="/sprint">Weekly Sprint</a>
+        <a href="/clans">Clans</a>
+        <a href="/news">News &amp; patch notes</a>
+        <a href="/privacy">Privacy</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener">Leaderboard protocol</a>
       </div>
@@ -961,11 +961,11 @@
         <div style="min-width:0">
           <div style="font-weight:800">@${esc(session.handle)}</div>
           <a class="ar-note" style="color:var(--orange2)"
-             href="profile.html?handle=${encodeURIComponent(session.handle)}">View public profile →</a>
+             href="/profile?handle=${encodeURIComponent(session.handle)}">View public profile →</a>
         </div>
       </div>
       <p class="ar-note" style="margin-top:12px">Your duel slices are recomputed from your chain
-        every time you submit on the <a href="leaderboard.html">leaderboard page</a> — there is no
+        every time you submit on the <a href="/leaderboard">leaderboard page</a> — there is no
         separate duel record to keep up to date, and no second book to game.
         <a href="#" id="you-signout" style="color:var(--dim)">sign out</a></p>`;
     document.getElementById('you-signout').addEventListener('click', (event) => {
@@ -1047,7 +1047,7 @@
         </div>
         <div class="ar-acts">
           <button class="ar-btn" id="copy-gauntlet">Copy the whole gauntlet</button>
-          <a class="ar-btn" href="duel.html?code=${encodeURIComponent(code)}">Open duel →</a>
+          <a class="ar-btn" href="/duel?code=${encodeURIComponent(code)}">Open duel →</a>
         </div>
       </div>`;
     tick();
@@ -1157,7 +1157,7 @@
         <time datetime="${esc(isoTime(w.endTs))}">${esc(absTime(w.endTs))}</time> —
         ${clockHtml(w.endTs, 'window closed', false)} left.` : ''}
       Nothing is decided until you both submit a record after that.
-      <a class="ar-btn" href="duel.html?code=${encodeURIComponent(body.code || code)}">Open duel →</a>`);
+      <a class="ar-btn" href="/duel?code=${encodeURIComponent(body.code || code)}">Open duel →</a>`);
     tick();
     joinInput.value = '';
     syncCodeField();
@@ -1285,7 +1285,7 @@
     if (status === 'awaiting') {
       const mine = [view.challenger, view.opponent].find((s) => s && isMe(s.handle));
       const nudge = mine && !mine.final
-        ? ` <a href="leaderboard.html">Submit your record →</a>`
+        ? ` <a href="/leaderboard">Submit your record →</a>`
         : '';
       const text = view.awaiting
         ? esc(view.awaiting)

--- a/site/index.html
+++ b/site/index.html
@@ -25,13 +25,13 @@
       <a href="#bubbles">Chart bubbles</a>
       <a href="#replay">Replay</a>
       <a href="#journal">Journal</a>
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html">News</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news">News</a>
       <a href="#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -45,7 +45,7 @@
     <p class="hero-sub reveal d2">PaperTrench overlays a <strong>paper-trading terminal</strong> on the memecoin sites you already use — real charts, real live prices, <strong>fake money</strong> — then shows you exactly what you did and why. <span style="color:var(--green)">Learn in an afternoon what usually costs a wallet.</span></p>
     <div class="hero-ctas reveal d3">
       <a class="btn btn-primary" href="https://github.com/OnlyTerp/papertrench/releases/latest" target="_blank" rel="noopener">⬇ Get the extension</a>
-      <a class="btn btn-ghost" href="streams.html"><span style="width:8px;height:8px;border-radius:50%;background:var(--red);box-shadow:0 0 10px var(--red)"></span>Watch live</a>
+      <a class="btn btn-ghost" href="/streams"><span style="width:8px;height:8px;border-radius:50%;background:var(--red);box-shadow:0 0 10px var(--red)"></span>Watch live</a>
       <a class="btn btn-ghost" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">★ Star on GitHub</a>
       <!-- ONBOARDING-BOT: disabled until the X handle is registered.
            To enable: register the handle, disclose it in the bio, complete the
@@ -144,7 +144,7 @@
     </div>
   </div>
   <div class="wrap" style="margin-top:38px">
-    <a class="news-strip reveal" href="news.html">
+    <a class="news-strip reveal" href="/news">
       <div class="txt">
         <h3>New in v3.5.0: the Arena repair — a leaderboard that verifies every price you claimed</h3>
         <p>Eleven audited defects closed across the verifier pipeline, ahead of real prize money — plus the three releases that came before it. All the patch notes.</p>
@@ -284,10 +284,10 @@
           <div class="feature-row"><div class="fi">🪪</div><div><h4>Verified identity</h4><p>One ranked record per verified account, making sybil entries expensive.</p></div></div>
         </div>
         <div class="reveal d3" style="display:flex;gap:12px;flex-wrap:wrap;margin-top:26px">
-          <a class="btn btn-primary" href="leaderboard.html">🛡 Enter the Arena</a>
-          <a class="btn btn-ghost" href="sprint.html">⚡ This week's Sprint</a>
-          <a class="btn btn-ghost" href="duels.html">⚔ Duels</a>
-          <a class="btn btn-ghost" href="clans.html">🏴 Clans</a>
+          <a class="btn btn-primary" href="/leaderboard">🛡 Enter the Arena</a>
+          <a class="btn btn-ghost" href="/sprint">⚡ This week's Sprint</a>
+          <a class="btn btn-ghost" href="/duels">⚔ Duels</a>
+          <a class="btn btn-ghost" href="/clans">🏴 Clans</a>
         </div>
       </div>
       <div class="split-visual reveal d1">
@@ -304,7 +304,7 @@
           </div>
           <div class="lb-chain" id="chainTicker"></div>
           <div style="font-size:11.5px;margin-top:12px;text-align:right">
-            <a href="leaderboard.html" style="color:var(--green);font-weight:700">Open the full Arena →</a>
+            <a href="/leaderboard" style="color:var(--green);font-weight:700">Open the full Arena →</a>
           </div>
         </div>
       </div>
@@ -389,7 +389,7 @@
            second, ungated number is just a slower lie. -->
       <div class="gcard reveal d1"><div class="gi">🧪</div><h3>Mutation-tested, not just covered</h3><p>The decision logic is pure functions exercised directly by the suite — the same code that runs in the page — and each guard has to fail against the exact change it protects against.</p></div>
       <div class="gcard reveal d2"><div class="gi">🕵️</div><h3>Zero telemetry</h3><p>No account, no signup, nothing phoned home. The only network calls are the public price APIs — and your own AI endpoint, only if you configure one.</p></div>
-      <a class="gcard live-banner reveal" href="streams.html">
+      <a class="gcard live-banner reveal" href="/streams">
         <span class="live-chip"><span class="dot"></span>LIVE</span>
         <div class="txt"><h3>Watch the PaperTrench Challenge — live on Twitch</h3><p>Streamers grind the leaderboard on stream, with giveaways for the best verified records — and a built-in OBS overlay so you can stream your own runs.</p></div>
         <span class="go">Watch the streams →</span>
@@ -442,8 +442,8 @@
     <div class="foot-inner">
       <a class="nav-logo" href="#"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="news.html">News &amp; patch notes</a>
-        <a href="streams.html">Live on Twitch</a>
+        <a href="/news">News &amp; patch notes</a>
+        <a href="/streams">Live on Twitch</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/ARCHITECTURE.md" target="_blank" rel="noopener">Architecture</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener">Leaderboard protocol</a>
@@ -489,7 +489,7 @@
     boardEl.innerHTML = entries.slice(0, 5).map((entry, i) => {
       const s = entry.stats;
       const [bg, fg] = A.tone(entry.handle);
-      return `<a class="lb-row" href="profile.html?handle=${encodeURIComponent(entry.handle)}" style="color:inherit">
+      return `<a class="lb-row" href="/profile?handle=${encodeURIComponent(entry.handle)}" style="color:inherit">
         <span class="rank">#${i + 1}</span>
         <span class="handle"><span class="avatar" style="background:${bg};color:${fg}">${A.esc(A.initials(entry.handle))}</span>${A.esc(entry.handle)}
           ${A.chipFor(entry.status)}</span>

--- a/site/leaderboard.html
+++ b/site/leaderboard.html
@@ -22,15 +22,15 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="leaderboard.html" aria-current="page">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/leaderboard" aria-current="page">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -79,9 +79,9 @@
           <span class="glyph">🛡</span><span id="board-h">The podium</span>
           <span class="spacer"></span>
           <div class="ar-tabs">
-            <a class="ar-tab" href="leaderboard.html" aria-current="page">All-time</a>
-            <a class="ar-tab" href="sprint.html">This week</a>
-            <a class="ar-tab" href="duels.html">Duels</a>
+            <a class="ar-tab" href="/leaderboard" aria-current="page">All-time</a>
+            <a class="ar-tab" href="/sprint">This week</a>
+            <a class="ar-tab" href="/duels">Duels</a>
           </div>
         </div>
         <div id="podium"></div>
@@ -184,13 +184,13 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="sprint.html">Weekly Sprint</a>
-        <a href="duels.html">Duels</a>
-        <a href="clans.html">Clans</a>
-        <a href="news.html">News &amp; patch notes</a>
-        <a href="privacy.html">Privacy</a>
+        <a href="/sprint">Weekly Sprint</a>
+        <a href="/duels">Duels</a>
+        <a href="/clans">Clans</a>
+        <a href="/news">News &amp; patch notes</a>
+        <a href="/privacy">Privacy</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener">Leaderboard protocol</a>
       </div>
@@ -221,7 +221,7 @@
 
   function podiumCard(entry, rank) {
     const s = entry.stats;
-    return `<a class="ar-pod rank-${rank}" href="profile.html?handle=${encodeURIComponent(entry.handle)}">
+    return `<a class="ar-pod rank-${rank}" href="/profile?handle=${encodeURIComponent(entry.handle)}">
       ${rank === 1 ? '<span class="crown" aria-hidden="true">👑</span>' : ''}
       <span class="place">${rank === 1 ? 'CHAMPION' : 'RANK 0' + rank}</span>
       ${face(entry, 'face')}
@@ -245,7 +245,7 @@
     const isYou = signedInHandle && entry.handle.toLowerCase() === signedInHandle.toLowerCase();
     const discipline = L.scoreTerms(s).discipline;
     return `<a class="ar-row ${isYou ? 'is-you' : ''}" style="animation-delay:${Math.min(index * 26, 320)}ms"
-       href="profile.html?handle=${encodeURIComponent(entry.handle)}">
+       href="/profile?handle=${encodeURIComponent(entry.handle)}">
       <span class="pos">#${rank}</span>
       <span class="c-delta">${L.deltaCell(snapshot, entry.handle, index + 3)}</span>
       <span class="ar-who">
@@ -415,7 +415,7 @@
         ${face(session, 'ar-face')}
         <div style="min-width:0">
           <div style="font-weight:800">@${esc(session.handle)}</div>
-          <a class="ar-note" style="color:var(--orange2)" href="profile.html?handle=${encodeURIComponent(session.handle)}">View public profile →</a>
+          <a class="ar-note" style="color:var(--orange2)" href="/profile?handle=${encodeURIComponent(session.handle)}">View public profile →</a>
         </div>
       </div>
       <p class="ar-note" style="margin-top:12px">Every submission re-verifies from scratch, and a new

--- a/site/news-chain.html
+++ b/site/news-chain.html
@@ -47,17 +47,17 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="index.html#bubbles">Chart bubbles</a>
-      <a href="index.html#replay">Replay</a>
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html" aria-current="page">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/#bubbles">Chart bubbles</a>
+      <a href="/#replay">Replay</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news" aria-current="page">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -66,7 +66,7 @@
 <article>
   <header class="post-hero">
     <div class="wrap-read">
-      <a class="post-back" href="news.html"><span aria-hidden="true">←</span> All updates</a>
+      <a class="post-back" href="/news"><span aria-hidden="true">←</span> All updates</a>
       <div class="post-meta">
         <span class="ver-chip">v2.8.1</span>
         <span class="tag fix">Fix</span>
@@ -163,11 +163,11 @@
 
     <p>Nobody would have noticed if this page did not exist. The bug is invisible unless you read your own toasts carefully, the affected window was short, and no money is real.</p>
 
-    <p>But the product's entire claim is that its numbers are true, and <a href="news-v2.html">we publish our own defect register</a> for the same reason. A team that hides the one bug that undermines its verification story has no standing to ask anyone to trust the verification story.</p>
+    <p>But the product's entire claim is that its numbers are true, and <a href="/news-v2">we publish our own defect register</a> for the same reason. A team that hides the one bug that undermines its verification story has no standing to ask anyone to trust the verification story.</p>
 
     <div class="callout">
       <span class="co-label">One more thing v2.8.0 shipped without telling anyone</span>
-      <p>The <strong>Turbo receipts card</strong> — the Settings card counting warm vs cold opens, median routing latency and per-site main-thread stalls, all measured locally and never sent anywhere — was in v2.8.0 and went unmentioned in its release notes. It is described in both entries now, where it belongs. <a href="news-turbo.html">More on Turbo →</a></p>
+      <p>The <strong>Turbo receipts card</strong> — the Settings card counting warm vs cold opens, median routing latency and per-site main-thread stalls, all measured locally and never sent anywhere — was in v2.8.0 and went unmentioned in its release notes. It is described in both entries now, where it belongs. <a href="/news-turbo">More on Turbo →</a></p>
     </div>
 
     <!-- ---------- patch notes ---------- -->
@@ -193,18 +193,18 @@
       </div>
       <div class="pn-foot">
         <span>Full history:</span>
-        <a href="news.html#v2-8-1">this release in the archive</a>
+        <a href="/news#v2-8-1">this release in the archive</a>
         <span>·</span>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener">how verification works ↗</a>
       </div>
     </div>
 
     <div class="post-nav">
-      <a class="pnav" href="news-quickedit.html">
+      <a class="pnav" href="/news-quickedit">
         <span class="dir">← Newer</span>
         <span class="t">The quick fixes live on the trading tab</span>
       </a>
-      <a class="pnav next" href="news-rugguard.html">
+      <a class="pnav next" href="/news-rugguard">
         <span class="dir">Older →</span>
         <span class="t">Fresh launches, and the rug guard</span>
       </a>
@@ -216,11 +216,11 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="index.html">Home</a>
-        <a href="news.html">News</a>
-        <a href="streams.html">Live on Twitch</a>
+        <a href="/">Home</a>
+        <a href="/news">News</a>
+        <a href="/streams">Live on Twitch</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener">Leaderboard protocol</a>
       </div>

--- a/site/news-fees.html
+++ b/site/news-fees.html
@@ -35,17 +35,17 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="index.html#bubbles">Chart bubbles</a>
-      <a href="index.html#replay">Replay</a>
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html" aria-current="page">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/#bubbles">Chart bubbles</a>
+      <a href="/#replay">Replay</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news" aria-current="page">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -54,7 +54,7 @@
 <article>
   <header class="post-hero">
     <div class="wrap-read">
-      <a class="post-back" href="news.html"><span aria-hidden="true">←</span> All updates</a>
+      <a class="post-back" href="/news"><span aria-hidden="true">←</span> All updates</a>
       <div class="post-meta">
         <span class="ver-chip">v2.2.0</span>
         <span class="tag feature">Feature</span>
@@ -95,7 +95,7 @@
 
     <p>Quick fill-in presets give rough starting points, but they are starting points and nothing more: <b>your own site settings are the truth</b>. If you are running an aggressive sniper config on Axiom, the numbers to type in are the ones already in your Axiom settings.</p>
 
-    <p>As of <a href="news-fills.html">v2.7.0</a>, a fees profile (Axiom/Padre bot · aggressive sniper · no costs) is switchable straight from the extension popup mid-session, with the numbers pinned by test to match the dashboard's card. The full form stays on the dashboard.</p>
+    <p>As of <a href="/news-fills">v2.7.0</a>, a fees profile (Axiom/Padre bot · aggressive sniper · no costs) is switchable straight from the extension popup mid-session, with the numbers pinned by test to match the dashboard's card. The full form stays on the dashboard.</p>
 
     <h2>The accounting is honest end to end</h2>
 
@@ -149,16 +149,16 @@
       </div>
       <div class="pn-foot">
         <span>Full history:</span>
-        <a href="news.html#v2-2-0">this release in the archive</a>
+        <a href="/news#v2-2-0">this release in the archive</a>
       </div>
     </div>
 
     <div class="post-nav">
-      <a class="pnav" href="news-instant-x.html">
+      <a class="pnav" href="/news-instant-x">
         <span class="dir">← Newer</span>
         <span class="t">Instant X links</span>
       </a>
-      <a class="pnav next" href="news-the-after.html">
+      <a class="pnav next" href="/news-the-after">
         <span class="dir">Older →</span>
         <span class="t">The After: what happened once you sold</span>
       </a>
@@ -170,11 +170,11 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="index.html">Home</a>
-        <a href="news.html">News</a>
-        <a href="streams.html">Live on Twitch</a>
+        <a href="/">Home</a>
+        <a href="/news">News</a>
+        <a href="/streams">Live on Twitch</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
       </div>

--- a/site/news-fills.html
+++ b/site/news-fills.html
@@ -52,17 +52,17 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="index.html#bubbles">Chart bubbles</a>
-      <a href="index.html#replay">Replay</a>
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html" aria-current="page">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/#bubbles">Chart bubbles</a>
+      <a href="/#replay">Replay</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news" aria-current="page">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -71,7 +71,7 @@
 <article>
   <header class="post-hero">
     <div class="wrap-read">
-      <a class="post-back" href="news.html"><span aria-hidden="true">←</span> All updates</a>
+      <a class="post-back" href="/news"><span aria-hidden="true">←</span> All updates</a>
       <div class="post-meta">
         <span class="ver-chip">v2.7.0</span>
         <span class="tag fix">Fix</span>
@@ -154,7 +154,7 @@
 
     <h2>Where this fits</h2>
 
-    <p>PaperTrench ranks its own defects by how badly they can lie to a user, and this is severity one: <em>a number displayed wrong</em>. The <a href="news-v2.html">v2.0.0 audit</a> closed 116 of those. F-33 is what the class looks like when a new code path — the on-chain vault feed — reaches production and meets a case the register did not yet cover.</p>
+    <p>PaperTrench ranks its own defects by how badly they can lie to a user, and this is severity one: <em>a number displayed wrong</em>. The <a href="/news-v2">v2.0.0 audit</a> closed 116 of those. F-33 is what the class looks like when a new code path — the on-chain vault feed — reaches production and meets a case the register did not yet cover.</p>
 
     <p>The register is public. So is this write-up. If a wrong number ever reaches your screen, it should reach this page too.</p>
 
@@ -185,16 +185,16 @@
         </div>
         <div class="pn-item">
           <h4>Flex without leaving the terminal</h4>
-          <p>The Flex button on the closed P&amp;L card now opens the share composer as a floating window centered over the page — no more bouncing to a dashboard tab. It is the SAME composer, and the card math now lives in one shared derivation used by both, so a card can never show different numbers depending on where you opened it. <a href="news-flex.html">Full story →</a></p>
+          <p>The Flex button on the closed P&amp;L card now opens the share composer as a floating window centered over the page — no more bouncing to a dashboard tab. It is the SAME composer, and the card math now lives in one shared derivation used by both, so a card can never show different numbers depending on where you opened it. <a href="/news-flex">Full story →</a></p>
         </div>
         <div class="pn-item">
           <h4>Terminal Turbo</h4>
-          <p>The same release carried a whole speed pass: Instant terminal links for Axiom, Padre and GMGN, warm pump.fun and Solscan viewers, a feed-demand gate that donates zero parsing when PaperTrench is off, chips that stop thrashing layout, a dashboard that stopped re-reading everything every 4 seconds, and receipts measured on your own machine. <a href="news-turbo.html">Full story →</a></p>
+          <p>The same release carried a whole speed pass: Instant terminal links for Axiom, Padre and GMGN, warm pump.fun and Solscan viewers, a feed-demand gate that donates zero parsing when PaperTrench is off, chips that stop thrashing layout, a dashboard that stopped re-reading everything every 4 seconds, and receipts measured on your own machine. <a href="/news-turbo">Full story →</a></p>
         </div>
       </div>
       <div class="pn-foot">
         <span>Full history:</span>
-        <a href="news.html#v2-7-0">this release in the archive</a>
+        <a href="/news#v2-7-0">this release in the archive</a>
         <span>·</span>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/DEFECTS.md" target="_blank" rel="noopener">the public defect register ↗</a>
       </div>
@@ -206,11 +206,11 @@
     </div>
 
     <div class="post-nav">
-      <a class="pnav" href="news-turbo.html">
+      <a class="pnav" href="/news-turbo">
         <span class="dir">← Newer</span>
         <span class="t">Terminal Turbo: every terminal, warm</span>
       </a>
-      <a class="pnav next" href="news-xray.html">
+      <a class="pnav next" href="/news-xray">
         <span class="dir">Older →</span>
         <span class="t">X-Ray: instant account intel on X</span>
       </a>
@@ -222,11 +222,11 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="index.html">Home</a>
-        <a href="news.html">News</a>
-        <a href="streams.html">Live on Twitch</a>
+        <a href="/">Home</a>
+        <a href="/news">News</a>
+        <a href="/streams">Live on Twitch</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/DEFECTS.md" target="_blank" rel="noopener">Defect register</a>
       </div>

--- a/site/news-flex.html
+++ b/site/news-flex.html
@@ -61,17 +61,17 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="index.html#bubbles">Chart bubbles</a>
-      <a href="index.html#replay">Replay</a>
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html" aria-current="page">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/#bubbles">Chart bubbles</a>
+      <a href="/#replay">Replay</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news" aria-current="page">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -80,7 +80,7 @@
 <article>
   <header class="post-hero">
     <div class="wrap-read">
-      <a class="post-back" href="news.html"><span aria-hidden="true">←</span> All updates</a>
+      <a class="post-back" href="/news"><span aria-hidden="true">←</span> All updates</a>
       <div class="post-meta">
         <span class="ver-chip">v2.5.0</span>
         <span class="ver-chip">v2.5.1</span>
@@ -132,7 +132,7 @@
       <li><b>Token symbol and multiple chip</b>, then a huge ◎ SOL P&amp;L as the hero number.</li>
       <li><b>Invested / Returned / P&amp;L%</b> columns, each with a USD sub-line.</li>
       <li><b>The journey line:</b> entry → exit → held. How long you were actually in it, which is the number people quietly omit.</li>
-      <li><b>An After line</b> — "−62% after exit — dodged" — that no other terminal can print, because no other terminal <a href="news-the-after.html">measures what happened after you left</a>.</li>
+      <li><b>An After line</b> — "−62% after exit — dodged" — that no other terminal can print, because no other terminal <a href="/news-the-after">measures what happened after you left</a>.</li>
     </ul>
 
     <h3>The em-dash rule</h3>
@@ -212,7 +212,7 @@
           <p>The PAPER watermark and the PaperTrench brand bar are drawn last by a code path that reads no settings — verified by a test that drives every combination of options and asserts the branding survives all of them. Flex the result; never fake it.</p>
         </div>
       </div>
-      <div class="pn-foot"><span>Also in v2.5.0:</span> <a href="news-instant-x.html">Instant X links learn GMGN and Axiom, plus hover preview cards</a></div>
+      <div class="pn-foot"><span>Also in v2.5.0:</span> <a href="/news-instant-x">Instant X links learn GMGN and Axiom, plus hover preview cards</a></div>
     </div>
 
     <div class="pn-panel reveal">
@@ -255,7 +255,7 @@
       </div>
       <div class="pn-foot">
         <span>Full history:</span>
-        <a href="news.html#v2-5-0">these releases in the archive</a>
+        <a href="/news#v2-5-0">these releases in the archive</a>
       </div>
     </div>
 
@@ -273,18 +273,18 @@
       </div>
       <div class="pn-foot">
         <span>Also in that batch:</span>
-        <a href="news-turbo.html">Terminal Turbo</a>
+        <a href="/news-turbo">Terminal Turbo</a>
         <span>·</span>
-        <a href="news-fills.html">the fill-accuracy fix</a>
+        <a href="/news-fills">the fill-accuracy fix</a>
       </div>
     </div>
 
     <div class="post-nav">
-      <a class="pnav" href="news-xray.html">
+      <a class="pnav" href="/news-xray">
         <span class="dir">← Newer</span>
         <span class="t">X-Ray: instant account intel on X</span>
       </a>
-      <a class="pnav next" href="news-instant-x.html">
+      <a class="pnav next" href="/news-instant-x">
         <span class="dir">Older →</span>
         <span class="t">Instant X links</span>
       </a>
@@ -296,11 +296,11 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="index.html">Home</a>
-        <a href="news.html">News</a>
-        <a href="streams.html">Live on Twitch</a>
+        <a href="/">Home</a>
+        <a href="/news">News</a>
+        <a href="/streams">Live on Twitch</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
       </div>

--- a/site/news-instant-x.html
+++ b/site/news-instant-x.html
@@ -42,17 +42,17 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="index.html#bubbles">Chart bubbles</a>
-      <a href="index.html#replay">Replay</a>
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html" aria-current="page">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/#bubbles">Chart bubbles</a>
+      <a href="/#replay">Replay</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news" aria-current="page">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -61,7 +61,7 @@
 <article>
   <header class="post-hero">
     <div class="wrap-read">
-      <a class="post-back" href="news.html"><span aria-hidden="true">←</span> All updates</a>
+      <a class="post-back" href="/news"><span aria-hidden="true">←</span> All updates</a>
       <div class="post-meta">
         <span class="ver-chip">v2.4.0</span>
         <span class="ver-chip">v2.5.0</span>
@@ -183,7 +183,7 @@
 
     <p>The same release also went after the work PaperTrench was making your terminal do — a feed-demand gate so that switching it off donates zero parsing to the host page, chips that stop thrashing layout at volume peaks, and a dashboard that stopped re-reading everything every four seconds. Plus receipts: the popup now counts your warm versus cold opens and shows your median routing time, measured locally.</p>
 
-    <p><a href="news-turbo.html">The full Terminal Turbo story →</a></p>
+    <p><a href="/news-turbo">The full Terminal Turbo story →</a></p>
 
     <!-- ---------- patch notes ---------- -->
     <div class="pn-panel reveal">
@@ -206,7 +206,7 @@
           <p>While enabled, PaperTrench keeps ONE muted background x.com tab as the viewer (closed again if you turn the toggle off before using it). Two passive bridge scripts now load on x.com — they act only on PaperTrench's own messages and are pinned by a manifest test to never include the trading engine or overlay. Zero new extension permissions, no telemetry, no remote switches. Ctrl/Cmd/middle-click always bypasses the feature and opens a real background tab.</p>
         </div>
       </div>
-      <div class="pn-foot"><span>Also in v2.4.0:</span> <a href="news.html#v2-4-0">a real off switch for the whole extension</a></div>
+      <div class="pn-foot"><span>Also in v2.4.0:</span> <a href="/news#v2-4-0">a real off switch for the whole extension</a></div>
     </div>
 
     <div class="pn-panel reveal">
@@ -229,7 +229,7 @@
           <p>A dead link used to trigger a pointless "repair": X rendered "this post doesn't exist", the extension mistook that for a failed hop, and full-reloaded the same dead URL — seconds to say the same thing. The error page now counts as arrival (a deleted launch tweet is signal — see it instantly); only an error that was already on screen before the hop still falls through to the repair. Also pinned by test: classification never rewrites a link — path and query pass through byte-for-byte, so PaperTrench can never be the reason a tweet looks dead.</p>
         </div>
       </div>
-      <div class="pn-foot"><span>Also in v2.5.0:</span> <a href="news-flex.html">the Flex Pack share card</a></div>
+      <div class="pn-foot"><span>Also in v2.5.0:</span> <a href="/news-flex">the Flex Pack share card</a></div>
     </div>
 
     <div class="pn-panel reveal">
@@ -248,15 +248,15 @@
           <p>With no registered viewer, a clicked X link — post, profile, or a token's community — used to open a separate tab right next to the x.com tab you already kept. Now PaperTrench adopts your existing X tab as the viewer and routes into it, community links included. It will never claim a tab you are looking at, a pinned tab, or one playing audio — and adopted tabs are yours: toggling the feature off never closes them.</p>
         </div>
       </div>
-      <div class="pn-foot"><span>Also in v2.7.0:</span> <a href="news-fills.html">fills land on the chart you are looking at</a></div>
+      <div class="pn-foot"><span>Also in v2.7.0:</span> <a href="/news-fills">fills land on the chart you are looking at</a></div>
     </div>
 
     <div class="post-nav">
-      <a class="pnav" href="news-flex.html">
+      <a class="pnav" href="/news-flex">
         <span class="dir">← Newer</span>
         <span class="t">The Flex Pack share card</span>
       </a>
-      <a class="pnav next" href="news-fees.html">
+      <a class="pnav next" href="/news-fees">
         <span class="dir">Older →</span>
         <span class="t">Fees &amp; costs emulation</span>
       </a>
@@ -268,11 +268,11 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="index.html">Home</a>
-        <a href="news.html">News</a>
-        <a href="streams.html">Live on Twitch</a>
+        <a href="/">Home</a>
+        <a href="/news">News</a>
+        <a href="/streams">Live on Twitch</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/PERMISSIONS.md" target="_blank" rel="noopener">Permissions audit</a>
       </div>

--- a/site/news-perps.html
+++ b/site/news-perps.html
@@ -29,17 +29,17 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="index.html#bubbles">Chart bubbles</a>
-      <a href="index.html#replay">Replay</a>
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html" aria-current="page">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/#bubbles">Chart bubbles</a>
+      <a href="/#replay">Replay</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news" aria-current="page">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -48,7 +48,7 @@
 <article>
   <header class="post-hero">
     <div class="wrap-read">
-      <a class="post-back" href="news.html"><span aria-hidden="true">←</span> All updates</a>
+      <a class="post-back" href="/news"><span aria-hidden="true">←</span> All updates</a>
       <div class="post-meta">
         <span class="ver-chip major">v3.0.0</span>
         <span class="tag feature">Feature</span>
@@ -116,11 +116,11 @@
     <p><b>Fixed, among others:</b> extension updates no longer leave open tabs half-dead; Birdeye pages work again after their address-format change; the entry line stopped teleporting on fomo charts; the Game tab actually shows up; and a fresh install keeps what your first save wrote.</p>
 
     <div class="post-nav">
-      <a class="pnav" href="news.html">
+      <a class="pnav" href="/news">
         <span class="dir">← All updates</span>
         <span class="t">The full release archive</span>
       </a>
-      <a class="pnav next" href="news-chain.html">
+      <a class="pnav next" href="/news-chain">
         <span class="dir">Older →</span>
         <span class="t">We shipped a build that broke the chain, and said so</span>
       </a>
@@ -132,11 +132,11 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="index.html">Home</a>
-        <a href="news.html">News</a>
-        <a href="streams.html">Live on Twitch</a>
+        <a href="/">Home</a>
+        <a href="/news">News</a>
+        <a href="/streams">Live on Twitch</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/DEFECTS.md" target="_blank" rel="noopener">Defect register</a>
       </div>

--- a/site/news-quickedit.html
+++ b/site/news-quickedit.html
@@ -46,17 +46,17 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="index.html#bubbles">Chart bubbles</a>
-      <a href="index.html#replay">Replay</a>
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html" aria-current="page">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/#bubbles">Chart bubbles</a>
+      <a href="/#replay">Replay</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news" aria-current="page">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -65,7 +65,7 @@
 <article>
   <header class="post-hero">
     <div class="wrap-read">
-      <a class="post-back" href="news.html"><span aria-hidden="true">←</span> All updates</a>
+      <a class="post-back" href="/news"><span aria-hidden="true">←</span> All updates</a>
       <div class="post-meta">
         <span class="ver-chip">v2.9.0</span>
         <span class="tag feature">Feature</span>
@@ -122,7 +122,7 @@
 
     <p>The <b>✎</b> in the panel header now opens a compact inline editor right on the trading tab: buy presets, sell percents, and fee / gas / tip / slippage. You are still looking at the candle while you retune.</p>
 
-    <p>Your costs also ride visibly under the buy row as <b>Fee / Gas / Tip / Slip</b> chips, click-to-edit, in both modes. <a href="news-fees.html">Costs only teach you something if you can see them</a> — a fee model buried three screens away is a fee model you forget is on.</p>
+    <p>Your costs also ride visibly under the buy row as <b>Fee / Gas / Tip / Slip</b> chips, click-to-edit, in both modes. <a href="/news-fees">Costs only teach you something if you can see them</a> — a fee model buried three screens away is a fee model you forget is on.</p>
 
     <div class="callout">
       <span class="co-label">One rulebook, three places</span>
@@ -149,7 +149,7 @@
 
     <p>Neither of these is a new capability. Every setting was already editable and focus mode already existed. What changed is the distance between a decision and the control that acts on it — and in this market that distance is the feature.</p>
 
-    <p>It is also the second round of feedback from the same person, shipped the same day. <a href="news.html">Most of the archive</a> looks like that.</p>
+    <p>It is also the second round of feedback from the same person, shipped the same day. <a href="/news">Most of the archive</a> looks like that.</p>
 
     <!-- ---------- patch notes ---------- -->
     <div class="pn-panel reveal">
@@ -170,18 +170,18 @@
       </div>
       <div class="pn-foot">
         <span>Full history:</span>
-        <a href="news.html#v2-9-0">this release in the archive</a>
+        <a href="/news#v2-9-0">this release in the archive</a>
         <span>·</span>
         <a href="https://github.com/OnlyTerp/papertrench/releases/tag/v2.9.0" target="_blank" rel="noopener">release notes on GitHub ↗</a>
       </div>
     </div>
 
     <div class="post-nav">
-      <a class="pnav" href="news.html">
+      <a class="pnav" href="/news">
         <span class="dir">← Newer</span>
         <span class="t">This is the latest — see all updates</span>
       </a>
-      <a class="pnav next" href="news-chain.html">
+      <a class="pnav next" href="/news-chain">
         <span class="dir">Older →</span>
         <span class="t">We shipped a build that broke the chain</span>
       </a>
@@ -193,11 +193,11 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="index.html">Home</a>
-        <a href="news.html">News</a>
-        <a href="streams.html">Live on Twitch</a>
+        <a href="/">Home</a>
+        <a href="/news">News</a>
+        <a href="/streams">Live on Twitch</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
       </div>

--- a/site/news-rugguard.html
+++ b/site/news-rugguard.html
@@ -46,17 +46,17 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="index.html#bubbles">Chart bubbles</a>
-      <a href="index.html#replay">Replay</a>
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html" aria-current="page">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/#bubbles">Chart bubbles</a>
+      <a href="/#replay">Replay</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news" aria-current="page">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -65,7 +65,7 @@
 <article>
   <header class="post-hero">
     <div class="wrap-read">
-      <a class="post-back" href="news.html"><span aria-hidden="true">←</span> All updates</a>
+      <a class="post-back" href="/news"><span aria-hidden="true">←</span> All updates</a>
       <div class="post-meta">
         <span class="ver-chip">v2.8.0</span>
         <span class="tag feature">Feature</span>
@@ -83,7 +83,7 @@
 
     <div class="callout" style="border-left-color:#ff8a80">
       <span class="co-label" style="color:#ff8a80">Do not run the v2.8.0 build</span>
-      <p>These features are real and they work — but the v2.8.0 <em>zip</em> shipped with attestation-chain recording broken and has been superseded. Everything described here is in the current release. <a href="news-chain.html">What happened, in full →</a></p>
+      <p>These features are real and they work — but the v2.8.0 <em>zip</em> shipped with attestation-chain recording broken and has been superseded. Everything described here is in the current release. <a href="/news-chain">What happened, in full →</a></p>
     </div>
 
     <h2>The armed buy that never fired (F-34)</h2>
@@ -93,7 +93,7 @@
     <p>Except on a coin 39 seconds old, the first trusted price never landed. Two independent reasons, stacked:</p>
 
     <ul>
-      <li><b>No aggregator had indexed it.</b> Dexscreener and Jupiter cannot quote a coin they have not seen. PaperTrench <a href="news-v2.html">refuses to invent a price</a>, so it correctly refused — and kept refusing, forever.</li>
+      <li><b>No aggregator had indexed it.</b> Dexscreener and Jupiter cannot quote a coin they have not seen. PaperTrench <a href="/news-v2">refuses to invent a price</a>, so it correctly refused — and kept refusing, forever.</li>
       <li><b>The chart was in MCap mode.</b> Every close was rejected as "no implied supply", because turning a market-cap value into a price needs a supply figure nobody had published yet.</li>
     </ul>
 
@@ -177,7 +177,7 @@
       <li><b>Threshold and off-switch live in Settings → Guardrails.</b></li>
     </ul>
 
-    <p>This is the one guardrail that ships <b>ON</b> — every other <a href="news-the-after.html">Guardrail</a> is opt-in — because the maintainer asked for exactly that. Practising the reflex of checking concentration before you buy is worth more than the friction costs.</p>
+    <p>This is the one guardrail that ships <b>ON</b> — every other <a href="/news-the-after">Guardrail</a> is opt-in — because the maintainer asked for exactly that. Practising the reflex of checking concentration before you buy is worth more than the friction costs.</p>
 
     <!-- ---------- patch notes ---------- -->
     <div class="pn-panel reveal">
@@ -199,23 +199,23 @@
         </div>
         <div class="pn-item">
           <h4>Also aboard, unmentioned at the time</h4>
-          <p>The Turbo receipts card, and half of an in-flight attestation-chain migration that broke chain recording on this build. <a href="news-chain.html">Both are covered here →</a></p>
+          <p>The Turbo receipts card, and half of an in-flight attestation-chain migration that broke chain recording on this build. <a href="/news-chain">Both are covered here →</a></p>
         </div>
       </div>
       <div class="pn-foot">
         <span>Full history:</span>
-        <a href="news.html#v2-8-0">this release in the archive</a>
+        <a href="/news#v2-8-0">this release in the archive</a>
         <span>·</span>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/CHANGELOG.md" target="_blank" rel="noopener">CHANGELOG.md ↗</a>
       </div>
     </div>
 
     <div class="post-nav">
-      <a class="pnav" href="news-chain.html">
+      <a class="pnav" href="/news-chain">
         <span class="dir">← Newer</span>
         <span class="t">We shipped a build that broke the chain</span>
       </a>
-      <a class="pnav next" href="news-turbo.html">
+      <a class="pnav next" href="/news-turbo">
         <span class="dir">Older →</span>
         <span class="t">Terminal Turbo: every terminal, warm</span>
       </a>
@@ -227,11 +227,11 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="index.html">Home</a>
-        <a href="news.html">News</a>
-        <a href="streams.html">Live on Twitch</a>
+        <a href="/">Home</a>
+        <a href="/news">News</a>
+        <a href="/streams">Live on Twitch</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/DEFECTS.md" target="_blank" rel="noopener">Defect register</a>
       </div>

--- a/site/news-the-after.html
+++ b/site/news-the-after.html
@@ -42,17 +42,17 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="index.html#bubbles">Chart bubbles</a>
-      <a href="index.html#replay">Replay</a>
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html" aria-current="page">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/#bubbles">Chart bubbles</a>
+      <a href="/#replay">Replay</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news" aria-current="page">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -61,7 +61,7 @@
 <article>
   <header class="post-hero">
     <div class="wrap-read">
-      <a class="post-back" href="news.html"><span aria-hidden="true">←</span> All updates</a>
+      <a class="post-back" href="/news"><span aria-hidden="true">←</span> All updates</a>
       <div class="post-meta">
         <span class="ver-chip">v2.1.0</span>
         <span class="tag feature">Feature</span>
@@ -205,18 +205,18 @@
       </div>
       <div class="pn-foot">
         <span>Full history:</span>
-        <a href="news.html#v2-1-0">this release in the archive</a>
+        <a href="/news#v2-1-0">this release in the archive</a>
         <span>·</span>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/GRADUATION.md" target="_blank" rel="noopener">the graduation bar ↗</a>
       </div>
     </div>
 
     <div class="post-nav">
-      <a class="pnav" href="news-fees.html">
+      <a class="pnav" href="/news-fees">
         <span class="dir">← Newer</span>
         <span class="t">Fees &amp; costs emulation</span>
       </a>
-      <a class="pnav next" href="news-v2.html">
+      <a class="pnav next" href="/news-v2">
         <span class="dir">Older →</span>
         <span class="t">Out of alpha: 139 defects published</span>
       </a>
@@ -228,11 +228,11 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="index.html">Home</a>
-        <a href="news.html">News</a>
-        <a href="streams.html">Live on Twitch</a>
+        <a href="/">Home</a>
+        <a href="/news">News</a>
+        <a href="/streams">Live on Twitch</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/GRADUATION.md" target="_blank" rel="noopener">Graduation criteria</a>
       </div>

--- a/site/news-trench-rank.html
+++ b/site/news-trench-rank.html
@@ -38,17 +38,17 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="index.html#bubbles">Chart bubbles</a>
-      <a href="index.html#replay">Replay</a>
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html" aria-current="page">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/#bubbles">Chart bubbles</a>
+      <a href="/#replay">Replay</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news" aria-current="page">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -57,7 +57,7 @@
 <article>
   <header class="post-hero">
     <div class="wrap-read">
-      <a class="post-back" href="news.html"><span aria-hidden="true">←</span> All updates</a>
+      <a class="post-back" href="/news"><span aria-hidden="true">←</span> All updates</a>
       <div class="post-meta">
         <span class="ver-chip">v2.10.0</span>
         <span class="tag feature">Feature</span>
@@ -111,11 +111,11 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="index.html">Home</a>
-        <a href="news.html">News</a>
-        <a href="streams.html">Live on Twitch</a>
+        <a href="/">Home</a>
+        <a href="/news">News</a>
+        <a href="/streams">Live on Twitch</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
       </div>

--- a/site/news-turbo.html
+++ b/site/news-turbo.html
@@ -49,17 +49,17 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="index.html#bubbles">Chart bubbles</a>
-      <a href="index.html#replay">Replay</a>
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html" aria-current="page">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/#bubbles">Chart bubbles</a>
+      <a href="/#replay">Replay</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news" aria-current="page">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -68,7 +68,7 @@
 <article>
   <header class="post-hero">
     <div class="wrap-read">
-      <a class="post-back" href="news.html"><span aria-hidden="true">←</span> All updates</a>
+      <a class="post-back" href="/news"><span aria-hidden="true">←</span> All updates</a>
       <div class="post-meta">
         <span class="ver-chip">v2.7.0</span>
         <span class="tag speed">Speed</span>
@@ -84,7 +84,7 @@
 
   <div class="wrap-read post-body">
 
-    <p class="post-lede"><a href="news-instant-x.html">Instant X links</a> proved the idea: keep one tab warm, route clicks into it as in-page navigations, and a 3.5-second cold boot becomes about half a second. Traders used it and immediately asked the obvious question — why only X?</p>
+    <p class="post-lede"><a href="/news-instant-x">Instant X links</a> proved the idea: keep one tab warm, route clicks into it as in-page navigations, and a 3.5-second cold boot becomes about half a second. Traders used it and immediately asked the obvious question — why only X?</p>
 
     <p>No good reason. So Turbo is that same mechanism applied to every destination you actually click from a terminal, plus a second, quieter half that nobody demos: making PaperTrench cost the host page less.</p>
 
@@ -179,7 +179,7 @@
 
     <p>Every speed claim in this write-up is the kind of thing a product can assert and never prove. So the popup counts your <b>warm versus cold opens</b> and shows your <b>median routing time</b> — measured on your machine, stored locally, never sent anywhere.</p>
 
-    <p>If Turbo is not helping you, your own receipts will say so. That is a strange thing to ship, and it is the same principle as everything else here: <a href="news-xray.html">a number you can check</a> beats a number you are asked to believe.</p>
+    <p>If Turbo is not helping you, your own receipts will say so. That is a strange thing to ship, and it is the same principle as everything else here: <a href="/news-xray">a number you can check</a> beats a number you are asked to believe.</p>
 
     <div class="callout">
       <span class="co-label">What we did not ship</span>
@@ -189,7 +189,7 @@
 
     <h2>Also in this release</h2>
 
-    <p>Turbo shipped inside the biggest batch so far. The headline item is a correctness fix, not a speed one — <a href="news-fills.html">paper fills could land up to ~13% away from the chart you clicked</a> — and the batch also carried the <a href="news-flex.html">floating Flex composer</a>, an <a href="news-xray.html">X-Ray dock fix</a>, quick settings in the popup, and a positions bar that waits for slow-painting site headers to settle instead of ending up underneath them.</p>
+    <p>Turbo shipped inside the biggest batch so far. The headline item is a correctness fix, not a speed one — <a href="/news-fills">paper fills could land up to ~13% away from the chart you clicked</a> — and the batch also carried the <a href="/news-flex">floating Flex composer</a>, an <a href="/news-xray">X-Ray dock fix</a>, quick settings in the popup, and a positions bar that waits for slow-painting site headers to settle instead of ending up underneath them.</p>
 
     <p><b>Note on versions:</b> v2.7.0 was tagged and published mid-batch, before the last five commits landed — so that build is missing Instant terminal links, the dashboard refresh fix, and the X-Ray dock fix. <b>v2.7.1 is the complete batch.</b> If you grabbed 2.7.0, update.</p>
 
@@ -232,7 +232,7 @@
       </div>
       <div class="pn-foot">
         <span>Full history:</span>
-        <a href="news.html#v2-7-0">this release in the archive</a>
+        <a href="/news#v2-7-0">this release in the archive</a>
         <span>·</span>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/CHANGELOG.md" target="_blank" rel="noopener">CHANGELOG.md ↗</a>
       </div>
@@ -253,11 +253,11 @@
     </div>
 
     <div class="post-nav">
-      <a class="pnav" href="news.html">
+      <a class="pnav" href="/news">
         <span class="dir">← Newer</span>
         <span class="t">This is the latest — see all updates</span>
       </a>
-      <a class="pnav next" href="news-fills.html">
+      <a class="pnav next" href="/news-fills">
         <span class="dir">Older →</span>
         <span class="t">The "instant +14%" is dead</span>
       </a>
@@ -269,11 +269,11 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="index.html">Home</a>
-        <a href="news.html">News</a>
-        <a href="streams.html">Live on Twitch</a>
+        <a href="/">Home</a>
+        <a href="/news">News</a>
+        <a href="/streams">Live on Twitch</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/PERMISSIONS.md" target="_blank" rel="noopener">Permissions audit</a>
       </div>

--- a/site/news-v2.html
+++ b/site/news-v2.html
@@ -35,17 +35,17 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="index.html#bubbles">Chart bubbles</a>
-      <a href="index.html#replay">Replay</a>
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html" aria-current="page">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/#bubbles">Chart bubbles</a>
+      <a href="/#replay">Replay</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news" aria-current="page">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -54,7 +54,7 @@
 <article>
   <header class="post-hero">
     <div class="wrap-read">
-      <a class="post-back" href="news.html"><span aria-hidden="true">←</span> All updates</a>
+      <a class="post-back" href="/news"><span aria-hidden="true">←</span> All updates</a>
       <div class="post-meta">
         <span class="ver-chip major">v2.0.0</span>
         <span class="tag fix">Fix</span>
@@ -158,7 +158,7 @@
 
     <p>A structured bug-report form, a nine-site release QA matrix, a preflight script that gates every tag, a full permissions audit (<code>docs/PERMISSIONS.md</code>), and the public roadmap plus defect register linked from the README.</p>
 
-    <p>Everything since — <a href="news-the-after.html">The After</a>, <a href="news-fees.html">fees</a>, <a href="news-flex.html">the Flex Pack</a>, <a href="news-xray.html">X-Ray</a>, <a href="news-fills.html">the vault-feed fix</a> — has shipped through that path.</p>
+    <p>Everything since — <a href="/news-the-after">The After</a>, <a href="/news-fees">fees</a>, <a href="/news-flex">the Flex Pack</a>, <a href="/news-xray">X-Ray</a>, <a href="/news-fills">the vault-feed fix</a> — has shipped through that path.</p>
 
     <!-- ---------- patch notes ---------- -->
     <div class="pn-panel reveal">
@@ -203,11 +203,11 @@
     </div>
 
     <div class="post-nav">
-      <a class="pnav" href="news-the-after.html">
+      <a class="pnav" href="/news-the-after">
         <span class="dir">← Newer</span>
         <span class="t">The After: what happened once you sold</span>
       </a>
-      <a class="pnav next" href="news.html">
+      <a class="pnav next" href="/news">
         <span class="dir">Older →</span>
         <span class="t">The full release archive</span>
       </a>
@@ -219,11 +219,11 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="index.html">Home</a>
-        <a href="news.html">News</a>
-        <a href="streams.html">Live on Twitch</a>
+        <a href="/">Home</a>
+        <a href="/news">News</a>
+        <a href="/streams">Live on Twitch</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/DEFECTS.md" target="_blank" rel="noopener">Defect register</a>
       </div>

--- a/site/news-xray.html
+++ b/site/news-xray.html
@@ -56,17 +56,17 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="index.html#bubbles">Chart bubbles</a>
-      <a href="index.html#replay">Replay</a>
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html" aria-current="page">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/#bubbles">Chart bubbles</a>
+      <a href="/#replay">Replay</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news" aria-current="page">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -75,7 +75,7 @@
 <article>
   <header class="post-hero">
     <div class="wrap-read">
-      <a class="post-back" href="news.html"><span aria-hidden="true">←</span> All updates</a>
+      <a class="post-back" href="/news"><span aria-hidden="true">←</span> All updates</a>
       <div class="post-meta">
         <span class="ver-chip">v2.6.0</span>
         <span class="tag feature">Feature</span>
@@ -282,7 +282,7 @@
       </div>
       <div class="pn-foot">
         <span>Full history:</span>
-        <a href="news.html#v2-6-0">this release in the archive</a>
+        <a href="/news#v2-6-0">this release in the archive</a>
         <span>·</span>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/CHANGELOG.md" target="_blank" rel="noopener">CHANGELOG.md ↗</a>
       </div>
@@ -307,18 +307,18 @@
       </div>
       <div class="pn-foot">
         <span>Also in that batch:</span>
-        <a href="news-turbo.html">Terminal Turbo</a>
+        <a href="/news-turbo">Terminal Turbo</a>
         <span>·</span>
-        <a href="news-fills.html">the fill-accuracy fix</a>
+        <a href="/news-fills">the fill-accuracy fix</a>
       </div>
     </div>
 
     <div class="post-nav">
-      <a class="pnav" href="news-fills.html">
+      <a class="pnav" href="/news-fills">
         <span class="dir">← Newer</span>
         <span class="t">The "instant +14%" is dead</span>
       </a>
-      <a class="pnav next" href="news-flex.html">
+      <a class="pnav next" href="/news-flex">
         <span class="dir">Older →</span>
         <span class="t">The Flex Pack share card</span>
       </a>
@@ -330,11 +330,11 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="index.html">Home</a>
-        <a href="news.html">News</a>
-        <a href="streams.html">Live on Twitch</a>
+        <a href="/">Home</a>
+        <a href="/news">News</a>
+        <a href="/streams">Live on Twitch</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/PERMISSIONS.md" target="_blank" rel="noopener">Permissions audit</a>
       </div>

--- a/site/news.html
+++ b/site/news.html
@@ -32,17 +32,17 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="index.html#bubbles">Chart bubbles</a>
-      <a href="index.html#replay">Replay</a>
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html" aria-current="page">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/#bubbles">Chart bubbles</a>
+      <a href="/#replay">Replay</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news" aria-current="page">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -92,7 +92,7 @@
 
     <div class="feat-grid">
 
-      <a class="feat-card lead a-violet reveal" href="news-perps.html">
+      <a class="feat-card lead a-violet reveal" href="/news-perps">
         <div class="feat-meta">
           <span class="ver-chip major">v3.0.0</span>
           <span class="tag feature">Feature</span>
@@ -103,7 +103,7 @@
         <span class="go">Read the full story <span class="arr" aria-hidden="true">→</span></span>
       </a>
 
-      <a class="feat-card a-green reveal" href="news-chain.html">
+      <a class="feat-card a-green reveal" href="/news-chain">
         <div class="feat-meta">
           <span class="ver-chip">v2.8.1</span>
           <span class="tag fix">Fix</span>
@@ -115,7 +115,7 @@
         <span class="go">Read the full story <span class="arr" aria-hidden="true">→</span></span>
       </a>
 
-      <a class="feat-card a-red reveal" href="news-rugguard.html">
+      <a class="feat-card a-red reveal" href="/news-rugguard">
         <div class="feat-meta">
           <span class="ver-chip">v2.8.0</span>
           <span class="tag feature">Feature</span>
@@ -126,7 +126,7 @@
         <span class="go">Read the full story <span class="arr" aria-hidden="true">→</span></span>
       </a>
 
-      <a class="feat-card a-orange reveal d1" href="news-quickedit.html">
+      <a class="feat-card a-orange reveal d1" href="/news-quickedit">
         <div class="feat-meta">
           <span class="ver-chip">v2.9.0</span>
           <span class="tag feature">Feature</span>
@@ -137,7 +137,7 @@
         <span class="go">Read the full story <span class="arr" aria-hidden="true">→</span></span>
       </a>
 
-      <a class="feat-card a-violet reveal" href="news-turbo.html">
+      <a class="feat-card a-violet reveal" href="/news-turbo">
         <div class="feat-meta">
           <span class="ver-chip">v2.7.0</span>
           <span class="tag speed">Speed</span>
@@ -148,7 +148,7 @@
         <span class="go">Read the full story <span class="arr" aria-hidden="true">→</span></span>
       </a>
 
-      <a class="feat-card a-violet reveal" href="news-xray.html">
+      <a class="feat-card a-violet reveal" href="/news-xray">
         <div class="feat-meta">
           <span class="ver-chip">v2.6.0</span>
           <span class="tag feature">Feature</span>
@@ -159,7 +159,7 @@
         <span class="go">Read the full story <span class="arr" aria-hidden="true">→</span></span>
       </a>
 
-      <a class="feat-card a-blue reveal" href="news-instant-x.html">
+      <a class="feat-card a-blue reveal" href="/news-instant-x">
         <div class="feat-meta">
           <span class="ver-chip">v2.4.0</span>
           <span class="tag speed">Speed</span>
@@ -170,7 +170,7 @@
         <span class="go">Read the full story <span class="arr" aria-hidden="true">→</span></span>
       </a>
 
-      <a class="feat-card a-red reveal d1" href="news-fills.html">
+      <a class="feat-card a-red reveal d1" href="/news-fills">
         <div class="feat-meta">
           <span class="ver-chip">v2.7.0</span>
           <span class="tag fix">Fix</span>
@@ -181,7 +181,7 @@
         <span class="go">Read the full story <span class="arr" aria-hidden="true">→</span></span>
       </a>
 
-      <a class="feat-card a-green reveal" href="news-the-after.html">
+      <a class="feat-card a-green reveal" href="/news-the-after">
         <div class="feat-meta">
           <span class="ver-chip">v2.1.0</span>
           <span class="tag feature">Feature</span>
@@ -192,7 +192,7 @@
         <span class="go">Read the full story <span class="arr" aria-hidden="true">→</span></span>
       </a>
 
-      <a class="feat-card a-orange reveal d1" href="news-flex.html">
+      <a class="feat-card a-orange reveal d1" href="/news-flex">
         <div class="feat-meta">
           <span class="ver-chip">v2.5.0</span>
           <span class="tag feature">Feature</span>
@@ -203,7 +203,7 @@
         <span class="go">Read the full story <span class="arr" aria-hidden="true">→</span></span>
       </a>
 
-      <a class="feat-card a-green reveal" href="news-fees.html">
+      <a class="feat-card a-green reveal" href="/news-fees">
         <div class="feat-meta">
           <span class="ver-chip">v2.2.0</span>
           <span class="tag feature">Feature</span>
@@ -214,7 +214,7 @@
         <span class="go">Read the full story <span class="arr" aria-hidden="true">→</span></span>
       </a>
 
-      <a class="feat-card a-orange reveal d1" href="news-v2.html">
+      <a class="feat-card a-orange reveal d1" href="/news-v2">
         <div class="feat-meta">
           <span class="ver-chip major">v2.0.0</span>
           <span class="tag fix">Fix</span>
@@ -264,11 +264,11 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="index.html">Home</a>
-        <a href="news.html">News</a>
-        <a href="streams.html">Live on Twitch</a>
+        <a href="/">Home</a>
+        <a href="/news">News</a>
+        <a href="/streams">Live on Twitch</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
       </div>

--- a/site/news.js
+++ b/site/news.js
@@ -275,7 +275,7 @@
       major: true,
       title: 'Paper perps on Hyperliquid and Jupiter — a second asset class',
       blurb: 'Leverage on the venues you actually use, with the venue’s own fees, funding and liquidation math. A major version because a liquidation can take your whole position — a different lesson from spot, announced as one.',
-      article: 'news-perps.html',
+      article: '/news-perps',
       points: [
         '<b>Four numbers before every entry.</b> Position size, the fee to open, your liquidation price with how far away it is, and what the position costs per hour to hold. On Hyperliquid the liquidation distance is also shown in ATRs — “1.3 ATR away on the 5m” says whether ordinary noise reaches it.',
         '<b>Real venue costs, not a house average.</b> Hyperliquid’s own taker/maker fees and hourly funding at the live rate; Jupiter’s 6 bps base fee, its price-impact fee, and hourly borrow. If the venue’s live rate can’t be read, the ticket won’t open — a perp without funding is a fantasy where leverage is free.',
@@ -320,7 +320,7 @@
       tags: ['feature'],
       title: 'Trench Rank — discipline is now the game',
       blurb: 'Every closed round gets a process grade, S to F. A disciplined red grades S. A lucky win grades F — and gets called lucky.',
-      article: 'news-trench-rank.html',
+      article: '/news-trench-rank',
       points: [
         '<b>Process grades on every closed round.</b> Graded on your plan, your exit, your sizing, and whether the entry was revenge — never on P&amp;L. The grade lands on the close toast, the rounds table, the calendar, and the share card.',
         '<b>The Trench Rank ladder.</b> Six tiers from Fresh Meat to Graduated, staged over the graduation criteria with live progress bars. The summit is the graduation bar itself — the game ends on purpose.',
@@ -344,7 +344,7 @@
       tags: ['feature'],
       title: 'The quick fixes live on the trading tab',
       blurb: 'Lev round two — the quick fixes now live where he meant them.',
-      article: 'news-quickedit.html',
+      article: '/news-quickedit',
       points: [
         '<b>A pencil on the trading panel.</b> The ✎ in the panel header opens a compact inline editor right on the trading tab — buy presets, sell percents, and fee/gas/tip/slippage — with the same validation rulebook the dashboard and popup use. Your costs ride as Fee/Gas/Tip/Slip chips under the buy row, click-to-edit, in both modes.',
         '<b>Focus mode is genuinely Axiom-compact now.</b> No balance card (cash rides inline on the Buy label, refreshed per fill), and while one-tap presets are on the big BUY button gets out of the way — the preset chips ARE the buttons, and Enter in the amount box buys. Instant-buy off keeps the button.',
@@ -355,7 +355,7 @@
       tags: ['fix', 'security'],
       title: 'The attestation chain lands whole',
       blurb: 'Update from v2.8.0 — it matters this time.',
-      article: 'news-chain.html',
+      article: '/news-chain',
       points: [
         '<b>v2.8.0 shipped with attestation-chain recording broken.</b> That release accidentally carried half of an in-flight migration: fills asked for the new segmented chain store, which was not aboard, so every paper fill made on v2.8.0 failed to append to your local attestation chain. The honest "could not be added to the verification chain" toast fired each time — the failure was visible, the chain simply could not record.',
         '<b>Your wallet, balances and P&amp;L were never affected.</b> The chain is the tamper-evidence layer used by leaderboard verification. On v2.8.1 the chain records again; fills made during the v2.8.0 window are simply absent from it, and the verify panel shows that gap honestly rather than pretending it is not there.',
@@ -369,7 +369,7 @@
       tags: ['feature', 'fix'],
       title: 'Fresh launches are snipeable, and the rug guard',
       blurb: 'Two from the maintainer\'s own trench session, same screenshot. Note: this build shipped with attestation-chain recording broken — use v2.8.1 or later.',
-      article: 'news-rugguard.html',
+      article: '/news-rugguard',
       points: [
         '<b>"ARMED … ON FIRST QUOTE" actually fires now (F-34).</b> A 39-second-old pump.fun coin used to strand the armed buy forever: no aggregator had indexed it, and with the chart in MCap mode every close was refused as "no implied supply".',
         '<b>The bonding curve is read directly.</b> The moment a pending coin looks like pump.fun, PaperTrench finds its bonding curve on chain (derived from the mint, verified against five live mainnet curves), identifies the real mint from the curve\'s reserve account, and streams the curve as a live CHAIN ⚡ feed with an immediate first quote. The fill is chain state, not a guess.',
@@ -393,8 +393,8 @@
       title: 'Community batch #2, Terminal Turbo, X-Ray dock, the floating Flex composer',
       blurb: 'The biggest batch so far: the fill-accuracy bug that could book you instant fake profit, then a whole pass on making every terminal feel fast.',
       articles: [
-        { href: 'news-fills.html', label: 'The fill-accuracy story' },
-        { href: 'news-turbo.html', label: 'Terminal Turbo, in full' },
+        { href: '/news-fills', label: 'The fill-accuracy story' },
+        { href: '/news-turbo', label: 'Terminal Turbo, in full' },
       ],
       points: [
         '<b>Fills land on the chart you are looking at — the "instant +14%" is dead.</b> On migrated (AMM) tokens the on-chain feed could lose one side of every trade it watched, filling paper trades up to ~13% away from the live chart. The stale-frame guard is now per-vault, and every fill is reconciled against the price on your screen (F-33).',
@@ -415,7 +415,7 @@
       tags: ['feature'],
       title: 'X-Ray — instant account intel on X',
       blurb: 'Open any X profile or post and the intel is already on screen: bio and handle changes, every contract address the account has posted, and who big follows them.',
-      article: 'news-xray.html',
+      article: '/news-xray',
       points: [
         '<b>Contract addresses posted.</b> Every CA the account has put out, dated by the post itself, newest first, click to copy — with a flag if one is sitting in the bio right now.',
         '<b>Bio, name and @handle changes,</b> counted separately, because a display-name swap and a rename are different tells.',
@@ -429,7 +429,7 @@
       tags: ['fix', 'feature'],
       title: 'Resize un-stick, four corners, Flex on the closed card',
       blurb: 'Three fixes straight from the maintainer taking a live trade.',
-      article: 'news-flex.html',
+      article: '/news-flex',
       points: [
         '<b>The resize grip can never stick again.</b> A cancelled gesture used to leave the drag latched, so the panel kept resizing with every mouse move. Pointer capture now guarantees a terminal event.',
         '<b>Resize from any corner.</b> All four corners are grips, anchored so the panel grows in the direction you drag.',
@@ -442,7 +442,7 @@
       tags: ['feature'],
       title: 'Share an open position — the still-holding flex',
       blurb: 'The real terminals card an OPEN position and ours only carded closed rounds.',
-      article: 'news-flex.html',
+      article: '/news-flex',
       points: [
         '<b>Live open positions on the Overview carry a Share button.</b> The card states OPEN, the middle column reads POSITION at the last recorded mark, and the journey line claims no EXIT that has not happened.',
         'USD figures appear only where fills and marks genuinely recorded them — same gallery, same Customize / Download / Copy, same un-removable branding.',
@@ -453,7 +453,7 @@
       tags: ['feature', 'speed'],
       title: 'The Flex Pack share card',
       blurb: 'Flex your PaperTrench P&L — with the one thing that can never come off the card.',
-      article: 'news-flex.html',
+      article: '/news-flex',
       points: [
         '<b>Terminal-grade share composer:</b> a huge ◎ SOL P&L, Invested / Returned / P&L% columns with honest USD sub-lines, the entry→exit→held journey line, and an observed-only After line no other terminal can print.',
         '<b>Backgrounds, yours.</b> Five built-in looks plus your own uploads — max 2 MB each, ten stored, saved between sessions.',
@@ -467,7 +467,7 @@
       tags: ['feature', 'speed'],
       title: 'Instant X links + a real off switch',
       blurb: 'Traders vet a coin by clicking its X link — and then wait ~3.5 seconds for a cold tab to load.',
-      article: 'news-instant-x.html',
+      article: '/news-instant-x',
       points: [
         '<b>Instant X links (opt-in).</b> X posts and profiles clicked on any supported trading site open in a kept-warm viewer tab via an in-page navigation: about half a second, and every follow-up click lands in the same already-hydrated tab.',
         '<b>Hover prefetch.</b> Rest the cursor on an X link for a tenth of a second and the hidden viewer starts navigating there before you click.',
@@ -491,7 +491,7 @@
       tags: ['feature'],
       title: 'Fees & costs emulation',
       blurb: 'Make paper fills cost what real fills cost.',
-      article: 'news-fees.html',
+      article: '/news-fees',
       points: [
         '<b>A new settings card models the FULL cost of a real fill:</b> the platform percentage, plus a flat priority fee (gas) and a bribe/tip per transaction — the costs that dominate small entries.',
         '<b>The accounting is honest end to end.</b> Flat costs join the cost basis on buys and reduce net proceeds on sells, so per-sell P&L, rounds, the calendar, the equity curve and the verification chain all include them.',
@@ -504,7 +504,7 @@
       tags: ['feature', 'fix'],
       title: 'The After, Guardrails, CSV export, onboarding',
       blurb: 'The practice loop gets its most important missing organ, plus training wheels and data ownership.',
-      article: 'news-the-after.html',
+      article: '/news-the-after',
       points: [
         '<b>The After.</b> Every closed round watches its coin for the following hour and records what ACTUALLY happened after your exit — observed extremes, sample counts, no interpolation.',
         '<b>Guardrails (training wheels).</b> Opt-in and enforced at buy time: a tilt breaker, a max position size, and a daily loss limit.',
@@ -528,7 +528,7 @@
       tags: ['fix', 'feature', 'security', 'speed'],
       title: 'Out of alpha',
       blurb: 'A four-track code audit produced a public, ranked defect register of 139 findings. v2.0.0 closes 116 of them — every one with a regression test that fails on the old code.',
-      article: 'news-v2.html',
+      article: '/news-v2',
       points: [
         '<b>Fills can no longer execute at stale prices.</b> Chain state, then the click-time snapshot, then a fresh page tick, then one resolver refresh — beyond that the trade is refused with a visible reason. The old default path filled at prices up to 10 seconds old.',
         '<b>The average-entry line finally holds your entry</b> instead of riding the candle on market-cap charts.',

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -17,17 +17,17 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="index.html#bubbles">Chart bubbles</a>
-      <a href="index.html#replay">Replay</a>
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/#bubbles">Chart bubbles</a>
+      <a href="/#replay">Replay</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -92,11 +92,11 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="index.html">Home</a>
-        <a href="news.html">News</a>
-        <a href="streams.html">Live on Twitch</a>
+        <a href="/">Home</a>
+        <a href="/news">News</a>
+        <a href="/streams">Live on Twitch</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>
       </div>

--- a/site/profile.html
+++ b/site/profile.html
@@ -361,18 +361,18 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
       <!-- A profile has no nav entry of its own — it is a leaf under the
            leaderboard. aria-current="true" says "you are inside this section";
            aria-current="page" would claim this IS leaderboard.html. -->
-      <a href="leaderboard.html" aria-current="true">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/leaderboard" aria-current="true">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -439,7 +439,7 @@
         <div class="ar-pane-head">
           <span class="glyph" style="color:var(--orange2)">▤</span><span id="sprints-h" role="heading" aria-level="2">Sprint history</span>
           <span class="spacer"></span>
-          <a class="ar-note" style="color:var(--orange2)" href="sprint.html">This week →</a>
+          <a class="ar-note" style="color:var(--orange2)" href="/sprint">This week →</a>
         </div>
         <div id="sprints"></div>
       </section>
@@ -473,13 +473,13 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="sprint.html">Weekly Sprint</a>
-        <a href="duels.html">Duels</a>
-        <a href="clans.html">Clans</a>
-        <a href="news.html">News &amp; patch notes</a>
-        <a href="privacy.html">Privacy</a>
+        <a href="/sprint">Weekly Sprint</a>
+        <a href="/duels">Duels</a>
+        <a href="/clans">Clans</a>
+        <a href="/news">News &amp; patch notes</a>
+        <a href="/privacy">Privacy</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener">Leaderboard protocol</a>
       </div>
@@ -1381,7 +1381,7 @@
     if (!asked) {
       showState(L.empty('🔎', 'This page needs a name.',
         'Profiles open from the board — every ranked row on the ' +
-        '<a href="leaderboard.html" style="color:var(--orange2)">leaderboard</a> links to the record ' +
+        '<a href="/leaderboard" style="color:var(--orange2)">leaderboard</a> links to the record ' +
         'behind it. There is no directory to browse, because a directory would list people who have ' +
         'submitted nothing.'));
       heroEl.innerHTML = '';
@@ -1420,7 +1420,7 @@
       showState(L.empty('🏴', 'Nobody trades under that name here.',
         '<strong>@' + esc(asked) + '</strong> has no PaperTrench profile. Profiles are minted by ' +
         'evidence rather than by signup: sign in on the ' +
-        '<a href="leaderboard.html" style="color:var(--orange2)">leaderboard</a>, submit a ' +
+        '<a href="/leaderboard" style="color:var(--orange2)">leaderboard</a>, submit a ' +
         'hash-chained record, and this page writes itself. Until then there is nothing to show, and ' +
         'nothing gets invented to fill the gap.'));
       return;

--- a/site/sprint.html
+++ b/site/sprint.html
@@ -143,15 +143,15 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html" aria-current="page">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint" aria-current="page">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -225,9 +225,9 @@
           <span id="board-h">This week's standings</span>
           <span class="spacer"></span>
           <div class="ar-tabs">
-            <a class="ar-tab" href="leaderboard.html">All-time</a>
-            <a class="ar-tab" href="sprint.html" aria-current="page">This week</a>
-            <a class="ar-tab" href="duels.html">Duels</a>
+            <a class="ar-tab" href="/leaderboard">All-time</a>
+            <a class="ar-tab" href="/sprint" aria-current="page">This week</a>
+            <a class="ar-tab" href="/duels">Duels</a>
           </div>
         </div>
         <!-- The row list is deliberately NOT a live region: announcing two
@@ -318,13 +318,13 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="sprint.html">Weekly Sprint</a>
-        <a href="duels.html">Duels</a>
-        <a href="clans.html">Clans</a>
-        <a href="news.html">News &amp; patch notes</a>
-        <a href="privacy.html">Privacy</a>
+        <a href="/sprint">Weekly Sprint</a>
+        <a href="/duels">Duels</a>
+        <a href="/clans">Clans</a>
+        <a href="/news">News &amp; patch notes</a>
+        <a href="/privacy">Privacy</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener">Leaderboard protocol</a>
       </div>
@@ -464,7 +464,7 @@
     const isYou = youHandle && String(item.handle).toLowerCase() === youHandle.toLowerCase();
     return `<a class="ar-row${isYou ? ' is-you' : ''}"
        style="animation-delay:${Math.min(index * 26, 320)}ms"
-       href="profile.html?handle=${encodeURIComponent(item.handle)}">
+       href="/profile?handle=${encodeURIComponent(item.handle)}">
       <span class="pos">#${index + 1}</span>
       <span class="ar-who">
         ${face(item)}
@@ -489,7 +489,7 @@
         <div style="min-width:0">
           <div style="font-weight:800">@${esc(session.handle)}</div>
           <a class="ar-note" style="color:var(--orange2)"
-             href="profile.html?handle=${encodeURIComponent(session.handle)}">View public profile →</a>
+             href="/profile?handle=${encodeURIComponent(session.handle)}">View public profile →</a>
         </div>
       </div>`;
   }
@@ -533,7 +533,7 @@
           closed inside this window yet — which is not a scolding, it is just Monday doing its job.
           One round opened and closed since the window started puts you on the board.</p>
         <p class="ar-note" style="margin-top:10px">Trade the way you normally would, then sync your
-          record on the <a href="leaderboard.html">leaderboard page</a>. The sprint reads the same
+          record on the <a href="/leaderboard">leaderboard page</a>. The sprint reads the same
           chain, so there is nothing extra to submit and no separate entry to miss.</p>`;
       return;
     }
@@ -591,7 +591,7 @@
     if (!entries.length) {
       boardEl.innerHTML = L.empty('🏁',
         'Nobody has closed a round this week yet.',
-        'The window is open and the board is blank — someone has to go first. One round opened <em>and</em> closed since Monday puts your name here. Trade the way you normally do, then sync your record on the <a href="leaderboard.html">leaderboard page</a>; the sprint reads the same chain. Nothing appears on this board until a real round has been committed and replayed — there are no seeded names and no demo week.');
+        'The window is open and the board is blank — someone has to go first. One round opened <em>and</em> closed since Monday puts your name here. Trade the way you normally do, then sync your record on the <a href="/leaderboard">leaderboard page</a>; the sprint reads the same chain. Nothing appears on this board until a real round has been committed and replayed — there are no seeded names and no demo week.');
       statusEl.textContent = 'No entries yet this week.';
       formulaEl.innerHTML = '<p class="ar-note">No entries yet, so there is no week to run it over. The worked example appears with the first ranked round.</p>';
       renderYou(session, entries);

--- a/site/streamer-signup.html
+++ b/site/streamer-signup.html
@@ -80,17 +80,17 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="index.html#bubbles">Chart bubbles</a>
-      <a href="index.html#replay">Replay</a>
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a href="/#bubbles">Chart bubbles</a>
+      <a href="/#replay">Replay</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -100,7 +100,7 @@
   <div class="wrap">
     <span class="sec-kicker k-twitch reveal">Streamer application</span>
     <h1 class="reveal d1">Get featured <span class="grad-twitch">in the trench.</span></h1>
-    <p class="hero-sub reveal d2">Any creator running the PaperTrench Challenge can apply. Approved streamers get a card on the <a href="streams.html" style="color:var(--twitch2)">streams page</a>, the Streamer role in Discord, and automated live alerts.</p>
+    <p class="hero-sub reveal d2">Any creator running the PaperTrench Challenge can apply. Approved streamers get a card on the <a href="/streams" style="color:var(--twitch2)">streams page</a>, the Streamer role in Discord, and automated live alerts.</p>
   </div>
 </header>
 
@@ -193,7 +193,7 @@
         <div class="big">🎥</div>
         <h2>Application received</h2>
         <p>A moderator will look it over and reach out on Discord. If you're approved, your card goes up on the streams page automatically.</p>
-        <a class="btn btn-primary" href="streams.html">Back to the streams page</a>
+        <a class="btn btn-primary" href="/streams">Back to the streams page</a>
       </div>
     </div>
 
@@ -207,7 +207,7 @@
       </div>
       <div class="side-card">
         <h3>Before you apply</h3>
-        <div class="perk"><span class="ico">⬇</span><span>Install the extension from the <a href="index.html#install" style="color:var(--orange2)">install guide</a> — free, open source, no signup.</span></div>
+        <div class="perk"><span class="ico">⬇</span><span>Install the extension from the <a href="/#install" style="color:var(--orange2)">install guide</a> — free, open source, no signup.</span></div>
         <div class="perk"><span class="ico">🟩</span><span>Open <code>🎥 Stream overlay</code> from the popup and add it to OBS with a chroma key.</span></div>
         <div class="perk"><span class="ico">⛓️</span><span>Your record is a <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener" style="color:var(--orange2)">hash-chained</a> paper wallet — same rules as everyone.</span></div>
       </div>
@@ -218,13 +218,13 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="index.html">Home</a>
-        <a href="streams.html">Watch Live</a>
-        <a href="news.html">News</a>
+        <a href="/">Home</a>
+        <a href="/streams">Watch Live</a>
+        <a href="/news">News</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
-        <a href="privacy.html">Privacy</a>
+        <a href="/privacy">Privacy</a>
       </div>
     </div>
     <div class="foot-note">Paper trading only · not financial advice · every P&amp;L on this site is simulated, and proud of it.</div>

--- a/site/streamer-signup.html
+++ b/site/streamer-signup.html
@@ -1,0 +1,236 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PaperTrench — Streamer application</title>
+<meta name="description" content="Apply to become a featured PaperTrench streamer — get the Streamer role in Discord, an announcement to the community, automated live alerts, and a card on the streams page.">
+<meta property="og:title" content="PaperTrench — Streamer application">
+<meta property="og:description" content="Apply to join the PaperTrench Challenge roster. Featured on the streams page, Streamer role in Discord, and automated live alerts.">
+<meta property="og:image" content="https://papertrench.com/assets/video-poster.jpg">
+<link rel="icon" type="image/png" href="assets/icon128.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;700;800&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+<link rel="stylesheet" href="arena.css">
+<style>
+  :root { --twitch: #9146FF; --twitch2: #bf94ff; }
+  .k-twitch { color: var(--twitch2); background: rgba(145,70,255,0.10); border: 1px solid rgba(145,70,255,0.32); }
+  .hero.compact { padding: 140px 0 24px; }
+  .hero.compact h1 { font-size: clamp(34px, 5vw, 58px); }
+  .grad-twitch {
+    background: linear-gradient(100deg, var(--twitch2) 10%, var(--twitch) 70%);
+    -webkit-background-clip: text; background-clip: text; color: transparent;
+  }
+
+  .apply-wrap { display: grid; grid-template-columns: minmax(0,1fr) 320px; gap: 28px; align-items: start; padding-bottom: 90px; }
+  @media (max-width: 900px) { .apply-wrap { grid-template-columns: 1fr; } }
+
+  .apply-card {
+    background: var(--panel); border: 1px solid var(--line2);
+    border-radius: var(--radius); padding: 26px 28px 28px;
+  }
+  .apply-card h2 { font-size: 19px; font-weight: 800; margin-bottom: 6px; }
+  .apply-card .lede { font-size: 13.5px; color: var(--muted); line-height: 1.6; margin-bottom: 22px; }
+
+  .req { color: var(--orange2); font-weight: 800; }
+  .ar-field { margin-bottom: 17px; }
+  textarea.ar-input { min-height: 96px; resize: vertical; line-height: 1.55; }
+  select.ar-input { appearance: none; cursor: pointer;
+    background-image: linear-gradient(45deg, transparent 50%, var(--muted) 50%), linear-gradient(135deg, var(--muted) 50%, transparent 50%);
+    background-position: calc(100% - 17px) 51%, calc(100% - 12px) 51%;
+    background-size: 5px 5px, 5px 5px; background-repeat: no-repeat; padding-right: 34px; }
+  select.ar-input option { background: var(--panel2); color: var(--text); }
+
+  /* A field whose answer becomes public says so where the answer is typed —
+     not in a policy page nobody opens. */
+  .vis {
+    display: inline-flex; align-items: center; gap: 5px; margin-left: 8px;
+    font-size: 9.5px; font-weight: 800; letter-spacing: 0.8px; text-transform: uppercase;
+    padding: 2px 7px; border-radius: 999px; vertical-align: middle;
+  }
+  .vis.public { color: var(--twitch2); background: rgba(145,70,255,0.12); border: 1px solid rgba(145,70,255,0.3); }
+  .vis.private { color: var(--green2); background: rgba(52,211,153,0.10); border: 1px solid rgba(52,211,153,0.28); }
+
+  .apply-actions { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; margin-top: 22px; }
+  .form-msg { font-size: 13px; font-weight: 650; line-height: 1.55; }
+  .form-msg.err { color: #ff8a80; }
+  .form-msg.ok { color: var(--green2); }
+
+  .done { text-align: center; padding: 26px 10px 10px; }
+  .done .big { font-size: 44px; margin-bottom: 12px; }
+  .done h2 { font-size: 21px; margin-bottom: 8px; }
+  .done p { font-size: 14px; color: var(--muted); line-height: 1.65; max-width: 420px; margin: 0 auto 20px; }
+
+  .side { display: grid; gap: 16px; position: sticky; top: 96px; }
+  @media (max-width: 900px) { .side { position: static; } }
+  .side-card { background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius); padding: 20px 22px; }
+  .side-card h3 { font-size: 12px; font-weight: 800; letter-spacing: 1.3px; text-transform: uppercase; color: var(--dim); margin-bottom: 13px; }
+  .perk { display: flex; gap: 11px; align-items: flex-start; margin-bottom: 13px; font-size: 13.5px; line-height: 1.5; }
+  .perk:last-child { margin-bottom: 0; }
+  .perk .ico { font-size: 16px; flex: none; line-height: 1.35; }
+  .perk b { font-weight: 750; }
+  .perk span { color: var(--muted); }
+</style>
+</head>
+<body>
+<div class="bg-glow"></div>
+<div class="bg-grid"></div>
+
+<nav>
+  <div class="nav-inner">
+    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <div class="nav-links">
+      <a href="index.html#bubbles">Chart bubbles</a>
+      <a href="index.html#replay">Replay</a>
+      <a href="leaderboard.html">Leaderboard</a>
+      <a href="sprint.html">Sprint</a>
+      <a href="duels.html">Duels</a>
+      <a href="clans.html">Clans</a>
+      <a href="news.html">News</a>
+      <a href="index.html#install">Install</a>
+      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
+    </div>
+  </div>
+</nav>
+
+<header class="hero compact">
+  <div class="wrap">
+    <span class="sec-kicker k-twitch reveal">Streamer application</span>
+    <h1 class="reveal d1">Get featured <span class="grad-twitch">in the trench.</span></h1>
+    <p class="hero-sub reveal d2">Any creator running the PaperTrench Challenge can apply. Approved streamers get a card on the <a href="streams.html" style="color:var(--twitch2)">streams page</a>, the Streamer role in Discord, and automated live alerts.</p>
+  </div>
+</header>
+
+<section style="padding-top:14px">
+  <div class="wrap apply-wrap">
+    <div class="apply-card reveal">
+      <!-- The form and the thank-you state swap in place; JS toggles them. -->
+      <div id="formPane">
+        <h2>Tell us about your channel</h2>
+        <p class="lede">Fields marked <span class="req">*</span> are required. We review applications by hand — expect a Discord DM once a moderator has looked at yours.</p>
+
+        <form id="applyForm" novalidate>
+          <label class="ar-field">
+            <span class="lbl">Creator / Channel Name <span class="req">*</span><span class="vis public">Public</span></span>
+            <input class="ar-input" type="text" name="name" maxlength="40" autocomplete="off" required>
+          </label>
+
+          <label class="ar-field">
+            <span class="lbl">Main Channel URL <span class="req">*</span><span class="vis public">Public</span></span>
+            <input class="ar-input" type="text" name="channelUrl" maxlength="200" inputmode="url" placeholder="twitch.tv/yourname" autocomplete="off" required>
+            <span class="hint">Twitch, YouTube, Kick, etc. Twitch channels can be embedded and played directly on the streams page.</span>
+          </label>
+
+          <label class="ar-field">
+            <span class="lbl">Discord Username <span class="req">*</span><span class="vis private">Private</span></span>
+            <input class="ar-input" type="text" name="discord" maxlength="40" autocomplete="off" required>
+            <span class="hint">So we can assign your Streamer role and post your live alerts.</span>
+          </label>
+
+          <label class="ar-field">
+            <span class="lbl">Average Live Viewers <span class="req">*</span><span class="vis private">Private</span></span>
+            <select class="ar-input" name="viewers" required>
+              <option value="" selected disabled>Choose one…</option>
+              <option>1–10</option>
+              <option>10–50</option>
+              <option>50–100</option>
+              <option>100+</option>
+            </select>
+          </label>
+
+          <label class="ar-field">
+            <span class="lbl">One line about your stream<span class="vis public">Public</span></span>
+            <input class="ar-input" type="text" name="blurb" maxlength="160" autocomplete="off" placeholder="Weekend challenge runs — fresh eyes on the trenches.">
+            <span class="hint">This is the blurb printed on your roster card if you're approved. Leave it blank and your card just shows your name.</span>
+          </label>
+
+          <label class="ar-field">
+            <span class="lbl">Anything else you'd like us to know?<span class="vis private">Private</span></span>
+            <textarea class="ar-input" name="notes" maxlength="1000" rows="4"></textarea>
+            <span class="hint">Only the moderator team reads this — it is never shown on the site.</span>
+          </label>
+
+          <label class="ar-field">
+            <span class="lbl">Preferred Contact Method<span class="vis private">Private</span></span>
+            <select class="ar-input" name="contactMethod">
+              <option value="" selected>No preference</option>
+              <option>Discord DM</option>
+              <option>Email</option>
+              <option>Twitter/X</option>
+              <option>Other</option>
+            </select>
+          </label>
+
+          <label class="ar-field">
+            <span class="lbl">Profile link<span class="vis private">Private</span></span>
+            <input class="ar-input" type="text" name="contactLink" maxlength="200" inputmode="url" autocomplete="off" placeholder="https://…">
+            <span class="hint">If you picked Discord, Twitter/X, or Other above, drop the profile link here.</span>
+          </label>
+
+          <label class="ar-field">
+            <span class="lbl">Best Day/Time to Reach You<span class="vis private">Private</span></span>
+            <input class="ar-input" type="text" name="bestTime" maxlength="100" autocomplete="off" placeholder="Weeknights after 8pm ET">
+          </label>
+
+          <div class="apply-actions">
+            <button class="ar-btn primary" type="submit" id="submitBtn">Send application</button>
+            <span class="form-msg" id="formMsg" role="status" aria-live="polite"></span>
+          </div>
+        </form>
+
+        <p class="ar-note" style="margin-top:20px">
+          What we store: the answers above, and a one-way hash of your IP for
+          abuse triage. Your Discord handle and contact details are visible only
+          to PaperTrench moderators — never published, never sold. Ask a
+          moderator to delete your application and it's gone.
+        </p>
+      </div>
+
+      <div class="done" id="donePane" hidden>
+        <div class="big">🎥</div>
+        <h2>Application received</h2>
+        <p>A moderator will look it over and reach out on Discord. If you're approved, your card goes up on the streams page automatically.</p>
+        <a class="btn btn-primary" href="streams.html">Back to the streams page</a>
+      </div>
+    </div>
+
+    <aside class="side reveal d1">
+      <div class="side-card">
+        <h3>What approved streamers get</h3>
+        <div class="perk"><span class="ico">🌟</span><span><b>Streamer role</b> in the PaperTrench Discord.</span></div>
+        <div class="perk"><span class="ico">📢</span><span><b>Featured announcement</b> introducing you to the community.</span></div>
+        <div class="perk"><span class="ico">🔴</span><span><b>Automated live notifications</b> when you go live.</span></div>
+        <div class="perk"><span class="ico">🎬</span><span><b>A card on the streams page</b> — Twitch channels play inline.</span></div>
+      </div>
+      <div class="side-card">
+        <h3>Before you apply</h3>
+        <div class="perk"><span class="ico">⬇</span><span>Install the extension from the <a href="index.html#install" style="color:var(--orange2)">install guide</a> — free, open source, no signup.</span></div>
+        <div class="perk"><span class="ico">🟩</span><span>Open <code>🎥 Stream overlay</code> from the popup and add it to OBS with a chroma key.</span></div>
+        <div class="perk"><span class="ico">⛓️</span><span>Your record is a <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener" style="color:var(--orange2)">hash-chained</a> paper wallet — same rules as everyone.</span></div>
+      </div>
+    </aside>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    <div class="foot-inner">
+      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <div class="foot-links">
+        <a href="index.html">Home</a>
+        <a href="streams.html">Watch Live</a>
+        <a href="news.html">News</a>
+        <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
+        <a href="privacy.html">Privacy</a>
+      </div>
+    </div>
+    <div class="foot-note">Paper trading only · not financial advice · every P&amp;L on this site is simulated, and proud of it.</div>
+  </div>
+</footer>
+
+<script src="streamer-signup.js"></script>
+</body>
+</html>

--- a/site/streamer-signup.js
+++ b/site/streamer-signup.js
@@ -1,0 +1,131 @@
+/* PaperTrench — streamer application form.
+ *
+ * Posts to the leaderboard Worker (POST /api/streamer/apply), which validates
+ * with the same core module the server tests exercise. Nothing is validated
+ * *only* here: this file exists to tell the applicant what went wrong without
+ * a round trip, and the server re-checks every field regardless.
+ *
+ * Operator notes: docs/STREAMS.md.
+ */
+(() => {
+  'use strict';
+
+  // Same API origin as arena.js — see the comment there on why the API lives
+  // on workers.dev rather than api.papertrench.com.
+  const API = 'https://papertrench-api.onerobby.workers.dev';
+
+  const $ = (id) => document.getElementById(id);
+  const form = $('applyForm');
+  const msg = $('formMsg');
+  const button = $('submitBtn');
+
+  /* ---------- scroll reveal (same behaviour as main.js) ---------- */
+  const io = new IntersectionObserver((entries) => {
+    for (const e of entries) {
+      if (e.isIntersecting) { e.target.classList.add('in'); io.unobserve(e.target); }
+    }
+  }, { threshold: 0.12 });
+  document.querySelectorAll('.reveal').forEach((el) => io.observe(el));
+
+  /**
+   * Server reason code -> what the applicant should read.
+   *
+   * The server returns codes, not sentences, so the wording lives here and can
+   * change without touching validation. An unmapped code must still say
+   * something true, which is what the fallback is for — never a blank toast
+   * that leaves someone staring at a form that did nothing.
+   */
+  const REASONS = {
+    'name-required': 'Add the name your channel goes by.',
+    'name-blocked': 'That channel name can’t be used here.',
+    'blurb-blocked': 'That one-line blurb can’t be used here.',
+    'channel-url-invalid': 'That channel link doesn’t look like a URL — try twitch.tv/yourname.',
+    'discord-required': 'Add your Discord username so we can reach you.',
+    'viewers-invalid': 'Pick an average viewer count.',
+    'contact-method-invalid': 'Pick a contact method from the list.',
+    'contact-link-invalid': 'That profile link doesn’t look like a URL.',
+    'already-applied': 'That channel already has an application in the queue.',
+    'rate-limited': 'Too many applications from this connection. Try again in an hour.',
+  };
+
+  const FIELD_FOR = {
+    'name-required': 'name',
+    'name-blocked': 'name',
+    'blurb-blocked': 'blurb',
+    'channel-url-invalid': 'channelUrl',
+    'discord-required': 'discord',
+    'viewers-invalid': 'viewers',
+    'contact-method-invalid': 'contactMethod',
+    'contact-link-invalid': 'contactLink',
+    'already-applied': 'channelUrl',
+  };
+
+  function say(text, kind) {
+    msg.textContent = text || '';
+    msg.className = 'form-msg' + (kind ? ' ' + kind : '');
+  }
+
+  /** Put the cursor where the problem is — a message alone makes them hunt. */
+  function focusField(reason) {
+    const name = FIELD_FOR[reason];
+    if (!name) return;
+    const el = form.elements[name];
+    if (el && el.focus) el.focus();
+  }
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (button.disabled) return;
+
+    const data = Object.fromEntries(new FormData(form).entries());
+
+    // A cheap local pass on the three required text fields, so the obvious
+    // omission does not cost a round trip. The server owns the real verdict.
+    if (!String(data.name || '').trim()) {
+      say(REASONS['name-required'], 'err'); focusField('name-required'); return;
+    }
+    if (!String(data.channelUrl || '').trim()) {
+      say(REASONS['channel-url-invalid'], 'err'); focusField('channel-url-invalid'); return;
+    }
+    if (!String(data.discord || '').trim()) {
+      say(REASONS['discord-required'], 'err'); focusField('discord-required'); return;
+    }
+    if (!String(data.viewers || '').trim()) {
+      say(REASONS['viewers-invalid'], 'err'); focusField('viewers-invalid'); return;
+    }
+
+    button.disabled = true;
+    say('Sending…');
+
+    let status = 0;
+    let body = null;
+    try {
+      const res = await fetch(API + '/api/streamer/apply', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      status = res.status;
+      body = await res.json().catch(() => null);
+    } catch (_) {
+      // Network-level failure: the application did NOT land, and saying
+      // anything else would be inventing an outcome.
+      button.disabled = false;
+      say('Couldn’t reach the server. Check your connection and try again.', 'err');
+      return;
+    }
+
+    if (status >= 200 && status < 300 && body && body.ok) {
+      $('formPane').hidden = true;
+      $('donePane').hidden = false;
+      $('donePane').scrollIntoView({ behavior: 'smooth', block: 'center' });
+      return;
+    }
+
+    button.disabled = false;
+    const reason = body && body.reason;
+    say(REASONS[reason] || 'Something went wrong sending that — try again in a moment.', 'err');
+    focusField(reason);
+  });
+})();

--- a/site/streams.html
+++ b/site/streams.html
@@ -141,17 +141,17 @@
 
 <nav>
   <div class="nav-inner">
-    <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
-      <a href="index.html#bubbles">Chart bubbles</a>
-      <a href="index.html#replay">Replay</a>
-      <a href="leaderboard.html">Leaderboard</a>
-      <a href="sprint.html">Sprint</a>
-      <a href="duels.html">Duels</a>
-      <a href="clans.html">Clans</a>
-      <a href="news.html">News</a>
-      <a href="index.html#install">Install</a>
-      <a class="nav-live" href="streams.html" title="Watch streamers run the PaperTrench Challenge live on Twitch" aria-current="page"><span class="dot"></span>Watch Live</a>
+      <a href="/#bubbles">Chart bubbles</a>
+      <a href="/#replay">Replay</a>
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/news">News</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch" aria-current="page"><span class="dot"></span>Watch Live</a>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -162,7 +162,7 @@
   <div class="wrap">
     <span class="live-count reveal"><span class="dot"></span><span id="liveCountLabel">The PaperTrench Challenge</span></span>
     <h1 class="reveal d1">Watch the trenches.<br><span class="grad-twitch">Live on Twitch.</span></h1>
-    <p class="hero-sub reveal d2">Streamers are grinding the PaperTrench leaderboard live — real charts, real launches, <strong>fake money</strong> — and the best verified records win <strong>giveaways</strong>. Watch how they read the trenches, then <a href="index.html#install" style="color:var(--orange2)">run your own paper wallet</a> and try to beat them.</p>
+    <p class="hero-sub reveal d2">Streamers are grinding the PaperTrench leaderboard live — real charts, real launches, <strong>fake money</strong> — and the best verified records win <strong>giveaways</strong>. Watch how they read the trenches, then <a href="/#install" style="color:var(--orange2)">run your own paper wallet</a> and try to beat them.</p>
   </div>
 </header>
 
@@ -202,7 +202,7 @@
         <h3>Streaming the challenge? Get featured here.</h3>
         <p>Any Twitch streamer running PaperTrench can join the roster — we link your stream on this page and you compete for the giveaway with a record nobody can fake.</p>
       </div>
-      <a class="btn btn-twitch" id="signupBtn" href="streamer-signup.html">Sign up as a streamer</a>
+      <a class="btn btn-twitch" id="signupBtn" href="/streamer-signup">Sign up as a streamer</a>
     </div>
   </div>
 </section>
@@ -231,7 +231,7 @@
       <p class="sec-sub reveal d2" style="margin:0 auto">PaperTrench ships a built-in <b>stream overlay</b> — a chroma-key window with your live equity, session P&amp;L, win rate, and open positions. It updates the instant you trade, and it's permanently marked <b>PAPER</b> so your chat always knows it's simulated.</p>
     </div>
     <div class="install-steps">
-      <div class="step reveal"><div class="n">01</div><h4>Install PaperTrench</h4><p>Grab the extension from the <a href="index.html#install" style="color:var(--orange2)">install guide</a> — free, open source, no signup.</p></div>
+      <div class="step reveal"><div class="n">01</div><h4>Install PaperTrench</h4><p>Grab the extension from the <a href="/#install" style="color:var(--orange2)">install guide</a> — free, open source, no signup.</p></div>
       <div class="step reveal d1"><div class="n">02</div><h4>Open the overlay</h4><p>Click the PaperTrench icon → <code>🎥 Stream overlay</code>. A capture-ready window opens on a green screen.</p></div>
       <div class="step reveal d2"><div class="n">03</div><h4>Add it to OBS</h4><p>Sources → <code>Window Capture</code> → pick the overlay → add a <code>Chroma Key</code> filter. Defaults just work.</p></div>
       <div class="step reveal d3"><div class="n">04</div><h4>Go live &amp; sign up</h4><p>Trade with the overlay on screen and <a href="#streamers" style="color:var(--orange2)">join the roster</a> to get featured on this page.</p></div>
@@ -245,7 +245,7 @@
     <span class="hero-badge reveal"><span class="dot"></span>Paper money. Real competition.</span>
     <h2 class="reveal d1" style="margin-top:24px">Think you can out-trade them?<br><span class="grad-twitch">Prove it on the board.</span></h2>
     <div class="hero-ctas reveal d3" style="margin-top:36px;justify-content:center">
-      <a class="btn btn-primary" href="index.html#install">⬇ Get PaperTrench</a>
+      <a class="btn btn-primary" href="/#install">⬇ Get PaperTrench</a>
       <a class="btn btn-ghost" href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener">How verification works</a>
     </div>
   </div>
@@ -254,10 +254,10 @@
 <footer>
   <div class="wrap">
     <div class="foot-inner">
-      <a class="nav-logo" href="index.html"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
       <div class="foot-links">
-        <a href="index.html">Home</a>
-        <a href="news.html">News</a>
+        <a href="/">Home</a>
+        <a href="/news">News</a>
         <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener">Leaderboard protocol</a>
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/LICENSE" target="_blank" rel="noopener">MIT License</a>

--- a/site/streams.html
+++ b/site/streams.html
@@ -202,7 +202,7 @@
         <h3>Streaming the challenge? Get featured here.</h3>
         <p>Any Twitch streamer running PaperTrench can join the roster — we link your stream on this page and you compete for the giveaway with a record nobody can fake.</p>
       </div>
-      <a class="btn btn-twitch" id="signupBtn" href="#" target="_blank" rel="noopener">Sign up as a streamer</a>
+      <a class="btn btn-twitch" id="signupBtn" href="streamer-signup.html">Sign up as a streamer</a>
     </div>
   </div>
 </section>

--- a/site/streams.js
+++ b/site/streams.js
@@ -1,9 +1,11 @@
 /* PaperTrench — Live on Twitch page.
  *
- * The roster comes from two places: the hand-maintained STREAMERS list below,
- * plus (optionally) the approval Google Sheet behind the signup form — rows
- * whose Approved column says yes appear on the page without a deploy. Full
- * setup walkthrough: docs/STREAMS.md.
+ * The roster is the hand-maintained STREAMERS list below, plus every
+ * application a moderator approved in site/admin.html (read from the Worker's
+ * /api/streamer/roster). A legacy Google-Sheet CSV is still honoured for
+ * deployments that ran on one, but nothing new needs it. Neither remote source
+ * can break the page: on any failure the hand-maintained list stands alone.
+ * Full setup walkthrough: docs/STREAMS.md.
  */
 (() => {
   'use strict';
@@ -37,20 +39,20 @@
     },
   ];
 
-  // Where "Sign up as a streamer" points. Paste the Google Form share link
-  // here once it exists (see docs/STREAMS.md); until then, GitHub issues.
-  const SIGNUP_URL = 'https://github.com/OnlyTerp/papertrench/issues/new'
-    + '?title=' + encodeURIComponent('Streamer signup: <your twitch handle>')
-    + '&body=' + encodeURIComponent(
-      'Twitch channel: https://twitch.tv/\n'
-      + 'When do you stream the challenge?: \n'
-      + 'Anything else we should know?: \n');
+  // Where "Sign up as a streamer" points — the on-site form, which posts to
+  // the leaderboard Worker and lands in the moderator queue (site/admin.html).
+  const SIGNUP_URL = 'streamer-signup.html';
 
-  // Approval-sheet roster (optional). Paste the "Publish to web → CSV" URL of
-  // the Google Sheet behind the signup form and the page pulls every row whose
-  // Approved column says yes — approving a streamer is typing "yes" in a cell,
-  // no deploy needed. Empty string disables it; on any fetch/parse failure the
-  // page just runs on STREAMERS above. Setup walkthrough: docs/STREAMS.md.
+  // The API roster: every application a moderator approved in site/admin.html.
+  // This is the pipeline the signup form feeds, and it needs no configuration —
+  // approving a streamer publishes their card within the 60s edge cache.
+  const API = 'https://papertrench-api.onerobby.workers.dev';
+
+  // Legacy approval-sheet roster (optional, and superseded by the API above).
+  // Paste the "Publish to web → CSV" URL of a Google Sheet and the page pulls
+  // every row whose Approved column says yes. Empty string disables it; on any
+  // fetch/parse failure the page just runs on STREAMERS above. Kept so a
+  // deployment already running on a sheet does not lose its roster on upgrade.
   const ROSTER_CSV_URL = '';
 
   const LIVE_POLL_MS = 60000;
@@ -139,6 +141,39 @@
 
   function findCol(headers, ...needles) {
     return headers.findIndex((h) => needles.some((n) => h.includes(n)));
+  }
+
+  /**
+   * Approved applications from the Worker.
+   *
+   * Same contract as the sheet loader below: enhancement, never load-bearing.
+   * A dead API leaves the hand-maintained STREAMERS list on the page rather
+   * than emptying the roster — an empty grid would state "nobody streams this"
+   * on the strength of a failed fetch.
+   */
+  async function loadApiRoster() {
+    try {
+      const res = await fetch(API + '/api/streamer/roster', { cache: 'no-store' });
+      if (!res.ok) throw new Error('HTTP ' + res.status);
+      const body = await res.json();
+      if (!body || !body.ok || !Array.isArray(body.streamers)) return;
+
+      const seen = new Set(roster.map((s) => s.login));
+      for (const row of body.streamers) {
+        // The server normalizes these, but the page owns what it renders:
+        // re-run the same login rule rather than trusting the shape.
+        const login = normalizeLogin(row && row.login);
+        if (!login || seen.has(login)) continue;
+        seen.add(login);
+        roster.push({
+          login,
+          name: String((row && row.name) || '').trim() || login,
+          blurb: String((row && row.blurb) || '').trim(),
+        });
+      }
+    } catch (err) {
+      console.warn('PaperTrench: roster API unavailable —', err.message);
+    }
   }
 
   async function loadSheetRoster() {
@@ -266,7 +301,7 @@
   const OPEN_SLOTS = 3;
   function openSlot() {
     return `
-        <a class="s-card" href="${esc(SIGNUP_URL)}" target="_blank" rel="noopener"
+        <a class="s-card" href="${esc(SIGNUP_URL)}"
            style="display:block;border-style:dashed;border-color:rgba(145,70,255,0.35)">
           <div class="s-thumb"><div class="ph">?</div></div>
           <div class="s-body">
@@ -348,7 +383,8 @@
     renderGrid();
 
     const before = `${featured}:${roster.length}`;
-    await loadSheetRoster();
+    // Both are optional and independent; neither can fail the page.
+    await Promise.all([loadApiRoster(), loadSheetRoster()]);
     pickFeatured();
     if (`${featured}:${roster.length}` !== before) {
       renderFeatured();

--- a/site/streams.js
+++ b/site/streams.js
@@ -41,7 +41,7 @@
 
   // Where "Sign up as a streamer" points — the on-site form, which posts to
   // the leaderboard Worker and lands in the moderator queue (site/admin.html).
-  const SIGNUP_URL = 'streamer-signup.html';
+  const SIGNUP_URL = '/streamer-signup';
 
   // The API roster: every application a moderator approved in site/admin.html.
   // This is the pipeline the signup form feeds, and it needs no configuration —


### PR DESCRIPTION
> **Stacked on #37.** Base it there — merge that first and this diff reduces to just the URL change. GitHub will retarget this to `main` automatically once #37 lands.

Links now read `/leaderboard` rather than `/leaderboard.html`, across all 26 pages plus the JS that builds links (`arena.js`, `news.js`, `streams.js`).

**No files are renamed and no directories are introduced.** GitHub Pages already resolves `/leaderboard` to `leaderboard.html`. I verified that against production before writing any of it:

| Request | Result |
| --- | --- |
| `/streams` | `200`, byte-identical body hash to `/streams.html` |
| `/index`, `/` | `200` |
| `/definitely-not-a-page` | `404` — so it's real file resolution, not a catch-all |

The `.html` spellings keep working, so **every link anyone has already shared stays good**. This changes which form the site is *built out of*, not which forms resolve.

### Why root-absolute rather than relative

`onlyterp.github.io/papertrench/streams` 301s to `papertrench.com/streams`, preserving the path — so the site only ever serves from a domain root, and `/leaderboard` can't break on the mirror.

Trailing-slash variants 404 (`/streams/` is not a thing), which is the detail that matters for assets: a page is only ever served at `/streams`, so the existing **relative** asset paths (`assets/icon128.png`) still resolve to `/assets/…`. Had `/streams/` resolved, every icon on every page would have 404'd.

### Updated alongside, so the change isn't half-applied

| | |
| --- | --- |
| `scripts/preflight.sh` | `NAV_DESTS` — otherwise the nav check greps for a spelling the site no longer contains and fails **every** page |
| `server/worker/auth.js` | the post-sign-in redirect, which would otherwise put `/leaderboard.html` in the address bar of everyone who logs in |
| `extension/dashboard.js` | six outbound links to the site |
| `docs/STREAMS.md`, `server/DEPLOY.md` | prose referring to the old URLs |

Source-file references are deliberately untouched — `site/streams.html` in a comment is a path, not a link. The conversion excludes any name containing a slash for exactly that reason.

### Verification

- `server/` **185/185**; `extension/` **1720/1721**
- The one failure is `extension/test/perpswiring.test.js`, which fails on `main` before this change and is untouched by it (confirmed on a clean checkout)
- Preflight's nav check passes against the new spellings — 26 pages reach all four destinations
- No leftover `href="*.html"` anywhere in `site/`

One caveat worth knowing: a plain static server (`python -m http.server`) does **not** do extensionless resolution, so local preview needs something that does, or opening the `.html` file directly. Production is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
