### PR TITLE
fix(site): finish the extensionless migration - the URLs JS builds

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -59,6 +59,20 @@ done
 [ -z "$NAV_MISSING" ] || fail "nav is missing destinations —$NAV_MISSING"
 echo "nav OK ($(grep -lc 'class="nav-links"' site/*.html | wc -l) pages reach $NAV_DESTS)"
 
+# The site links its pages extensionless. A "<page>.html" string left in JS
+# is not a broken link — .html still resolves — which is exactly why it
+# survives review: it works, it is just the wrong spelling, and it escapes
+# an href-based sweep because it is built at runtime.
+#
+# One of these shipped into the SHARE URL for every duel, so the link people
+# passed around carried the old form indefinitely.
+STALE_URLS=$(grep -rnoE "'[a-z0-9-]+\.html" site/*.html site/*.js | grep -v papertrench.com || true)
+if [ -n "$STALE_URLS" ]; then
+  echo "$STALE_URLS" >&2
+  fail "site JS still builds .html URLs — the site links extensionless"
+fi
+echo "url spelling OK (no .html URLs built in site JS)"
+
 # Every public page must be in sitemap.xml, or deliberately named as excluded.
 #
 # A sitemap is the one file that rots without any symptom: pages get added, the

--- a/site/clans.html
+++ b/site/clans.html
@@ -412,7 +412,7 @@
         const { out } = await post('/api/clan/join', {
           code: document.getElementById('join-code').value,
         });
-        if (out && out.ok) { window.location.href = 'clan.html?tag=' + encodeURIComponent(out.tag); return; }
+        if (out && out.ok) { window.location.href = '/clan?tag=' + encodeURIComponent(out.tag); return; }
         tell(`<p class="ar-note">${esc(problemText((out && out.reason) || 'server-error'))}</p>`);
       });
     }
@@ -445,7 +445,7 @@
           motto: document.getElementById('new-motto').value,
           open: document.getElementById('new-open').checked,
         });
-        if (out && out.ok) { window.location.href = 'clan.html?tag=' + encodeURIComponent(out.tag); return; }
+        if (out && out.ok) { window.location.href = '/clan?tag=' + encodeURIComponent(out.tag); return; }
         tell(`<p class="ar-note">${esc(problemText((out && out.reason) || 'server-error'))}</p>`);
       });
     }

--- a/site/duel.html
+++ b/site/duel.html
@@ -1327,7 +1327,7 @@
     document.getElementById('eyebrow-text').textContent = 'No duel code in this link';
     fail(L.empty('🔗', 'This link has no duel code in it.',
       'A duel link carries its code in the address, like ' +
-      '<code style="font-family:var(--mono);color:var(--orange2)">duel.html?code=TRENCH-XXXXXX</code>. ' +
+      '<code style="font-family:var(--mono);color:var(--orange2)">/duel?code=TRENCH-XXXXXX</code>. ' +
       'Without one there is no duel to look up, and nothing is invented to fill the page. ' +
       '<a href="/duels" style="color:var(--orange2)">Your duels are here</a>.'));
     seatEl.innerHTML = '<p class="ar-note">Nothing to join without a code.</p>';

--- a/site/duels.html
+++ b/site/duels.html
@@ -1032,7 +1032,7 @@
     const code = String(body.code);
     // The server builds the canonical link from its own SITE_ORIGIN; fall back
     // to this page's origin only if it did not send one.
-    const url = body.url || new URL('duel.html?code=' + encodeURIComponent(code), location.href).href;
+    const url = body.url || new URL('/duel?code=' + encodeURIComponent(code), location.href).href;
     const duration = humanDuration(body.durationMs);
     const gauntlet = code + (duration ? ' · ' + duration : '') +
       ' · paper only, same clock, no money. Accept: ' + url;
@@ -1320,7 +1320,7 @@
   function duelCard(view, index) {
     const code = String(view.code || '');
     const status = String(view.status || '');
-    const href = 'duel.html?code=' + encodeURIComponent(code);
+    const href = '/duel?code=' + encodeURIComponent(code);
     const absolute = new URL(href, location.href).href;
     const w = view.window || {};
     const duration = humanDuration(view.durationMs);


### PR DESCRIPTION
> **Context:** I went looking to improve the empty states on `/clan`, `/duel` and `/profile`. They didn''t need it — each already renders an icon, a plain-language reason, and a link onward (*"No clan named."* → the clan board; *"This link has no duel code in it."* → your duels). **The example inside one of those states was stale**, and pulling that thread found four more.

The extensionless-URL change swept `href` attributes. It couldn''t see URLs assembled at runtime, and five survived:

| File | |
| --- | --- |
| `clans.html` ×2 | `location.href = 'clan.html?tag=' + tag` |
| `duels.html` | `new URL('duel.html?code=' + code, …)` — **the share link** |
| `duels.html` | `href = 'duel.html?code=' + code` |
| `duel.html` | the worked example in the no-code empty state |

None of these are broken links — `.html` still resolves — **which is exactly why they survived review**. They work. They''re just the wrong spelling, and an href-based sweep can''t reach a string concatenated in JS.

## Why this is a PR and not a tidy-up

`duels.html:1035` builds the URL people **share**. Every duel invite sent since the migration has carried the old form, and those links outlive the page that made them.

Verified the replacement still resolves absolutely:

```
new URL('/duel?code=ABC', 'https://papertrench.com/duels')
  → https://papertrench.com/duel?code=ABC
```

## preflight now greps for the pattern

Same reasoning as the checks above it: this class is invisible in review **because it functions**. The guard prints `file:line` for every offender and is mutation-tested — restoring the duel share URL fails it by name:

```
site/duels.html:1035:'duel.html
site/duels.html:1323:'duel.html
PREFLIGHT FAIL: site JS still builds .html URLs — the site links extensionless
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
