### PR TITLE
feat(dashboard): settings save themselves

### DIFF
--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -4253,7 +4253,11 @@ function renderSettings(el) {
       ${renderTurboCard()}
     </div>
     <div class="card" style="margin-top:16px;display:flex;align-items:center;gap:10px;flex-wrap:wrap">
-      <button class="btn" id="save-settings">Save settings</button>
+      <!-- Kept, though nothing needs it: changes save on their own now. It is
+           here for the person who wants to see something happen after typing,
+           and as the retry when an auto-save reports a failure. -->
+      <button class="btn-sec" id="save-settings" title="Changes already save on their own — this forces one now">Save now</button>
+      <span class="dim" style="font-size:12px">Changes save automatically.</span>
       <span id="save-status" class="dim" style="font-size:12px" role="status"></span>
       <button class="btn-sec" id="test-ai">Test AI endpoint</button>
       <span id="ai-test-result" class="dim" style="font-size:12px"></span>
@@ -4265,7 +4269,56 @@ function renderSettings(el) {
 }
 
 /** Wire the settings form. Called after the section is in the document. */
+/**
+ * Persist settings as they are changed, so the Save button is a confirmation
+ * rather than a requirement.
+ *
+ * Reported repeatedly: people change a setting, leave the tab, and find it
+ * reverted — the form looked applied because the control looked applied, and
+ * the button that made it true was a scroll away past seventy other controls.
+ *
+ * Bound to `change`, deliberately not `input`. On a text or number field
+ * `change` fires when the value is COMMITTED (blur, or Enter), while `input`
+ * fires per keystroke — which would save "0." as someone types "0.5", and
+ * saveFromForm coerces what it is given. Checkboxes, selects and ranges fire
+ * `change` at the moment they settle, so those still feel instant.
+ *
+ * saveFromForm re-reads storage, lays only form-controlled keys over it, and
+ * writes nothing back into the DOM, so calling it repeatedly is safe and
+ * cannot fight the user's cursor.
+ */
+function bindSettingsAutosave(section) {
+  if (!section) return;
+  let timer = null;
+
+  section.addEventListener('change', (event) => {
+    const el = event.target;
+    if (!el || !el.matches || !el.matches('input, select, textarea')) return;
+    // The search box is a view control, not a setting.
+    if (el.id === 'set-search') return;
+
+    const status = document.getElementById('save-status');
+    if (status) { status.textContent = 'Saving…'; status.style.color = ''; }
+
+    // Coalesce bursts — toggling three checkboxes is one write, not three.
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      // saveFromForm owns its own success/failure reporting, including the
+      // "adjusted:" notes when a value had to be coerced. Nothing to add here.
+      saveFromForm().catch((err) => {
+        console.error('PaperTrench: autosave failed', err);
+        if (status) {
+          status.textContent = 'Auto-save failed — press Save settings to retry.';
+          status.style.color = 'var(--red)';
+        }
+      });
+    }, 250);
+  });
+}
+
 function bindSettings() {
+  bindSettingsAutosave(document.getElementById('settings'));
   document.getElementById('save-settings').addEventListener('click', saveFromForm);
   // Fees & costs quick fill-in: writes the fields, never storage — Save still
   // owns persistence, and the numbers stay the user's to edit.

--- a/extension/test/settingssave.test.js
+++ b/extension/test/settingssave.test.js
@@ -135,3 +135,68 @@ test('D-56 does not disarm migrations for genuinely old installs', () => {
     'a pre-revision install (no settingsRevision at all) still migrates');
   assert.equal(fromAncient.settingsRevision, E.SETTINGS_REVISION);
 });
+
+/* ------------------------------------------------------------------------
+ * Auto-save.
+ *
+ * Reported repeatedly: a setting is changed, the tab is left, and the change
+ * is gone. The control looked applied because it WAS applied — to the DOM —
+ * and the button that made it true sat past seventy other controls.
+ * ---------------------------------------------------------------------- */
+
+// This file's existing suite is behavioural (it drives the engine), so it
+// never needed the filesystem. These cases assert a source contract instead.
+const fsAuto = require('node:fs');
+const pathAuto = require('node:path');
+const dashSrcAuto = fsAuto.readFileSync(pathAuto.join(__dirname, '..', 'dashboard.js'), 'utf8');
+
+function autosaveBlock() {
+  const start = dashSrcAuto.indexOf('function bindSettingsAutosave(');
+  assert.ok(start !== -1, 'bindSettingsAutosave must exist');
+  const end = dashSrcAuto.indexOf('\n}', start);
+  return dashSrcAuto.slice(start, end + 2);
+}
+
+test('settings auto-save is wired, and the Save button is no longer the only path', () => {
+  const bind = dashSrcAuto.slice(
+    dashSrcAuto.indexOf('function bindSettings()'),
+    dashSrcAuto.indexOf('\n}', dashSrcAuto.indexOf('function bindSettings()')));
+  assert.match(bind, /bindSettingsAutosave\(/, 'bindSettings must install the autosave listener');
+});
+
+test('auto-save listens for change, never input', () => {
+  // `input` fires per keystroke, so it would hand saveFromForm "0." midway
+  // through someone typing "0.5" — and saveFromForm coerces what it is given.
+  // `change` fires when a text field is COMMITTED (blur or Enter) and the
+  // moment a checkbox, select or range settles.
+  const block = autosaveBlock();
+  assert.match(block, /addEventListener\('change'/, 'must bind change');
+  assert.ok(!/addEventListener\('input'/.test(block),
+    'binding input would save half-typed numbers');
+});
+
+test('auto-save coalesces a burst into one write', () => {
+  const block = autosaveBlock();
+  assert.match(block, /clearTimeout\(timer\)/, 'a pending save must be superseded');
+  assert.match(block, /setTimeout\(/, 'and the write deferred briefly');
+});
+
+test('the search box is not mistaken for a setting', () => {
+  const block = autosaveBlock();
+  assert.match(block, /id === 'set-search'/,
+    'typing in the settings filter must not trigger a settings write');
+});
+
+test('a failed auto-save says so and names the way out', () => {
+  // Silence here is the worst outcome: the user believes a setting persisted
+  // BECAUSE they were told saving is automatic.
+  const block = autosaveBlock();
+  assert.match(block, /catch/, 'the save promise must be caught');
+  assert.match(block, /Auto-save failed/, 'and the failure surfaced');
+  assert.match(block, /Save/, 'pointing at the manual button as the retry');
+});
+
+test('the settings screen tells the user saving is automatic', () => {
+  assert.match(dashSrcAuto, /Changes save automatically\./,
+    'the promise has to be visible, or the button still looks required');
+});


### PR DESCRIPTION
> *"a lot of people miss the save settings button — can you autosave after every setting change"*

The control looked applied because it **was** applied — to the DOM. The button that made it true sat at the bottom of seventy other controls, past a scroll most people never make.

## `change`, deliberately not `input`

On a text or number field, `change` fires when the value is **committed** (blur or Enter). `input` fires per keystroke — which would hand `saveFromForm` `"0."` midway through someone typing `"0.5"`, and `saveFromForm` coerces what it''s given. That would turn autosave into a silent value-mangler.

Checkboxes, selects and ranges fire `change` the moment they settle, so those still feel instant. A 250 ms debounce coalesces a burst of toggles into one write.

## Why calling it repeatedly is safe

I checked before wiring it: `saveFromForm` re-reads storage, lays only the form-controlled keys over it (the D-19 fix), and **writes nothing back into the DOM**. So an auto-save can''t fight the user''s cursor, and can''t revert a content-script settings write made meanwhile.

## The failure path matters more than usual

Silence here is the worst outcome, because the user now believes saving is automatic **because the screen says so**. A failed auto-save reports itself and names the manual button as the retry.

The Save button stays — relabelled *"Save now"*, demoted to secondary — for the person who wants to see something happen after typing, and as that retry.

## Tests

Six cases, including the two that would quietly ruin it:

- binding `input` instead of `change` (saves half-typed numbers)
- swallowing a save failure (user trusts a promise that isn''t being kept)

Plus: the settings filter search box isn''t mistaken for a setting, bursts coalesce, and the screen actually tells the user saving is automatic.

```
extension  1726/1727
```

The one failure is `perpswiring.test.js` — fails on `main` before this change, fixed separately in #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
