### PR TITLE
feat(dashboard): one box per preset, not a comma-separated string

### DIFF
--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -158,6 +158,44 @@
     }
     .card h4 { margin: 16px 0 8px; font-size: 12px; font-weight: 700; color: var(--dim); }
     .grid2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(370px, 1fr)); gap: 16px; align-items: start; }
+
+    /* ---------- preset rows ----------
+       One box per button, instead of a text field holding "0.1, 0.5, 1, 2".
+       Each box is the size of the value it holds, so the row reads as the row
+       of buttons it becomes in the overlay. */
+    .preset-row { display: flex; flex-wrap: wrap; gap: 7px; align-items: center; margin: 2px 0 4px; }
+    .preset-box { position: relative; display: inline-flex; }
+    .preset-box input {
+      width: 76px; padding: 8px 20px 8px 10px;
+      font-family: var(--mono); font-size: 13px; font-weight: 650; color: var(--text);
+      background: rgba(0,0,0,0.26); border: 1px solid var(--line);
+      border-radius: 9px; transition: border-color .15s;
+    }
+    .preset-box input:focus { outline: none; border-color: var(--amber); }
+    /* The spinners are noise at this size and steal the space the × needs. */
+    .preset-box input::-webkit-outer-spin-button,
+    .preset-box input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+    .preset-box input[type=number] { -moz-appearance: textfield; }
+    .preset-del {
+      position: absolute; right: 3px; top: 50%; transform: translateY(-50%);
+      width: 16px; height: 16px; padding: 0; line-height: 1;
+      display: grid; place-items: center;
+      font: inherit; font-size: 13px; cursor: pointer;
+      color: var(--faint); background: none; border: 0; border-radius: 4px;
+      opacity: 0; transition: opacity .15s, color .15s;
+    }
+    /* Revealed on hover or keyboard focus — :focus-within covers the case
+       where the × itself is tabbed to, which hover alone would never show. */
+    .preset-box:hover .preset-del, .preset-box:focus-within .preset-del { opacity: 1; }
+    .preset-del:hover { color: var(--red); background: rgba(255,95,86,0.14); }
+    .preset-add {
+      font: inherit; font-size: 12px; font-weight: 650; cursor: pointer;
+      color: var(--dim); background: rgba(255,255,255,0.04);
+      border: 1px dashed var(--line-2, rgba(255,255,255,0.14));
+      border-radius: 9px; padding: 8px 12px;
+      transition: color .15s, background .15s, border-color .15s;
+    }
+    .preset-add:hover { color: var(--text); background: rgba(255,255,255,0.08); border-color: var(--amber); }
     .grid3 { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 16px; align-items: start; }
 
     .section { animation: fade-in 0.3s var(--ease) both; }

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -4113,6 +4113,35 @@ function renderTurboCard() {
 
 /* ---------- settings ---------- */
 
+/**
+ * A row of one-value boxes for a preset list.
+ *
+ * These were a single text field holding "0.1, 0.5, 1, 2". That asks the user
+ * to know the delimiter, to spot a stray comma, and to edit four numbers
+ * inside one string — and it silently dropped whatever failed to parse, which
+ * looked like the app forgetting a value rather than rejecting it.
+ *
+ * The comma-joined field survives as a HIDDEN mirror, kept in sync on every
+ * edit. saveFromForm's numberList() still reads exactly what it always read,
+ * so the validation, the coercion notes and their tests are untouched by a
+ * change that is only about how the values are typed.
+ */
+function renderPresetBoxes(id, values, { max, step, unit, addLabel }) {
+  const box = (v, i) => `
+    <span class="preset-box">
+      <input type="number" min="0" max="${max}" step="${step}" value="${esc(String(v))}"
+             data-preset-for="${id}" aria-label="${esc(unit)} preset ${i + 1}">
+      <button type="button" class="preset-del" data-preset-del="${id}"
+              title="Remove this preset" aria-label="Remove preset ${i + 1}">×</button>
+    </span>`;
+  return `
+    <div class="preset-row" data-preset-row="${id}">
+      ${values.map(box).join('')}
+      <button type="button" class="preset-add" data-preset-add="${id}">+ ${esc(addLabel)}</button>
+    </div>
+    <input type="hidden" id="${id}" value="${esc(values.join(', '))}">`;
+}
+
 function renderSettings(el) {
   // D-24: a corrupt backup can leave presetsBuy/sellPcts as non-arrays. An
   // unguarded .join() threw mid-render, leaving Settings blank AND unbound —
@@ -4131,7 +4160,10 @@ function renderSettings(el) {
       <div class="card">
         <h3>Wallet &amp; Trading</h3>
         <div class="field"><label for="set-balance">Starting paper balance (SOL)</label><input id="set-balance" type="number" min="0.1" step="0.1" value="${settings.balanceStartSol}"></div>
-        <div class="field"><label for="set-sellpcts">Quick-sell presets (%)</label><input id="set-sellpcts" type="text" value="${esc(sellPctsList.join(', '))}"></div>
+        <div class="field"><label>Quick-sell presets (%)</label>
+          ${renderPresetBoxes('set-sellpcts', sellPctsList, { max: 100, step: 1, unit: 'Percent', addLabel: 'Add %' })}
+          <small>One box per button in the overlay. Up to 8, each 1–100%.</small>
+        </div>
       </div>
       <div class="card">
         <h3>Fees &amp; costs</h3>
@@ -4152,7 +4184,10 @@ function renderSettings(el) {
       </div>
       <div class="card">
         <h3>Buying</h3>
-        <div class="field"><label for="set-presets">Quick-buy presets (SOL)</label><input id="set-presets" type="text" value="${esc(presetsBuyList.join(', '))}"><small>Comma separated, shown as buttons in the overlay.</small></div>
+        <div class="field"><label>Quick-buy presets (SOL)</label>
+          ${renderPresetBoxes('set-presets', presetsBuyList, { max: 1000, step: 0.1, unit: 'SOL', addLabel: 'Add amount' })}
+          <small>One box per button in the overlay. Up to 8.</small>
+        </div>
         <div class="field field-check"><label><input type="checkbox" id="set-instant-buy" ${settings.instantBuyEnabled !== false ? 'checked' : ''}> One-click quick buy</label><small>Tapping a preset amount fires the buy immediately, like Axiom and Padre. Off makes presets only select the amount for the BUY button.</small></div>
         <div class="field field-check"><label><input type="checkbox" id="set-list-quick-buy" ${settings.listQuickBuyEnabled !== false ? 'checked' : ''}> One-tap buy buttons on token lists</label><small>A "P" button on every token row of Axiom Pulse, Padre Trenches and GMGN Trenches — buys the first preset amount without opening the chart.</small></div>
         <div class="field field-check"><label><input type="checkbox" id="set-list-quick-open" ${settings.listQuickOpen !== false ? 'checked' : ''}> Open the chart tab after a list buy</label><small>When a one-tap list buy opens a NEW position, its chart opens in a background tab so the position is one click away. Turn off for list-only trading.</small></div>
@@ -4265,7 +4300,74 @@ function renderSettings(el) {
 }
 
 /** Wire the settings form. Called after the section is in the document. */
+/**
+ * Keep each preset row's hidden comma-joined mirror in step with its boxes.
+ *
+ * The mirror is what saveFromForm reads, so it has to be current BEFORE any
+ * save fires. Sync runs synchronously in the same event that changed a box,
+ * and the save path is debounced behind it, so the order holds without the two
+ * knowing about each other.
+ */
+function bindPresetRows(section) {
+  if (!section) return;
+  const MAX_BOXES = 8; // numberList() truncates past this; don't offer a 9th.
+
+  const sync = (id) => {
+    const mirror = document.getElementById(id);
+    const row = section.querySelector(`[data-preset-row="${id}"]`);
+    if (!mirror || !row) return;
+    const values = [...row.querySelectorAll(`input[data-preset-for="${id}"]`)]
+      .map((i) => i.value.trim())
+      .filter((v) => v !== '');
+    mirror.value = values.join(', ');
+    const add = row.querySelector(`[data-preset-add="${id}"]`);
+    if (add) add.hidden = values.length >= MAX_BOXES;
+  };
+
+  // A row edited to empty would be silently refilled with defaults by
+  // saveFromForm. Say so at the point of editing instead.
+  const rows = [...section.querySelectorAll('[data-preset-row]')].map((r) => r.dataset.presetRow);
+  for (const id of rows) sync(id);
+
+  section.addEventListener('input', (e) => {
+    const id = e.target && e.target.dataset && e.target.dataset.presetFor;
+    if (id) sync(id);
+  });
+
+  section.addEventListener('click', (e) => {
+    const del = e.target.closest('[data-preset-del]');
+    if (del) {
+      const id = del.dataset.presetDel;
+      const row = section.querySelector(`[data-preset-row="${id}"]`);
+      // Never remove the last one: an empty list is restored to defaults by
+      // saveFromForm, which reads as the app ignoring the edit.
+      if (row && row.querySelectorAll('.preset-box').length > 1) {
+        del.closest('.preset-box').remove();
+        sync(id);
+        // Removal is a committed edit; text boxes only fire `change` on blur,
+        // so autosave needs telling.
+        document.getElementById(id).dispatchEvent(new Event('change', { bubbles: true }));
+      }
+      return;
+    }
+
+    const add = e.target.closest('[data-preset-add]');
+    if (!add) return;
+    const id = add.dataset.presetAdd;
+    const row = section.querySelector(`[data-preset-row="${id}"]`);
+    if (!row || row.querySelectorAll('.preset-box').length >= MAX_BOXES) return;
+    const template = row.querySelector('.preset-box');
+    const fresh = template.cloneNode(true);
+    const input = fresh.querySelector('input');
+    input.value = '';
+    row.insertBefore(fresh, add);
+    input.focus();
+    sync(id);
+  });
+}
+
 function bindSettings() {
+  bindPresetRows(document.getElementById('settings'));
   document.getElementById('save-settings').addEventListener('click', saveFromForm);
   // Fees & costs quick fill-in: writes the fields, never storage — Save still
   // owns persistence, and the numbers stay the user's to edit.

--- a/extension/test/quickbuy.test.js
+++ b/extension/test/quickbuy.test.js
@@ -118,11 +118,19 @@ test('the quick-buy controls live in their own labeled card (discoverability)', 
   assert.ok(cardOpen !== -1, 'a "Buying" settings card must exist');
   // Every QB control must come AFTER the card heading (i.e. inside the card,
   // not scattered elsewhere in the page).
-  for (const id of ['set-presets', 'set-instant-buy', 'set-list-quick-buy', 'set-panel-buy', 'set-panel-presets']) {
+  for (const id of ['set-instant-buy', 'set-list-quick-buy', 'set-panel-buy', 'set-panel-presets']) {
     const at = dashJs.indexOf(`id="${id}"`);
     assert.ok(at !== -1, `${id} must exist`);
     assert.ok(at > cardOpen, `${id} must live inside the Buying card`);
   }
+  // set-presets is no longer written as a literal id= in the card: it is a row
+  // of one-value boxes emitted by renderPresetBoxes(), which also carries the
+  // hidden comma-joined mirror that saveFromForm reads. The property under
+  // test is unchanged — the control must sit inside the Buying card — so it is
+  // located by the call that renders it.
+  const presetsAt = dashJs.indexOf("renderPresetBoxes('set-presets'");
+  assert.ok(presetsAt !== -1, 'the quick-buy preset row must be rendered');
+  assert.ok(presetsAt > cardOpen, 'the quick-buy preset row must live inside the Buying card');
 });
 
 /* ---------------- screener row quick buys ---------------- */
@@ -464,4 +472,65 @@ test('an armed row snipe keeps probing until filled or expired (D-42 Bug 4)', ()
     'the armed intent runs a repeating 1.5 s flush probe');
   assert.match(content, /if \(!rowArmed\) \{\s*\n\s*clearInterval\(rowArmedFlushTimer\)/,
     'the probe self-clears when the intent fills or expires');
+});
+/* ------------------------------------------------------------------------
+ * One box per preset.
+ *
+ * The list was a single text field holding "0.1, 0.5, 1, 2" — the user had to
+ * know the delimiter, spot a stray comma, and edit four numbers inside one
+ * string. Whatever failed to parse was dropped, which reads as the app
+ * forgetting a value rather than refusing it.
+ * ---------------------------------------------------------------------- */
+
+test('both preset lists render as boxes, not a comma-separated string', () => {
+  for (const id of ['set-presets', 'set-sellpcts']) {
+    assert.ok(dashJs.includes(`renderPresetBoxes('${id}'`), `${id} must render as boxes`);
+  }
+  // The old shape must be gone, or the change is cosmetic on one of them.
+  assert.ok(!/id="set-presets" type="text"/.test(dashJs), 'the SOL text field must be gone');
+  assert.ok(!/id="set-sellpcts" type="text"/.test(dashJs), 'the % text field must be gone');
+});
+
+test('the hidden mirror keeps the existing save path intact', () => {
+  // saveFromForm reads these through numberList(), which splits a comma
+  // string. Keeping that contract is what makes this a UI change only —
+  // validation, the coercion notes and their tests all stay put.
+  const helper = dashJs.slice(
+    dashJs.indexOf('function renderPresetBoxes('),
+    dashJs.indexOf('\n}', dashJs.indexOf('function renderPresetBoxes(')));
+  assert.match(helper, /type="hidden" id="\$\{id\}"/, 'a hidden mirror must carry the id');
+  assert.match(helper, /values\.join\(', '\)/, 'and hold the comma-joined value numberList expects');
+  assert.match(dashJs, /numberList\('set-presets'/, 'the save path must be unchanged');
+  assert.match(dashJs, /numberList\('set-sellpcts'/, 'for both lists');
+});
+
+test('the mirror is resynced on every edit, before any save can read it', () => {
+  const bind = dashJs.slice(
+    dashJs.indexOf('function bindPresetRows('),
+    dashJs.indexOf('\nfunction bindSettings()'));
+  assert.match(bind, /addEventListener\('input'/, 'typing in a box must resync the mirror');
+  assert.match(bind, /mirror\.value = values\.join\(', '\)/, 'the mirror is rewritten from the boxes');
+  // Removal is a committed edit, but a hidden input fires no change of its
+  // own — without this, deleting a preset would not autosave.
+  assert.match(bind, /dispatchEvent\(new Event\('change'/,
+    'removing a box must announce itself as a change');
+});
+
+test('a preset row can never be emptied to nothing', () => {
+  // saveFromForm restores defaults for an empty list, so an empty row reads
+  // as the app ignoring the edit rather than accepting it.
+  const bind = dashJs.slice(
+    dashJs.indexOf('function bindPresetRows('),
+    dashJs.indexOf('\nfunction bindSettings()'));
+  assert.match(bind, /length > 1/, 'the last remaining box must not be removable');
+});
+
+test('the row stops offering more boxes than the save path will keep', () => {
+  // numberList() truncates past 8; offering a 9th box would accept input that
+  // is silently discarded on save.
+  const bind = dashJs.slice(
+    dashJs.indexOf('function bindPresetRows('),
+    dashJs.indexOf('\nfunction bindSettings()'));
+  assert.match(bind, /MAX_BOXES = 8/, 'the cap must match numberList()');
+  assert.match(bind, />= MAX_BOXES/, 'and be enforced on add');
 });


### PR DESCRIPTION
> *"I hate this `0.1, 0.5, 1, 2` setting thing — make a box per buy."*

Both preset lists (quick-buy SOL, quick-sell %) were a single text field. That asks the user to know the delimiter, to spot a stray comma, and to edit four numbers inside one string — and `numberList()` **silently drops** whatever fails to parse, so a typo reads as the app forgetting a value rather than refusing it.

It''s now one box per button, matching the row of buttons it becomes in the overlay, with **+** to add and **×** to remove.

## The save path is untouched

The comma-joined field survives as a **hidden mirror**, resynced on every edit. `saveFromForm`''s `numberList()` reads exactly what it always read — so the validation, the *">0 and ≤ max, max 8"* rules, the coercion notes, and every existing test over them are unaffected by a change that is only about how the values are typed.

## Two limits moved to where they''re felt

Both were previously silently discarded on save:

- **the last box can''t be removed** — an empty list is restored to defaults, which reads as the edit being ignored
- **no ninth box is offered** — `numberList()` truncates past 8, so accepting a 9th would take input it throws away

## One subtlety worth flagging

Removal dispatches a `change` event on the mirror. A hidden input fires none of its own, so without that, **deleting a preset wouldn''t trigger the auto-save in #45**. Easy thing to miss when the two land together.

## A test needed updating, not weakening

`quickbuy.test.js` has a discoverability test (from a real report: *"a user could not FIND the QB toggle"*) that located the control by the literal `id="set-presets"` — which now arrives from `renderPresetBoxes()`. It asserts the same property (the control sits inside the Buying card) against the call that renders it. The other four ids in that loop are unchanged.

## Tests

Five added, including the two invariants that make the mirror safe: it''s rewritten from the boxes on every `input`, and the 8-box cap matches `numberList()`''s own.

```
extension  1725/1726
```

The one failure is `perpswiring.test.js` — fixed separately in #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
