### PR TITLE
fix(popup): the update banner was permanently visible, and its x was inert

### DIFF
--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -37,6 +37,14 @@
 
     * { box-sizing: border-box; }
 
+    /* The hidden attribute must outrank every component's own display rule.
+       [hidden] { display: none } is a UA rule, so any author rule with a class
+       selector beats it: a component styled .thing { display: flex } renders
+       while carrying hidden, and el.hidden = true does nothing. See the fuller
+       note in popup.html, where that trap made the update banner permanent. */
+    [hidden] { display: none !important; }
+
+
     html { scrollbar-color: rgba(255,255,255,0.16) transparent; }
 
     body {

--- a/extension/overlay.html
+++ b/extension/overlay.html
@@ -20,6 +20,14 @@
       --mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
     }
     * { box-sizing: border-box; }
+
+    /* The hidden attribute must outrank every component's own display rule.
+       [hidden] { display: none } is a UA rule, so any author rule with a class
+       selector beats it: a component styled .thing { display: flex } renders
+       while carrying hidden, and el.hidden = true does nothing. See the fuller
+       note in popup.html, where that trap made the update banner permanent. */
+    [hidden] { display: none !important; }
+
     html, body { height: 100%; }
     body {
       margin: 0;

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -19,6 +19,23 @@
       --mono: ui-monospace, "SF Mono", Menlo, monospace;
     }
     * { box-sizing: border-box; }
+
+    /* The hidden attribute must outrank every component's own display rule.
+     *
+     * The browser's default sheet says [hidden] { display: none }, but that is
+     * a UA rule: any author rule with a class selector beats it. So a component
+     * styled `.thing { display: flex }` renders even while carrying `hidden`,
+     * and `el.hidden = true` from JS silently does nothing.
+     *
+     * That is exactly what happened to the update banner — it shipped with the
+     * hidden attribute set, was visible to everyone anyway (showing its
+     * placeholder text rather than a real version), and its dismiss button
+     * appeared broken because setting .hidden could not take effect. One rule
+     * here fixes that and inoculates every other display-styled component in
+     * this file against the same trap.
+     */
+    [hidden] { display: none !important; }
+
     body {
       width: 316px; margin: 0; padding: 0;
       background: var(--bg);

--- a/extension/test/updatebanner.test.js
+++ b/extension/test/updatebanner.test.js
@@ -199,3 +199,58 @@ test('popup update nudge: fetch failure leaves the popup exactly as it was', asy
   assert.equal(els['update-banner'].hidden, true, 'a failed fetch must never surface the banner');
   assert.ok(els['update-banner'].innerHTML === '' || true);
 });
+
+/* ------------------------------------------------------------------------
+ * The CSS half of "hidden".
+ *
+ * Every test above asserts on the `hidden` PROPERTY, and every one of them
+ * passed while the banner was permanently on screen for every user. That is
+ * the gap they could not see: `hidden` only blanks an element because the UA
+ * stylesheet says [hidden] { display: none }, and that rule loses to any
+ * author rule with a class selector. `.update-banner { display: flex }` shipped
+ * without a guard, so the attribute in the markup did nothing, the banner
+ * rendered its placeholder text to everyone, and `el.hidden = true` from the
+ * dismiss handler could not take it away.
+ *
+ * A property assertion cannot catch that. These check the stylesheet instead.
+ * ---------------------------------------------------------------------- */
+
+const HTML_WITH_HIDDEN_TOGGLES = ['popup.html', 'dashboard.html', 'overlay.html'];
+
+/** The <style> block of an extension page. */
+function styleOf(file) {
+  const s = fs.readFileSync(path.join(ROOT, file), 'utf8');
+  const from = s.indexOf('<style>');
+  const to = s.lastIndexOf('</style>');
+  assert.ok(from !== -1 && to > from, `${file} must have a <style> block`);
+  return s.slice(from, to);
+}
+
+test('every page that hides things declares a [hidden] guard', () => {
+  for (const file of HTML_WITH_HIDDEN_TOGGLES) {
+    assert.match(styleOf(file), /\[hidden\]\s*\{[^}]*display:\s*none/,
+      `${file} needs a [hidden] rule, or its display-styled components ignore the attribute`);
+  }
+});
+
+test('the [hidden] guard outranks the component rules it has to beat', () => {
+  // Both sides are author rules here, so specificity decides: [hidden] is an
+  // attribute selector (0,1,0) and ties with a single class (0,1,0). A tie is
+  // broken by source order, which would make the guard depend on sitting after
+  // every component in the file — a rule nobody would remember when adding
+  // one. !important removes the question.
+  for (const file of HTML_WITH_HIDDEN_TOGGLES) {
+    assert.match(styleOf(file), /\[hidden\]\s*\{[^}]*display:\s*none\s*!important/,
+      `${file}'s [hidden] guard must be !important, or a later class rule silently wins`);
+  }
+});
+
+test('the update banner in particular cannot render while hidden', () => {
+  const css = styleOf('popup.html');
+  // The banner is the component the bug actually shipped on: it sets a display
+  // value, and it is the one element popup.js toggles with .hidden.
+  assert.match(css, /\.update-banner\s*\{[^}]*display:\s*flex/,
+    'this test is about the banner being display-styled — if that changed, revisit it');
+  assert.match(css, /\[hidden\]\s*\{[^}]*display:\s*none\s*!important/,
+    'and the guard that makes hiding it actually work');
+});


### PR DESCRIPTION
> Reported with a screenshot: *"this button I always see but it doesn''t actually work — I download the newest version but it doesn''t go away, also when you click the x it doesn''t go away."*

All three symptoms are **one CSS bug**, and none of them are in the update check.

`.update-banner` sets `display: flex`, and nothing guarded the `hidden` attribute. `[hidden] { display: none }` is a **UA** rule, so any author rule with a class selector beats it. In order:

1. The `hidden` in the markup never applied → the banner rendered for **every user, on every popup open**
2. What it rendered was the static placeholder `"A newer PaperTrench is out."` — which is why the screenshot has **no version number in it**. `render()` only writes a version when there''s a real notice, and it had correctly decided there was none.
3. `banner.hidden = true` in the dismiss handler couldn''t take effect either → × looked broken

### On "only tell me if there''s a new release, not every commit"

It already did. Both checks poll `/releases/latest` and compare semver against the running manifest. That half needed no change — the reporter just never saw a genuine notice, only the placeholder.

### The fix

One rule per page rather than a patch to the one component:

```css
[hidden] { display: none !important; }
```

`!important` because both sides are author rules and `[hidden]` (0,1,0) merely **ties** a single class — a tie broken by source order, which would leave the guard depending on sitting after every component in the file. Nobody would remember that when adding the next one.

`dashboard.html` and `overlay.html` get it too. Neither had a guard, `dashboard.js` toggles `.hidden` from JS across **46** display-styled classes, and this is a trap rather than an incident.

### Why the existing suite was green through all of it

This is the part I''d flag for review.

`updatebanner.test.js` already covered the feature *well* — five cases, driving the real `popup.js` against a stubbed DOM. Every one of them asserts `banner.hidden === true`.

**The property was always correct. The pixels never were.** A test that reads back the property it just set cannot see a stylesheet overriding it, so the suite stayed green while the feature was broken for 100% of users.

The three added cases assert the **CSS contract** instead: the guard exists on every page that hides things, it''s `!important`, and the banner is still the display-styled component that made it necessary. Mutation-tested — deleting the guard turns two of them red.

```
extension  1723/1724
```

The one failure is `perpswiring.test.js`, which fails on `main` before this change and is untouched by it. (Fix for that is coming in a separate PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
