### PR TITLE
feat(site): skip link, main landmark and named nav on every page

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -59,6 +59,26 @@ done
 [ -z "$NAV_MISSING" ] || fail "nav is missing destinations —$NAV_MISSING"
 echo "nav OK ($(grep -lc 'class="nav-links"' site/*.html | wc -l) pages reach $NAV_DESTS)"
 
+# Every page carries the same accessibility landmarks.
+#
+# A skip link is the first tab stop; without it, reaching page content by
+# keyboard means tabbing through eleven nav links on every navigation. It
+# needs a <main id="main"> to land on, and the primary <nav> needs a name so
+# a screen reader can tell it from the ones inside the page.
+#
+# Checked rather than remembered, for the same reason as the nav destinations
+# above: 20 of 27 pages had no landmark at all until this pass, because
+# nothing said they should.
+A11Y_MISSING=""
+for page in site/*.html; do
+  grep -q 'class="nav-links"' "$page" || continue
+  grep -q 'class="skip-link"' "$page" || A11Y_MISSING="$A11Y_MISSING $(basename "$page"):skip-link"
+  grep -q 'id="main"'         "$page" || A11Y_MISSING="$A11Y_MISSING $(basename "$page"):main"
+  grep -q '<nav aria-label='   "$page" || A11Y_MISSING="$A11Y_MISSING $(basename "$page"):nav-label"
+done
+[ -z "$A11Y_MISSING" ] || fail "pages missing accessibility landmarks —$A11Y_MISSING"
+echo "a11y OK (skip link, main landmark and named nav on $(grep -lc 'class="skip-link"' site/*.html | wc -l) pages)"
+
 # Every public page must be in sitemap.xml, or deliberately named as excluded.
 #
 # A sitemap is the one file that rots without any symptom: pages get added, the

--- a/site/404.html
+++ b/site/404.html
@@ -52,10 +52,11 @@
 </style>
 </head>
 <body>
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="/assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -70,6 +71,8 @@
     </div>
   </div>
 </nav>
+
+<main id="main">
 
 <header class="lost">
   <div class="wrap">
@@ -87,6 +90,7 @@
     </div>
   </div>
 </header>
+</main>
 
 <footer>
   <div class="wrap">

--- a/site/admin.html
+++ b/site/admin.html
@@ -89,10 +89,11 @@
 </style>
 </head>
 <body>
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -106,6 +107,8 @@
     </div>
   </div>
 </nav>
+
+<main id="main">
 
 <header class="admin-head">
   <div class="wrap">
@@ -153,6 +156,7 @@
     </div>
   </div>
 </section>
+</main>
 
 <footer>
   <div class="wrap">

--- a/site/clan.html
+++ b/site/clan.html
@@ -17,10 +17,11 @@
 <link rel="stylesheet" href="arena.css">
 </head>
 <body>
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -36,7 +37,7 @@
   </div>
 </nav>
 
-<main class="ar-page">
+<main id="main" class="ar-page">
   <div class="wrap">
     <div id="head"></div>
 

--- a/site/clans.html
+++ b/site/clans.html
@@ -17,10 +17,11 @@
 <link rel="stylesheet" href="arena.css">
 </head>
 <body>
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -82,7 +83,7 @@
   </div>
 </header>
 
-<main class="wrap" style="padding-bottom:96px">
+<main id="main" class="wrap" style="padding-bottom:96px">
   <div class="ar-shell">
 
     <div class="ar-stack">

--- a/site/duel.html
+++ b/site/duel.html
@@ -308,10 +308,11 @@
 </style>
 </head>
 <body>
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -364,7 +365,7 @@
   </div>
 </header>
 
-<main class="wrap" style="padding-bottom:96px">
+<main id="main" class="wrap" style="padding-bottom:96px">
   <div class="ar-shell">
 
     <div class="ar-stack">

--- a/site/duels.html
+++ b/site/duels.html
@@ -459,10 +459,11 @@
 </style>
 </head>
 <body>
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -554,7 +555,7 @@
   </div>
 </header>
 
-<main class="wrap" style="padding-bottom:96px">
+<main id="main" class="wrap" style="padding-bottom:96px">
 
   <section class="ar-pane" aria-labelledby="you-h" style="margin-bottom:22px">
     <div class="ar-pane-head ar-headwrap">

--- a/site/index.html
+++ b/site/index.html
@@ -15,10 +15,11 @@
 <link rel="stylesheet" href="style.css">
 </head>
 <body>
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="#"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -36,6 +37,8 @@
     </div>
   </div>
 </nav>
+
+<main id="main">
 
 <!-- ============ HERO ============ -->
 <header class="hero">
@@ -436,6 +439,7 @@
     </div>
   </div>
 </section>
+</main>
 
 <footer>
   <div class="wrap">

--- a/site/leaderboard.html
+++ b/site/leaderboard.html
@@ -17,10 +17,11 @@
 <link rel="stylesheet" href="arena.css">
 </head>
 <body>
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -70,7 +71,7 @@
   </div>
 </header>
 
-<main class="wrap" style="padding-bottom:96px">
+<main id="main" class="wrap" style="padding-bottom:96px">
   <div class="ar-shell">
 
     <div class="ar-stack">

--- a/site/news-chain.html
+++ b/site/news-chain.html
@@ -42,10 +42,11 @@
 </style>
 </head>
 <body class="a-green">
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -62,6 +63,8 @@
     </div>
   </div>
 </nav>
+
+<main id="main">
 
 <article>
   <header class="post-hero">
@@ -212,6 +215,7 @@
 
   </div>
 </article>
+</main>
 
 <footer>
   <div class="wrap">

--- a/site/news-fees.html
+++ b/site/news-fees.html
@@ -30,10 +30,11 @@
 </style>
 </head>
 <body class="a-green">
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -50,6 +51,8 @@
     </div>
   </div>
 </nav>
+
+<main id="main">
 
 <article>
   <header class="post-hero">
@@ -166,6 +169,7 @@
 
   </div>
 </article>
+</main>
 
 <footer>
   <div class="wrap">

--- a/site/news-fills.html
+++ b/site/news-fills.html
@@ -47,10 +47,11 @@
 </style>
 </head>
 <body class="a-red">
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -67,6 +68,8 @@
     </div>
   </div>
 </nav>
+
+<main id="main">
 
 <article>
   <header class="post-hero">
@@ -218,6 +221,7 @@
 
   </div>
 </article>
+</main>
 
 <footer>
   <div class="wrap">

--- a/site/news-flex.html
+++ b/site/news-flex.html
@@ -56,10 +56,11 @@
 </style>
 </head>
 <body class="a-orange">
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -76,6 +77,8 @@
     </div>
   </div>
 </nav>
+
+<main id="main">
 
 <article>
   <header class="post-hero">
@@ -292,6 +295,7 @@
 
   </div>
 </article>
+</main>
 
 <footer>
   <div class="wrap">

--- a/site/news-instant-x.html
+++ b/site/news-instant-x.html
@@ -37,10 +37,11 @@
 </style>
 </head>
 <body class="a-blue">
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -57,6 +58,8 @@
     </div>
   </div>
 </nav>
+
+<main id="main">
 
 <article>
   <header class="post-hero">
@@ -264,6 +267,7 @@
 
   </div>
 </article>
+</main>
 
 <footer>
   <div class="wrap">

--- a/site/news-perps.html
+++ b/site/news-perps.html
@@ -24,10 +24,11 @@
 </style>
 </head>
 <body class="a-violet">
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -44,6 +45,8 @@
     </div>
   </div>
 </nav>
+
+<main id="main">
 
 <article>
   <header class="post-hero">
@@ -128,6 +131,7 @@
 
   </div>
 </article>
+</main>
 
 <footer>
   <div class="wrap">

--- a/site/news-quickedit.html
+++ b/site/news-quickedit.html
@@ -41,10 +41,11 @@
 </style>
 </head>
 <body class="a-orange">
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -61,6 +62,8 @@
     </div>
   </div>
 </nav>
+
+<main id="main">
 
 <article>
   <header class="post-hero">
@@ -189,6 +192,7 @@
 
   </div>
 </article>
+</main>
 
 <footer>
   <div class="wrap">

--- a/site/news-rugguard.html
+++ b/site/news-rugguard.html
@@ -41,10 +41,11 @@
 </style>
 </head>
 <body class="a-red">
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -61,6 +62,8 @@
     </div>
   </div>
 </nav>
+
+<main id="main">
 
 <article>
   <header class="post-hero">
@@ -223,6 +226,7 @@
 
   </div>
 </article>
+</main>
 
 <footer>
   <div class="wrap">

--- a/site/news-the-after.html
+++ b/site/news-the-after.html
@@ -37,10 +37,11 @@
 </style>
 </head>
 <body class="a-green">
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -57,6 +58,8 @@
     </div>
   </div>
 </nav>
+
+<main id="main">
 
 <article>
   <header class="post-hero">
@@ -224,6 +227,7 @@
 
   </div>
 </article>
+</main>
 
 <footer>
   <div class="wrap">

--- a/site/news-trench-rank.html
+++ b/site/news-trench-rank.html
@@ -33,10 +33,11 @@
 </style>
 </head>
 <body class="a-violet">
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -53,6 +54,8 @@
     </div>
   </div>
 </nav>
+
+<main id="main">
 
 <article>
   <header class="post-hero">
@@ -107,6 +110,7 @@
 
   </div>
 </article>
+</main>
 
 <footer>
   <div class="wrap">

--- a/site/news-turbo.html
+++ b/site/news-turbo.html
@@ -44,10 +44,11 @@
 </style>
 </head>
 <body class="a-violet">
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -64,6 +65,8 @@
     </div>
   </div>
 </nav>
+
+<main id="main">
 
 <article>
   <header class="post-hero">
@@ -265,6 +268,7 @@
 
   </div>
 </article>
+</main>
 
 <footer>
   <div class="wrap">

--- a/site/news-v2.html
+++ b/site/news-v2.html
@@ -30,10 +30,11 @@
 </style>
 </head>
 <body class="a-orange">
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -50,6 +51,8 @@
     </div>
   </div>
 </nav>
+
+<main id="main">
 
 <article>
   <header class="post-hero">
@@ -215,6 +218,7 @@
 
   </div>
 </article>
+</main>
 
 <footer>
   <div class="wrap">

--- a/site/news-xray.html
+++ b/site/news-xray.html
@@ -51,10 +51,11 @@
 </style>
 </head>
 <body class="a-violet">
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -71,6 +72,8 @@
     </div>
   </div>
 </nav>
+
+<main id="main">
 
 <article>
   <header class="post-hero">
@@ -326,6 +329,7 @@
 
   </div>
 </article>
+</main>
 
 <footer>
   <div class="wrap">

--- a/site/news.html
+++ b/site/news.html
@@ -27,10 +27,11 @@
 </style>
 </head>
 <body>
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -47,6 +48,8 @@
     </div>
   </div>
 </nav>
+
+<main id="main">
 
 <!-- ============ HERO ============ -->
 <header class="hero news-hero">
@@ -260,6 +263,7 @@
     </div>
   </div>
 </section>
+</main>
 
 <footer>
   <div class="wrap">

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -12,10 +12,11 @@
 <link rel="stylesheet" href="style.css">
 </head>
 <body class="a-green">
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -32,6 +33,8 @@
     </div>
   </div>
 </nav>
+
+<main id="main">
 
 <article>
   <header class="post-hero">
@@ -88,6 +91,7 @@
 
   </div>
 </article>
+</main>
 
 <footer>
   <div class="wrap">

--- a/site/profile.html
+++ b/site/profile.html
@@ -356,10 +356,11 @@
 </style>
 </head>
 <body>
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -386,7 +387,7 @@
   </div>
 </header>
 
-<main class="wrap" style="padding-bottom:96px">
+<main id="main" class="wrap" style="padding-bottom:96px">
   <div class="ar-shell" id="shell">
 
     <!-- Pane titles carry role="heading" rather than being <h2>: style.css

--- a/site/sprint.html
+++ b/site/sprint.html
@@ -138,10 +138,11 @@
 </style>
 </head>
 <body>
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -215,7 +216,7 @@
   </div>
 </header>
 
-<main class="wrap" style="padding-bottom:96px">
+<main id="main" class="wrap" style="padding-bottom:96px">
   <div class="ar-shell">
 
     <div class="ar-stack">

--- a/site/streamer-signup.html
+++ b/site/streamer-signup.html
@@ -75,10 +75,11 @@
 </style>
 </head>
 <body>
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -95,6 +96,8 @@
     </div>
   </div>
 </nav>
+
+<main id="main">
 
 <header class="hero compact">
   <div class="wrap">
@@ -214,6 +217,7 @@
     </aside>
   </div>
 </section>
+</main>
 
 <footer>
   <div class="wrap">

--- a/site/streams.html
+++ b/site/streams.html
@@ -136,10 +136,11 @@
 </style>
 </head>
 <body>
-<div class="bg-glow"></div>
-<div class="bg-grid"></div>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
 
-<nav>
+<nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
     <div class="nav-links">
@@ -156,6 +157,8 @@
     </div>
   </div>
 </nav>
+
+<main id="main">
 
 <!-- ============ HERO ============ -->
 <header class="hero compact">
@@ -250,6 +253,7 @@
     </div>
   </div>
 </section>
+</main>
 
 <footer>
   <div class="wrap">

--- a/site/style.css
+++ b/site/style.css
@@ -47,6 +47,22 @@ a:focus-visible, button:focus-visible {
   outline-offset: 3px;
   border-radius: 8px;
 }
+/* Skip link — the first tab stop on every page.
+   Ten-odd nav links sit before the content, so reaching it by keyboard meant
+   tabbing through all of them on every navigation. Positioned off-screen
+   rather than display:none: a hidden element is not focusable, and a skip
+   link that cannot be focused is decoration. */
+.skip-link {
+  position: absolute; left: 12px; top: -60px; z-index: 200;
+  padding: 10px 18px; border-radius: 0 0 10px 10px;
+  background: var(--orange); color: #2a1400;
+  font-size: 14px; font-weight: 750;
+  transition: top .18s;
+}
+.skip-link:focus { top: 0; }
+
+/* The landmark is a scroll target, not a control — no ring when jumped to. */
+#main:focus { outline: none; }
 
 /* Anchor jumps (#bubbles, #install, …) land below the fixed navbar instead
    of underneath it. */


### PR DESCRIPTION
`site/index.html` had **zero** aria attributes and no landmarks, and **20 of 27 pages had no `<main>` at all**.

The practical cost lands on every navigation: eleven nav links sit before the content, so reaching the page by keyboard meant tabbing through all of them — every time, on every page.

## Four things, applied uniformly

| | |
| --- | --- |
| **Skip link** | first focusable element on every page |
| **`<main id="main">`** | for it to land on |
| **`aria-label` on the primary `<nav>`** | so a screen reader can tell it from the navs inside a page |
| **`aria-hidden` on `.bg-glow` / `.bg-grid`** | decorative gradients with nothing to announce |

The seven Arena pages already had a `<main>` and only needed the id. The other twenty are wrapped from the end of the site nav to the footer — which is exactly the page''s own content on all of them.

The skip link is positioned off-screen rather than `display: none`. **A hidden element is not focusable**, and a skip link that can''t be focused is decoration.

## No structural risk

Verified before writing it: `style.css` targets `section` as a bare element, and nothing keys off `body > section` or sibling order, so the wrap changes no layout. Every `<img>` already carried `alt`.

## preflight now checks it

Same reasoning as the nav-destinations check directly above it — 20 of 27 pages had no landmark **because nothing said they should**. Mutation-tested: stripping the skip link from `privacy.html` fails it by name.

### Worth flagging: the guard''s first version passed vacuously

Written through a generator, the quoting collapsed to:

```sh
grep -q "class="nav-links""      # greps for  class=nav-links
```

...which matches nothing, so every page took the `|| continue` — a green check that had checked nothing. I caught it by testing the pattern directly, rewrote it with single-quoted patterns, and confirmed it matches before trusting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
