### PR TITLE
fix(test): perps wiring test failed on every Windows clone, not in the code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,35 @@
 *.gif binary
 *.png binary
 *.jpg binary
+
+# Source is LF in the working copy on every platform.
+#
+# The blobs are already LF, so this changes nothing in the repository — what it
+# changes is CHECKOUT. Without it, a Windows clone with core.autocrlf=true gets
+# CRLF working files, and this suite reads source as text and asserts on it: a
+# great many tests slice a function body out of a file and match literals
+# against it. Any such literal containing \n silently stops matching, indexOf
+# returns -1, and the assertion fails on a file whose code is perfectly correct.
+#
+# That is not hypothetical. perpswiring.test.js asserted
+#   poll.indexOf('S.detect(') < poll.indexOf('enterPage();\n      }')
+# which is 1670 < -1 on a CRLF checkout. It failed on every Windows clone and
+# passed in CI, so the repo looked green while contributors saw a red suite on
+# a fresh clone and had no way to tell it from a real break.
+#
+# Shell scripts get it worst: scripts/preflight.sh with CRLF fails at the
+# shebang on most shells.
+*.js   text eol=lf
+*.mjs  text eol=lf
+*.cjs  text eol=lf
+*.json text eol=lf
+*.html text eol=lf
+*.css  text eol=lf
+*.md   text eol=lf
+*.sql  text eol=lf
+*.toml text eol=lf
+*.yml  text eol=lf
+*.yaml text eol=lf
+*.svg  text eol=lf
+*.txt  text eol=lf
+*.sh   text eol=lf

--- a/extension/test/perpswiring.test.js
+++ b/extension/test/perpswiring.test.js
@@ -157,8 +157,17 @@ test('an unmounted page keeps looking — a first failed detect is never permane
     'and it must re-run detection against the CURRENT title, not a cached one');
   // The cheap check gates the expensive one: detect is string matching, but
   // enterPage does storage and network work.
-  assert.ok(poll.indexOf('S.detect(') < poll.indexOf('enterPage();\n      }'),
-    'detection must gate entry, not the other way round');
+  //
+  // Asserted on the nesting rather than on byte offsets. The previous form
+  // compared indexOf('S.detect(') against indexOf('enterPage();\n      }') —
+  // a literal carrying both a newline and an exact indent, so it matched
+  // nothing on a CRLF checkout, indexOf returned -1, and `1670 < -1` failed on
+  // every Windows clone while passing in CI. The repo now pins source to LF
+  // (.gitattributes), and this no longer depends on either.
+  const guarded = /if \(S\.detect\([^)]*\)\) \{\s*[^}]*?enterPage\(\);\s*\}/.test(poll);
+  assert.ok(guarded,
+    'detection must gate entry, not the other way round — enterPage() must sit '
+    + 'INSIDE the if (S.detect(...)) block');
 });
 
 test('a market switch is caught without depending on a title observer', () => {


### PR DESCRIPTION
`perpswiring.test.js` has been the one red test in the suite. **The code it accuses is correct** — `pollLocation()` does gate `enterPage()` behind `S.detect()`, exactly as the test''s own comment describes.

The assertion was:

```js
poll.indexOf('S.detect(') < poll.indexOf('enterPage();\n      }')
```

A literal carrying both a newline **and** an exact indent. Repo blobs are LF, but a clone with `core.autocrlf=true` (the Windows default) checks out CRLF — so that literal matches nothing, `indexOf` returns `-1`, and the comparison is:

```
1670 < -1   →  false
```

...on a file with no defect in it.

So it **passed in CI** (Linux, LF) and **failed on every Windows checkout**. The repo looked green while anyone cloning fresh on Windows saw a red suite and no way to tell it from a real break.

## Two fixes, because either alone leaves the trap half-set

### 1 · `.gitattributes` pins source to LF on checkout

The blobs are **already LF**, so this is a zero-diff change to the repository and a real change to working copies. I verified that before writing it:

```
blob has CRLF : false     (0 CR bytes)
worktree CRLF : true      (autocrlf converting on checkout)
```

This matters well beyond one test. A great many tests here slice a function body out of a source file and match literals against it — any literal containing `\n` is one CRLF checkout away from matching nothing and failing on correct code.

Shell scripts get it worst, and were already exposed: `scripts/preflight.sh` with CRLF fails at the shebang on most shells.

### 2 · The assertion no longer depends on line endings at all

Rewritten to assert the **nesting** — that `enterPage()` sits inside the `if (S.detect(...))` block — rather than comparing byte offsets of whitespace-bearing literals.

**Mutation-tested:** hoisting `enterPage()` out of the gate still turns it red, so it keeps testing the thing it was written to test.

## Result

```
extension  1721/1721
server      186/186
```

The suite is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
