### PR TITLE
feat(site): robots.txt + sitemap.xml, with a drift guard

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -59,6 +59,39 @@ done
 [ -z "$NAV_MISSING" ] || fail "nav is missing destinations —$NAV_MISSING"
 echo "nav OK ($(grep -lc 'class="nav-links"' site/*.html | wc -l) pages reach $NAV_DESTS)"
 
+# Every public page must be in sitemap.xml, or deliberately named as excluded.
+#
+# A sitemap is the one file that rots without any symptom: pages get added, the
+# sitemap stays as it was, and nothing anywhere reports that search engines are
+# being handed a stale map. The failure is invisible until someone wonders why a
+# page never appeared in results. So the exclusions are enumerated HERE rather
+# than left implicit — adding a page forces a decision about it.
+#
+#   admin            noindex — moderator queue
+#   clan/duel/profile parameterised; without a query string they are empty states
+#   404              error page
+SITEMAP_SKIP="admin clan duel profile 404"
+SITEMAP_MISSING=""
+for page in site/*.html; do
+  slug=$(basename "$page" .html)
+  case " $SITEMAP_SKIP " in *" $slug "*) continue ;; esac
+  # index is published as the bare origin, every other page as /<slug>.
+  if [ "$slug" = "index" ]; then want="<loc>https://papertrench.com/</loc>"
+  else want="<loc>https://papertrench.com/$slug</loc>"; fi
+  grep -qF "$want" site/sitemap.xml || SITEMAP_MISSING="$SITEMAP_MISSING $slug"
+done
+[ -z "$SITEMAP_MISSING" ] || fail "sitemap.xml is missing pages —$SITEMAP_MISSING"
+
+# ...and the reverse: a <loc> whose page was deleted or renamed points crawlers
+# at a 404, which costs more than the missing entry above.
+SITEMAP_STALE=""
+for loc in $(sed -n 's,.*<loc>https://papertrench\.com/\([a-z0-9-]*\)</loc>.*,\1,p' site/sitemap.xml); do
+  [ -z "$loc" ] && continue   # the bare origin, which is index.html
+  [ -f "site/$loc.html" ] || SITEMAP_STALE="$SITEMAP_STALE $loc"
+done
+[ -z "$SITEMAP_STALE" ] || fail "sitemap.xml lists pages that do not exist —$SITEMAP_STALE"
+echo "sitemap OK ($(grep -c '<loc>' site/sitemap.xml) urls, all resolve to a page)"
+
 # The manifest must never regress to <all_urls> content scripts (DEFECT O-09).
 if grep -q '"<all_urls>"' extension/manifest.json; then
   # host_permissions may legitimately stay broad (user-configured AI/RPC

--- a/site/robots.txt
+++ b/site/robots.txt
@@ -1,0 +1,18 @@
+# PaperTrench — https://papertrench.com
+#
+# Everything public is crawlable. The one page that should stay out of results
+# is /admin, and it is kept out by the `noindex` meta tag it already carries —
+# deliberately NOT by a Disallow line here.
+#
+# Those two are not interchangeable. Disallow stops a crawler from FETCHING the
+# page, which means it never reads the noindex; a URL discovered from an
+# external link can then still be listed, and the instruction telling it not to
+# be is the one thing the crawler was blocked from seeing. Allowing the fetch is
+# what lets the noindex actually work. Nothing is exposed by that: signed out,
+# /admin renders a sign-in gate and no application data, and the queue itself is
+# gated server-side on every request.
+
+User-agent: *
+Allow: /
+
+Sitemap: https://papertrench.com/sitemap.xml

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Public pages, in the extensionless form the site links (GitHub Pages resolves
+  /leaderboard to leaderboard.html).
+
+  No <lastmod>. Every file's git mtime is the day the extensionless-URL refactor
+  rewrote its links, so a lastmod here would tell search engines that a
+  three-week-old news article changed today. A date that is technically true and
+  semantically false is worse than no date: Google treats an untrustworthy
+  lastmod as a reason to ignore the field everywhere on the site.
+
+  Deliberately absent:
+    /admin                  noindex — moderator queue, not public
+    /clan /duel /profile    parameterised; without ?tag= / ?code= / ?handle=
+                            they render an empty state, so there is nothing at
+                            these URLs worth landing on
+    /404                    error page
+
+  scripts/preflight.sh checks this file against site/*.html, so a new page
+  cannot be added without either listing it here or naming it as excluded.
+-->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://papertrench.com/</loc></url>
+  <url><loc>https://papertrench.com/leaderboard</loc></url>
+  <url><loc>https://papertrench.com/sprint</loc></url>
+  <url><loc>https://papertrench.com/duels</loc></url>
+  <url><loc>https://papertrench.com/clans</loc></url>
+  <url><loc>https://papertrench.com/streams</loc></url>
+  <url><loc>https://papertrench.com/streamer-signup</loc></url>
+  <url><loc>https://papertrench.com/news</loc></url>
+  <url><loc>https://papertrench.com/privacy</loc></url>
+  <url><loc>https://papertrench.com/news-chain</loc></url>
+  <url><loc>https://papertrench.com/news-fees</loc></url>
+  <url><loc>https://papertrench.com/news-fills</loc></url>
+  <url><loc>https://papertrench.com/news-flex</loc></url>
+  <url><loc>https://papertrench.com/news-instant-x</loc></url>
+  <url><loc>https://papertrench.com/news-perps</loc></url>
+  <url><loc>https://papertrench.com/news-quickedit</loc></url>
+  <url><loc>https://papertrench.com/news-rugguard</loc></url>
+  <url><loc>https://papertrench.com/news-the-after</loc></url>
+  <url><loc>https://papertrench.com/news-trench-rank</loc></url>
+  <url><loc>https://papertrench.com/news-turbo</loc></url>
+  <url><loc>https://papertrench.com/news-v2</loc></url>
+  <url><loc>https://papertrench.com/news-xray</loc></url>
+</urlset>


### PR DESCRIPTION
Both `robots.txt` and `sitemap.xml` 404 on production today — I checked before writing this. This adds them in the extensionless form the site now links, plus a preflight check so they can''t quietly rot.

### No `<lastmod>`

Every page''s git mtime is the day the extensionless-URL refactor (#38) rewrote its links. A `lastmod` here would therefore tell search engines that a three-week-old news article changed today — technically true, semantically false. Google treats an untrustworthy `lastmod` as a reason to discount the field across the whole site, so it''s omitted rather than published wrong. Same rule this codebase already applies to numbers on screen.

### `/admin` is crawlable on purpose

It stays out of results via the `noindex` meta tag it already carries — **not** a `Disallow` line. Those aren''t interchangeable:

> `Disallow` stops a crawler from **fetching** the page, which means it never reads the `noindex`. A URL discovered from an external link can then still be listed, and the one instruction telling it not to be is exactly what the crawler was blocked from seeing.

Nothing is exposed by allowing the fetch: signed out, `/admin` renders a sign-in gate and no application data, and the queue is gated server-side on every request regardless.

### The guard (`scripts/preflight.sh`)

A sitemap is the one file that rots with no symptom — pages get added, the map stays as it was, and nothing anywhere reports that crawlers are being handed a stale list. The check runs both directions:

- every `site/*.html` is either in the sitemap or named in `SITEMAP_SKIP`
- every `<loc>` resolves to a file that exists

Adding a page now forces a decision about it instead of defaulting to silence. Exclusions are enumerated in the script rather than left implicit: `admin` (noindex), `clan`/`duel`/`profile` (parameterised — without `?tag=`, `?code=` or `?handle=` they render an empty state), `404`.

### Verification

- XML parses; namespace is `http://www.sitemaps.org/schemas/sitemap/0.9`
- 22 urls — none missing, none stale
- **Mutation-tested both branches**: dropping `/privacy` trips `missing`, adding a ghost `<loc>` trips `stale`. Neither passes vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
