### PR TITLE
feat(overlay): keyboard shortcuts, off by default, page-local

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ details live in the commit messages.
 
 ## Unreleased
 
+**Keyboard shortcuts, off by default.** Pick **Alt + key** or **Ctrl + Shift + key**
+in Settings and three keys become available on any trading page: **P** shows or
+hides the trade panel, **B** the positions bar, **A** jumps straight to the
+amount box. Nothing here places an order and nothing opens or closes a tab, and
+the keys stay out of the way entirely while you are typing in any field.
+
 **Streamer signup lives on the site now.** "Sign up as a streamer" used to
 hand you off to a Google Form; it now opens **papertrench.com/streamer-signup**
 — the same questions, on the site, in the site's own styling. Applications go

--- a/extension/content.js
+++ b/extension/content.js
@@ -5251,6 +5251,58 @@
     renderPositionsBar();
   }
 
+  /* ---------------- keyboard shortcuts ----------------
+   *
+   * Three bindings, and every one of them only moves PaperTrench's own
+   * furniture: show the panel, show the positions bar, put the cursor in the
+   * amount box. Deliberately nothing that trades and nothing that touches a
+   * tab — a keystroke that fires an order is a keystroke that fires one by
+   * accident, and opening or closing tabs from a key is exactly what this was
+   * asked to stay away from.
+   *
+   * Off by default. Two schemes rather than a rebinding UI: these run on other
+   * people's sites, where every plain key and most single-modifier combos are
+   * already spoken for, so the choice that matters is which modifier is free
+   * on the terminal you use — not which letter.
+   */
+  const SHORTCUT_SCHEMES = {
+    alt: (e) => e.altKey && !e.ctrlKey && !e.metaKey && !e.shiftKey,
+    ctrlshift: (e) => e.ctrlKey && e.shiftKey && !e.altKey && !e.metaKey,
+  };
+
+  function onShortcutKey(event) {
+    const test = SHORTCUT_SCHEMES[settings && settings.shortcutScheme];
+    if (!test || masterOff || settings.overlayEnabled === false) return;
+    if (event.repeat || !test(event)) return;
+
+    // Never steal a key from something being typed into — the host site's
+    // search box, a comment field, or our own amount input.
+    const target = event.composedPath ? event.composedPath()[0] : event.target;
+    if (target && (/^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName || '')
+      || target.isContentEditable)) return;
+
+    const key = String(event.key || '').toLowerCase();
+    if (key === 'p') {
+      panelMinimized = !panelMinimized;
+      setPanelVisible(true);
+    } else if (key === 'b') {
+      setBarHidden(!positionsBarHidden);
+    } else if (key === 'a') {
+      if (!els.custom || els.custom.offsetParent === null) return; // buy section hidden
+      panelMinimized = false;
+      setPanelVisible(true);
+      els.custom.focus();
+      els.custom.select();
+    } else return;
+
+    // Claimed only once we know we acted, so an unbound combo still reaches
+    // whatever the site wanted it for.
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  window.addEventListener('keydown', onShortcutKey, true);
+
   function renderPresets() {
     // Two user toggles strip the buy controls back: the preset row can be
     // hidden on its own, or the whole buy section (label, presets, custom

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -4232,6 +4232,17 @@ function renderSettings(el) {
         <div class="field field-check"><label><input type="checkbox" id="set-overlay" ${settings.overlayEnabled !== false ? 'checked' : ''}> Enable overlay</label><small>The trade panel itself. Off hides the panel on all pages (the switch above outranks this one).</small></div>
         <div class="field field-check"><label><input type="checkbox" id="set-overlay-auto-hide" ${settings.overlayHideWhenNoToken !== false ? 'checked' : ''}> Hide overlay when no token is detected</label><small>The panel disappears on home pages and screeners, then pops back when you open a coin.</small></div>
         <div class="field field-check"><label><input type="checkbox" id="set-focus-mode" ${settings.panelFocusMode === true ? 'checked' : ''}> Focus mode — minimal trade panel</label><small>Strips the banner, sparkline, thesis and last-close card from the trade tab — only token, price, balance and buy/sell controls remain. For distraction-free execution.</small></div>
+        <div class="field"><label for="set-shortcuts">Keyboard shortcuts</label>
+          <select id="set-shortcuts">
+            <option value="off" ${!settings.shortcutScheme || settings.shortcutScheme === 'off' ? 'selected' : ''}>Off</option>
+            <option value="alt" ${settings.shortcutScheme === 'alt' ? 'selected' : ''}>Alt + key</option>
+            <option value="ctrlshift" ${settings.shortcutScheme === 'ctrlshift' ? 'selected' : ''}>Ctrl + Shift + key</option>
+          </select>
+          <small><b>P</b> show/hide the trade panel · <b>B</b> show/hide the positions bar · <b>A</b> jump to the amount box.
+          Two schemes rather than free rebinding, because these run on the dex's own page where most combinations are already
+          taken — the choice that matters is which modifier is free on the terminal you use, not which letter. Nothing here
+          trades, and nothing opens or closes a tab. Keys are ignored while you are typing in any field.</small>
+        </div>
       </div>
       <div class="card">
         <h3>Instant links</h3>
@@ -4523,6 +4534,11 @@ function gatherSettingsFromForm(notes = [], base = settings) {
     overlayEnabled: document.getElementById('set-overlay').checked,
     overlayHideWhenNoToken: document.getElementById('set-overlay-auto-hide').checked,
     panelFocusMode: document.getElementById('set-focus-mode').checked,
+    // Closed set, validated here rather than trusted: content.js looks the
+    // value up in SHORTCUT_SCHEMES, and anything unrecognised means no
+    // shortcuts at all — which would be an invisible failure, not a refusal.
+    shortcutScheme: ['off', 'alt', 'ctrlshift'].includes(document.getElementById('set-shortcuts').value)
+      ? document.getElementById('set-shortcuts').value : 'off',
     gamingModeEnabled: document.getElementById('set-gaming-mode').checked,
     warmXLinksEnabled: document.getElementById('set-warm-x').checked,
     warmEverywhereEnabled: document.getElementById('set-warm-everywhere').checked,

--- a/extension/test/shortcuts.test.js
+++ b/extension/test/shortcuts.test.js
@@ -1,0 +1,97 @@
+/* Keyboard shortcuts.
+ *
+ * Requested with an explicit limit: "make sure it's changeable in the settings
+ * and only give a couple options in a dropdown so it doesn't affect the tab
+ * like closing or opening new tabs with commands."
+ *
+ * So the tests that matter are the ones about what these keys must NEVER do.
+ * They run on other people's trading pages, inside a document the user is also
+ * typing into, and a keystroke that fires an order fires one by accident.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const content = fs.readFileSync(path.join(ROOT, 'content.js'), 'utf8');
+const dashJs = fs.readFileSync(path.join(ROOT, 'dashboard.js'), 'utf8');
+const manifest = JSON.parse(fs.readFileSync(path.join(ROOT, 'manifest.json'), 'utf8'));
+
+function handler() {
+  const start = content.indexOf('function onShortcutKey(');
+  assert.ok(start !== -1, 'onShortcutKey must exist');
+  const end = content.indexOf('\n  }', start);
+  return content.slice(start, end + 4);
+}
+
+test('shortcuts are in-page, not Chrome commands', () => {
+  // A manifest `commands` entry is configured at chrome://extensions/shortcuts,
+  // not in our settings, and cannot be limited to acting only on the page —
+  // which is exactly the control that was asked for.
+  assert.ok(!manifest.commands,
+    'no manifest commands block: these must stay page-local and settings-controlled');
+});
+
+test('no shortcut can open, close or navigate a tab', () => {
+  const fn = handler();
+  for (const banned of ['chrome.tabs', 'window.open', 'location.href', 'location.assign', 'target="_blank"']) {
+    assert.ok(!fn.includes(banned), `a shortcut must never reach for ${banned}`);
+  }
+});
+
+test('no shortcut can place an order', () => {
+  // The whole point of paper trading is that mistakes are cheap, but an
+  // accidental fill still corrupts the journal it teaches from.
+  const fn = handler();
+  for (const banned of ['requestBuy', 'doBuy', 'doSell', 'requestSell']) {
+    assert.ok(!fn.includes(banned), `a shortcut must never call ${banned}`);
+  }
+});
+
+test('shortcuts are off until the user picks a scheme', () => {
+  const fn = handler();
+  assert.match(fn, /SHORTCUT_SCHEMES\[settings && settings\.shortcutScheme\]/,
+    'the active scheme comes from settings');
+  assert.match(fn, /if \(!test\b/, 'an unset or unknown scheme must disable them entirely');
+  // 'off' is not a scheme, so the lookup misses and nothing binds.
+  const table = content.slice(content.indexOf('const SHORTCUT_SCHEMES'), content.indexOf('function onShortcutKey('));
+  assert.ok(!/\boff\s*:/.test(table), "'off' must not be a scheme — it is the absence of one");
+});
+
+test('keys are ignored while the user is typing', () => {
+  const fn = handler();
+  assert.match(fn, /INPUT\|TEXTAREA\|SELECT/, 'form fields must keep their keys');
+  assert.match(fn, /isContentEditable/, 'and so must rich-text editors');
+  assert.match(fn, /composedPath/,
+    'the real target must be read through the shadow boundary, not the retarget');
+});
+
+test('the master switch and a disabled overlay both silence them', () => {
+  const fn = handler();
+  assert.match(fn, /masterOff/, 'the app-wide off switch outranks shortcuts');
+  assert.match(fn, /overlayEnabled === false/, 'a hidden panel has nothing to toggle');
+});
+
+test('an unhandled combination is left for the site', () => {
+  const fn = handler();
+  const prevent = fn.indexOf('event.preventDefault()');
+  const bail = fn.indexOf('} else return;');
+  assert.ok(bail !== -1 && bail < prevent,
+    'unrecognised keys must return BEFORE the event is claimed');
+});
+
+test('the settings dropdown offers exactly the schemes the page implements', () => {
+  const table = content.slice(content.indexOf('const SHORTCUT_SCHEMES'), content.indexOf('function onShortcutKey('));
+  const implemented = [...table.matchAll(/^\s{4}(\w+):/gm)].map((m) => m[1]);
+  const select = dashJs.slice(dashJs.indexOf('<select id="set-shortcuts">'), dashJs.indexOf('</select>', dashJs.indexOf('<select id="set-shortcuts">')));
+  const offered = [...select.matchAll(/value="(\w+)"/g)].map((m) => m[1]);
+  assert.deepEqual(offered, ['off', ...implemented],
+    'the dropdown and the implementation must not drift apart');
+  assert.ok(offered.length <= 3, 'the request was for a couple of options, not a rebinding UI');
+});
+
+test('the saved scheme is validated against that same closed set', () => {
+  assert.match(dashJs, /\['off', 'alt', 'ctrlshift'\]\.includes\(/,
+    'an unrecognised value would disable shortcuts silently rather than refuse');
+});


### PR DESCRIPTION
> *"make sure it''s changeable in the settings and only give a couple options in a dropdown so it doesn''t affect the tab like closing or opening new tabs with commands"*

The limit is built in, and the tests are mostly about what these keys must **never** do.

## In-page handlers, not a manifest `commands` block

Chrome commands are configured at `chrome://extensions/shortcuts` — **not** in our settings — and they can''t be scoped to "only act on the page". That''s the exact control that was asked for, so they''re page-local handlers instead. A test pins it: no `commands` block may appear in the manifest.

## Three bindings, all UI-only

| Key | Does |
| --- | --- |
| **P** | show/hide the trade panel |
| **B** | show/hide the positions bar |
| **A** | jump to the amount box |

**Nothing that trades**, deliberately — paper mistakes are cheap, but an accidental fill still corrupts the journal the product teaches from. **Nothing that touches a tab**, equally deliberately.

## Why two schemes and not a rebinding UI

These run on the dex''s own page, where nearly every plain key and single-modifier combo is already taken. The choice that actually matters is **which modifier is free on the terminal you use** — not which letter. A rebinding UI would hand over control of the half that doesn''t matter.

## Guards, in order

1. No scheme set (the default) → nothing binds
2. Master switch off, or overlay disabled → silent
3. Focus is in an `INPUT` / `TEXTAREA` / `SELECT` / contenteditable → key left alone
4. `preventDefault()` runs **only after** we know we acted, so an unbound combination still reaches whatever the site wanted it for

The focus check reads `composedPath()[0]` — the retargeted `event.target` would report our host element rather than the field actually being typed into, which would make guard 3 useless from inside the shadow root.

## Tests

Nine, weighted at the prohibitions: no `chrome.tabs` / `window.open` / `location` reachable from a shortcut, no order-placing call reachable either, and the settings dropdown is cross-checked against `SHORTCUT_SCHEMES` — they''re the same closed set written twice, and drift would mean offering a scheme that silently does nothing.

```
extension  1729/1730
```

The one failure is `perpswiring.test.js` — fixed separately in #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
