### PR TITLE
feat(dashboard): what's new, once per version, baked into the build

### DIFF
--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -157,6 +157,38 @@
       text-transform: uppercase; color: var(--dim);
     }
     .card h4 { margin: 16px 0 8px; font-size: 12px; font-weight: 700; color: var(--dim); }
+    /* ---------- what's new ---------- */
+    #pt-whatsnew {
+      position: fixed; inset: 0; z-index: 200;
+      display: grid; place-items: center; padding: 24px;
+      background: rgba(4, 6, 10, 0.72); backdrop-filter: blur(4px);
+    }
+    .wn-card {
+      width: min(560px, 100%); max-height: 80vh; display: flex; flex-direction: column;
+      background: var(--panel-solid); border: 1px solid var(--line-2);
+      border-radius: var(--r-xl); box-shadow: var(--shadow-lg);
+    }
+    .wn-head { display: flex; align-items: flex-start; gap: 12px; padding: 20px 22px 12px; }
+    .wn-kicker { font-size: 9.5px; font-weight: 800; letter-spacing: 1.3px; text-transform: uppercase; color: var(--amber); }
+    .wn-head h2 { margin: 4px 0 0; font-size: 18px; font-weight: 800; letter-spacing: -0.3px; }
+    .wn-close {
+      margin-left: auto; width: 28px; height: 28px; flex: none;
+      font: inherit; font-size: 17px; line-height: 1; cursor: pointer;
+      color: var(--faint); background: none; border: 0; border-radius: 8px;
+    }
+    .wn-close:hover { color: var(--text); background: var(--raised); }
+    .wn-body { overflow-y: auto; padding: 4px 22px 8px; }
+    .wn-entry { padding: 12px 0; border-bottom: 1px solid var(--line); }
+    .wn-entry:last-child { border-bottom: none; }
+    .wn-entry h3 { margin: 0 0 5px; font-size: 14px; font-weight: 750; color: var(--text); letter-spacing: 0; text-transform: none; }
+    .wn-entry p { margin: 0; font-size: 13px; line-height: 1.62; color: var(--dim); }
+    .wn-foot {
+      display: flex; align-items: center; gap: 12px;
+      padding: 14px 22px 18px; border-top: 1px solid var(--line);
+    }
+    .wn-foot a { color: var(--amber); font-size: 12.5px; font-weight: 650; text-decoration: none; }
+    .wn-foot a:hover { text-decoration: underline; }
+    .wn-foot .btn { margin-left: auto; }
     .grid2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(370px, 1fr)); gap: 16px; align-items: start; }
     .grid3 { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 16px; align-items: start; }
 

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -251,6 +251,8 @@ async function init() {
   // Unpacked installs never auto-update; this is the only channel that tells
   // a user a fix shipped. Renders once per load, before any section.
   try { renderUpdateBanner(); } catch (_) {}
+  // And once, after an update actually lands, what changed in it.
+  renderWhatsNew().catch((err) => console.warn("PaperTrench: what's-new skipped —", err.message));
   renderSidebar();
   renderSection(currentSection);
   // Seed the baseline so the first poll does not re-render an unchanged page.
@@ -655,6 +657,79 @@ async function renderUpdateBanner() {
   document.body.insertBefore(banner, document.body.firstChild);
   const dismiss = banner.querySelector('#pt-update-dismiss');
   if (dismiss) dismiss.addEventListener('click', () => banner.remove());
+}
+
+/**
+ * "What's new", once per version.
+ *
+ * An unpacked install has no update channel and no store listing, so a user who
+ * replaces the folder has nowhere to learn what they just got. The notes are
+ * baked into the build by scripts/make-whatsnew.js and read from disk — no
+ * network, and true of the build actually running rather than of whatever is
+ * newest on GitHub.
+ *
+ * Shown when the running version differs from the last one acknowledged here.
+ * A FIRST install is not an update, so it is recorded silently: opening a brand
+ * new dashboard to a changelog for a version you have never not had is noise.
+ */
+async function renderWhatsNew() {
+  const version = String(chrome.runtime.getManifest().version);
+  const stored = await chrome.storage.local.get(['pt_whatsnew_seen']);
+  const seen = stored && stored.pt_whatsnew_seen;
+
+  if (seen === version) return;
+  if (!seen) {
+    // Nothing acknowledged yet: this is a first run, not an upgrade.
+    await chrome.storage.local.set({ pt_whatsnew_seen: version });
+    return;
+  }
+
+  const res = await fetch(chrome.runtime.getURL('whatsnew.json'));
+  const notes = await res.json();
+  // The notes are baked per build, so a mismatch means the file was not
+  // regenerated for this version. Say nothing rather than show the last one.
+  if (!notes || notes.version !== version || !Array.isArray(notes.entries) || !notes.entries.length) {
+    await chrome.storage.local.set({ pt_whatsnew_seen: version });
+    return;
+  }
+
+  const wrap = document.createElement('div');
+  wrap.id = 'pt-whatsnew';
+  wrap.innerHTML = `
+    <div class="wn-card" role="dialog" aria-modal="true" aria-labelledby="wn-title">
+      <div class="wn-head">
+        <div>
+          <div class="wn-kicker">Updated</div>
+          <h2 id="wn-title">What's new in v${esc(version)}</h2>
+        </div>
+        <button class="wn-close" id="wn-close" aria-label="Close">×</button>
+      </div>
+      <div class="wn-body">
+        ${notes.entries.map((e) => `
+          <div class="wn-entry">
+            ${e.title ? `<h3>${esc(e.title)}</h3>` : ''}
+            <p>${esc(e.text)}</p>
+          </div>`).join('')}
+      </div>
+      <div class="wn-foot">
+        <a href="https://papertrench.com/news" target="_blank" rel="noopener noreferrer">All patch notes ↗</a>
+        <button class="btn" id="wn-done">Got it</button>
+      </div>
+    </div>`;
+  document.body.appendChild(wrap);
+
+  // Acknowledged on close, not on show: a dashboard opened and abandoned
+  // should still get one chance to read this.
+  const close = async () => {
+    wrap.remove();
+    try { await chrome.storage.local.set({ pt_whatsnew_seen: version }); } catch (_) {}
+  };
+  wrap.querySelector('#wn-close').addEventListener('click', close);
+  wrap.querySelector('#wn-done').addEventListener('click', close);
+  wrap.addEventListener('click', (e) => { if (e.target === wrap) close(); });
+  document.addEventListener('keydown', function esc2(e) {
+    if (e.key === 'Escape') { document.removeEventListener('keydown', esc2); close(); }
+  });
 }
 
 async function saveSettings() {

--- a/extension/test/whatsnew.test.js
+++ b/extension/test/whatsnew.test.js
@@ -1,0 +1,93 @@
+/* "What's new", once per version.
+ *
+ * An unpacked install has no update channel and no store listing, so someone
+ * who replaces the folder has nowhere to learn what they just got. The notes
+ * are baked into the build rather than fetched: the extension does not call
+ * home to read its own release notes, and a baked file is true of the build
+ * actually running rather than of whatever is newest on GitHub.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const ROOT = path.join(__dirname, '..');
+const REPO = path.join(ROOT, '..');
+const dashJs = fs.readFileSync(path.join(ROOT, 'dashboard.js'), 'utf8');
+const manifest = JSON.parse(fs.readFileSync(path.join(ROOT, 'manifest.json'), 'utf8'));
+const notes = JSON.parse(fs.readFileSync(path.join(ROOT, 'whatsnew.json'), 'utf8'));
+
+function fn() {
+  const start = dashJs.indexOf('async function renderWhatsNew(');
+  assert.ok(start !== -1, 'renderWhatsNew must exist');
+  return dashJs.slice(start, dashJs.indexOf('\n}', start) + 2);
+}
+
+test('the baked notes describe the version that is actually shipping', () => {
+  assert.equal(notes.version, manifest.version,
+    'whatsnew.json must be regenerated whenever the manifest version moves');
+  assert.ok(Array.isArray(notes.entries) && notes.entries.length,
+    'a release with no notes tells the user nothing');
+});
+
+test('whatsnew.json is exactly what CHANGELOG.md says — no hand edits', () => {
+  // It is generated, so it can drift the moment someone edits either side.
+  execFileSync(process.execPath,
+    [path.join(REPO, 'scripts', 'make-whatsnew.js'), '--check'],
+    { cwd: REPO, encoding: 'utf8' });
+});
+
+test('the notes are read from the build, never from the network', () => {
+  const body = fn();
+  assert.match(body, /chrome\.runtime\.getURL\('whatsnew\.json'\)/,
+    'the notes must come from the packaged file');
+  for (const banned of ['api.github.com', 'https://papertrench-api', 'releases/latest']) {
+    assert.ok(!body.includes(banned), `what's-new must not reach for ${banned}`);
+  }
+});
+
+test('a first install is not treated as an update', () => {
+  // Opening a brand-new dashboard to a changelog for a version you have never
+  // not had is noise, not news.
+  const body = fn();
+  assert.match(body, /if \(!seen\)/, 'an unseen-version marker means first run');
+  assert.match(body, /pt_whatsnew_seen: version/, 'and is recorded silently');
+});
+
+test('it shows once, and only after the version actually changes', () => {
+  const body = fn();
+  assert.match(body, /if \(seen === version\) return;/,
+    'the same version must never show twice');
+});
+
+test('acknowledgement happens on close, not on show', () => {
+  // A dashboard opened and abandoned should still get one chance to be read.
+  const body = fn();
+  const showAt = body.indexOf('document.body.appendChild(wrap)');
+  const markAt = body.indexOf('const close =');
+  assert.ok(showAt !== -1 && markAt > showAt,
+    'the seen-marker write must live in the close handler, after the render');
+});
+
+test('a stale or mismatched notes file says nothing rather than the wrong thing', () => {
+  const body = fn();
+  assert.match(body, /notes\.version !== version/,
+    'notes baked for another version must not be shown as this one');
+});
+
+test('applicant-facing text is escaped', () => {
+  // The notes come from CHANGELOG.md, which is ours — but it is markdown full
+  // of quotes and angle brackets, and this renders through innerHTML.
+  const body = fn();
+  assert.match(body, /esc\(e\.title\)/, 'titles must be escaped');
+  assert.match(body, /esc\(e\.text\)/, 'and so must bodies');
+});
+
+test('the dialog can be dismissed by every route a user will try', () => {
+  const body = fn();
+  assert.match(body, /#wn-close/, 'the × closes it');
+  assert.match(body, /#wn-done/, 'the button closes it');
+  assert.match(body, /e\.target === wrap/, 'clicking the backdrop closes it');
+  assert.match(body, /'Escape'/, 'Escape closes it');
+});

--- a/extension/whatsnew.json
+++ b/extension/whatsnew.json
@@ -1,0 +1,14 @@
+{
+  "version": "3.12.1",
+  "date": "2026-08-22",
+  "entries": [
+    {
+      "title": "Lute is in the Instant-links list",
+      "text": "(Terp: \"instant link loading needs to be setup for lute also, i think we jsu forgot to ad that feature for the site\"). Lute has actually had the full treatment since early August — token links anywhere route to a kept-warm lute.gg viewer, and links on lute.gg to other terminals route the same way. What was missing was the telling of it: the Settings → \"Instant terminal links\" description listed every other terminal and left Lute out, so the feature read as forgotten. The list now names Lute, and a regression test re-derives the list from the actual terminal registry so no terminal can be silently dropped from it again."
+    },
+    {
+      "title": "The dashboard sidebar is alive again",
+      "text": "(pre-existing, since 8/20). A referenced-but-never-defined variable crashed the dashboard's first paint — the sidebar's equity/PnL/discipline KPIs didn't appear until you clicked into a section, and the season share card never opened at all. Both fixed; the live gate now asserts a clean init with zero console errors."
+    }
+  ]
+}

--- a/scripts/make-whatsnew.js
+++ b/scripts/make-whatsnew.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/* Bake the running version's patch notes into the extension.
+ *
+ *   node scripts/make-whatsnew.js          write extension/whatsnew.json
+ *   node scripts/make-whatsnew.js --check  verify it matches CHANGELOG.md
+ *
+ * The dashboard shows these once after an update. Baked at build time rather
+ * than fetched, for two reasons: an unpacked install has no update channel to
+ * ask, and the doctrine is that the extension does not call home to read its
+ * own release notes. The file is small, it is the truth as shipped, and it
+ * works with the network off.
+ *
+ * "Unreleased" is deliberately skipped — it describes work that is not in the
+ * build the user is running, and showing it would be the release-notes version
+ * of a wrong number.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const CHANGELOG = path.join(ROOT, 'CHANGELOG.md');
+const MANIFEST = path.join(ROOT, 'extension', 'manifest.json');
+const OUT = path.join(ROOT, 'extension', 'whatsnew.json');
+
+const version = JSON.parse(fs.readFileSync(MANIFEST, 'utf8')).version;
+const md = fs.readFileSync(CHANGELOG, 'utf8').replace(/\r\n/g, '\n');
+
+/** The body of `## v<version> — <date>`, up to the next `## `. */
+function sectionFor(v) {
+  const re = new RegExp(`^## v${v.replace(/\./g, '\\.')}(?:\\s+—\\s+(\\S+))?\\s*$`, 'm');
+  const m = re.exec(md);
+  if (!m) return null;
+  const from = m.index + m[0].length;
+  const next = md.indexOf('\n## ', from);
+  return { date: m[1] || null, body: md.slice(from, next === -1 ? undefined : next).trim() };
+}
+
+/**
+ * Markdown -> the small shape the dashboard renders.
+ *
+ * Each entry in this changelog is a **bold lead-in** followed by prose, so the
+ * lead-in becomes the headline and the rest the detail. Anything that does not
+ * fit that shape is kept as a plain paragraph rather than dropped — release
+ * notes that silently omit an item are worse than ones that look uneven.
+ */
+function parseEntries(body) {
+  return body.split(/\n\s*\n/).map((para) => {
+    const flat = para.replace(/\n/g, ' ').trim();
+    if (!flat) return null;
+    const lead = /^\*\*(.+?)\*\*\s*(.*)$/.exec(flat);
+    if (lead) return { title: lead[1].trim(), text: lead[2].trim() };
+    return { title: null, text: flat };
+  }).filter(Boolean);
+}
+
+const section = sectionFor(version);
+if (!section) {
+  console.error(`CHANGELOG.md has no "## v${version}" section — release notes cannot be baked.`);
+  process.exit(1);
+}
+
+const payload = {
+  version,
+  date: section.date,
+  entries: parseEntries(section.body),
+};
+const json = JSON.stringify(payload, null, 2) + '\n';
+
+if (process.argv.includes('--check')) {
+  const current = fs.existsSync(OUT) ? fs.readFileSync(OUT, 'utf8') : null;
+  if (current !== json) {
+    console.error('extension/whatsnew.json is stale — run: node scripts/make-whatsnew.js');
+    process.exit(1);
+  }
+  console.log(`whatsnew OK (v${version}, ${payload.entries.length} entries)`);
+} else {
+  fs.writeFileSync(OUT, json);
+  console.log(`wrote extension/whatsnew.json (v${version}, ${payload.entries.length} entries)`);
+}

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -18,6 +18,10 @@ echo "manifest: $MANIFEST_V  package: $PACKAGE_V"
 [ "$MANIFEST_V" = "$PACKAGE_V" ] || fail "manifest.json ($MANIFEST_V) != package.json ($PACKAGE_V)"
 
 grep -q "## v$MANIFEST_V" CHANGELOG.md || fail "CHANGELOG.md has no entry for v$MANIFEST_V"
+# The in-extension patch notes are generated from the section above, so they
+# rot the moment a version is bumped without regenerating them — and a user
+# who just updated would be shown the PREVIOUS release as if it were new.
+node scripts/make-whatsnew.js --check || fail "extension/whatsnew.json is stale for v$MANIFEST_V"
 # Download CTAs must point at /releases/latest and never pin a versioned zip,
 # which 404s until the release asset exists (policy since f23df6c).
 grep -q 'github.com/OnlyTerp/papertrench/releases/latest' site/index.html \


### PR DESCRIPTION
An unpacked install has no update channel and no store listing. Someone who replaces the folder has nowhere to learn what they just got — the existing update banner only says a newer version **exists**, never what was in it.

## Baked, not fetched

`scripts/make-whatsnew.js` reads the running manifest version, pulls that section out of `CHANGELOG.md`, and writes `extension/whatsnew.json`.

Two reasons it isn''t a network read:

1. The doctrine is that the extension doesn''t call home to read its own release notes
2. A baked file is true of **the build actually running**, rather than of whatever is newest on GitHub

It also works with the network off.

`## Unreleased` is deliberately skipped — it describes work that is *not* in the build the user is holding, and showing it would be the release-notes equivalent of a wrong number.

## Shown once, and only for an actual update

- **A first install is recorded silently.** Opening a brand-new dashboard to a changelog for a version you have never *not* had is noise, not news.
- **The seen-marker is written on close, not on show** — a dashboard opened and abandoned still gets one chance to be read.
- **A version mismatch renders nothing.** If `whatsnew.json` was baked for a different version, showing the previous release to someone who just updated is worse than showing nothing.

## preflight regenerates and compares

The file is generated, so it rots the moment a version is bumped without rerunning the tool — and the person who just updated would be shown the **previous** release as if it were new. `make-whatsnew.js --check` now runs right beside the "CHANGELOG has an entry for this version" check it depends on.

## Tests

Nine, including the ones that matter most:

- the notes are read from the packaged file and **never** from a URL (no `api.github.com`, no `releases/latest`)
- a version mismatch renders nothing
- titles and bodies are escaped — they arrive from markdown full of quotes and angle brackets, through `innerHTML`
- all four dismissal routes work (×, button, backdrop, Escape)
- and `--check` runs from the suite, so a hand-edited `whatsnew.json` fails

```
extension  1729/1730
```

The one failure is `perpswiring.test.js` — fixed separately in #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
