### PR TITLE
feat(site): profile control in the site header

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -79,6 +79,18 @@ done
 [ -z "$A11Y_MISSING" ] || fail "pages missing accessibility landmarks —$A11Y_MISSING"
 echo "a11y OK (skip link, main landmark and named nav on $(grep -lc 'class="skip-link"' site/*.html | wc -l) pages)"
 
+# The profile control is on every page or it is on none: a header that shows
+# who you are on the leaderboard and not on a news article reads as a bug in
+# the sign-in, not as a missing include.
+PROFILE_MISSING=""
+for page in site/*.html; do
+  grep -q 'class="nav-links"' "$page" || continue
+  grep -q 'id="nav-profile"' "$page" || PROFILE_MISSING="$PROFILE_MISSING $(basename "$page"):slot"
+  grep -q 'nav-profile.js' "$page"    || PROFILE_MISSING="$PROFILE_MISSING $(basename "$page"):script"
+done
+[ -z "$PROFILE_MISSING" ] || fail "pages missing the header profile control —$PROFILE_MISSING"
+echo "profile control OK (slot + script on every page)"
+
 # Every public page must be in sitemap.xml, or deliberately named as excluded.
 #
 # A sitemap is the one file that rots without any symptom: pages get added, the

--- a/site/404.html
+++ b/site/404.html
@@ -67,6 +67,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -129,5 +130,6 @@
     if (path && path !== '/') document.getElementById('badPath').textContent = path;
   })();
 </script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/admin.html
+++ b/site/admin.html
@@ -103,6 +103,7 @@
       <a href="/clans">Clans</a>
       <a href="/streamer-signup">Streamer signup</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -182,5 +183,6 @@
 </footer>
 
 <script src="admin.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/clan.html
+++ b/site/clan.html
@@ -32,6 +32,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -501,5 +502,6 @@
   })();
 })();
 </script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/clans.html
+++ b/site/clans.html
@@ -32,6 +32,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -534,5 +535,6 @@
   })();
 })();
 </script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/duel.html
+++ b/site/duel.html
@@ -323,6 +323,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -1351,5 +1352,6 @@
   })();
 })();
 </script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/duels.html
+++ b/site/duels.html
@@ -474,6 +474,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -1421,5 +1422,6 @@
   loadDuels();
 })();
 </script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -33,6 +33,7 @@
       <a href="/news">News</a>
       <a href="#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -530,5 +531,6 @@
   })();
 })();
 </script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/leaderboard.html
+++ b/site/leaderboard.html
@@ -32,6 +32,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -552,5 +553,6 @@
   });
 })();
 </script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/nav-profile.js
+++ b/site/nav-profile.js
@@ -1,0 +1,84 @@
+/* The profile control in the site header.
+ *
+ * Every page carries it, but only eight of the twenty-seven load arena.js, so
+ * this is deliberately standalone — no shared module, no build step, and it
+ * must never throw into a page that is otherwise static.
+ *
+ * Signed out it is a sign-in link; signed in it is the user's avatar and handle
+ * pointing at their own profile. Both are one element in the same slot, so the
+ * nav does not reflow when the answer arrives.
+ */
+(() => {
+  'use strict';
+
+  // Same origin and session transport as arena.js. See the comments there on
+  // why the API is cross-site and why the token rides in localStorage as well
+  // as a cookie.
+  const API = 'https://papertrench-api.onerobby.workers.dev';
+  const TOKEN_KEY = 'pt_session_token';
+  const CACHE_KEY = 'pt_nav_identity';
+
+  const slot = document.getElementById('nav-profile');
+  if (!slot) return;
+
+  const esc = (s) => String(s == null ? '' : s).replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ));
+
+  /** Only an https image we serve or X serves may be used as an avatar. */
+  function safeAvatar(url) {
+    try {
+      const u = new URL(String(url));
+      return u.protocol === 'https:' ? u.toString() : null;
+    } catch { return null; }
+  }
+
+  function renderSignedOut() {
+    slot.innerHTML = `<a class="nav-profile signin" href="${API}/api/auth/x/start">Sign in</a>`;
+  }
+
+  function renderSignedIn(me) {
+    const handle = String(me.handle || '').replace(/[^A-Za-z0-9_]/g, '');
+    if (!handle) { renderSignedOut(); return; }
+    const avatar = safeAvatar(me.avatarUrl);
+    slot.innerHTML = `
+      <a class="nav-profile" href="/profile?handle=${encodeURIComponent(handle)}" title="Your PaperTrench profile">
+        ${avatar
+          ? `<img src="${esc(avatar)}" alt="" width="22" height="22" loading="lazy">`
+          : '<span class="nav-profile-dot" aria-hidden="true"></span>'}
+        <span class="nav-profile-handle">@${esc(handle)}</span>
+      </a>`;
+  }
+
+  // Paint from the last known answer first. The nav is above the fold on every
+  // page, and a control that appears a beat late reads as the page still
+  // loading — worse, one that flips from "Sign in" to a handle looks like it
+  // signed you in on arrival.
+  let cached = null;
+  try { cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null'); } catch (_) {}
+  if (cached && cached.handle) renderSignedIn(cached); else renderSignedOut();
+
+  (async () => {
+    let me = null;
+    try {
+      const token = localStorage.getItem(TOKEN_KEY);
+      const res = await fetch(API + '/api/me', {
+        credentials: 'include',
+        headers: token ? { Authorization: 'Bearer ' + token } : {},
+      });
+      if (!res.ok) return;              // transient: keep whatever is on screen
+      me = await res.json();
+    } catch (_) {
+      return; // offline or blocked — the cached control stays, and it is honest
+    }
+
+    if (me && me.signedIn) {
+      renderSignedIn(me);
+      try { localStorage.setItem(CACHE_KEY, JSON.stringify({ handle: me.handle, avatarUrl: me.avatarUrl })); } catch (_) {}
+    } else {
+      // A definite signed-out answer is the one thing that may clear the cache.
+      renderSignedOut();
+      try { localStorage.removeItem(CACHE_KEY); } catch (_) {}
+    }
+  })();
+})();

--- a/site/news-chain.html
+++ b/site/news-chain.html
@@ -59,6 +59,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -242,5 +243,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-fees.html
+++ b/site/news-fees.html
@@ -47,6 +47,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -196,5 +197,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-fills.html
+++ b/site/news-fills.html
@@ -64,6 +64,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -248,5 +249,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-flex.html
+++ b/site/news-flex.html
@@ -73,6 +73,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -322,5 +323,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-instant-x.html
+++ b/site/news-instant-x.html
@@ -54,6 +54,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -294,5 +295,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-perps.html
+++ b/site/news-perps.html
@@ -41,6 +41,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -158,5 +159,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-quickedit.html
+++ b/site/news-quickedit.html
@@ -58,6 +58,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -219,5 +220,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-rugguard.html
+++ b/site/news-rugguard.html
@@ -58,6 +58,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -253,5 +254,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-the-after.html
+++ b/site/news-the-after.html
@@ -54,6 +54,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -254,5 +255,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-trench-rank.html
+++ b/site/news-trench-rank.html
@@ -50,6 +50,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -137,5 +138,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-turbo.html
+++ b/site/news-turbo.html
@@ -61,6 +61,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -295,5 +296,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-v2.html
+++ b/site/news-v2.html
@@ -47,6 +47,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -245,5 +246,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-xray.html
+++ b/site/news-xray.html
@@ -68,6 +68,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -356,5 +357,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news.html
+++ b/site/news.html
@@ -44,6 +44,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -291,5 +292,6 @@
 
 <script src="news.js"></script>
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -29,6 +29,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -119,5 +120,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/profile.html
+++ b/site/profile.html
@@ -374,6 +374,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -1503,5 +1504,6 @@
   })();
 })();
 </script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/sprint.html
+++ b/site/sprint.html
@@ -153,6 +153,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -620,5 +621,6 @@
   })();
 })();
 </script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/streamer-signup.html
+++ b/site/streamer-signup.html
@@ -92,6 +92,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -244,5 +245,6 @@
 </footer>
 
 <script src="streamer-signup.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/streams.html
+++ b/site/streams.html
@@ -153,6 +153,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch" aria-current="page"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -280,5 +281,6 @@
 </footer>
 
 <script src="streams.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/style.css
+++ b/site/style.css
@@ -112,6 +112,30 @@ nav {
   box-shadow: 0 0 0 rgba(255,157,69,0);
 }
 .nav-cta:hover { transform: translateY(-1px); box-shadow: 0 6px 24px rgba(255,157,69,0.35); }
+/* Profile control — the one nav item whose content depends on who is looking.
+   Sized like the pills beside it so the bar does not reflow when the answer
+   arrives, and painted from cache first for the same reason. */
+.nav-profile {
+  display: inline-flex; align-items: center; gap: 7px;
+  margin-left: 8px; padding: 6px 13px 6px 7px; border-radius: 999px;
+  font-size: 13px; font-weight: 700; white-space: nowrap;
+  color: var(--text); background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--line2);
+  transition: background .2s, border-color .2s;
+}
+.nav-profile:hover { background: rgba(255, 255, 255, 0.1); border-color: rgba(255, 157, 69, 0.4); }
+.nav-profile img { width: 22px; height: 22px; border-radius: 50%; flex: none; }
+.nav-profile-dot {
+  width: 22px; height: 22px; border-radius: 50%; flex: none;
+  background: linear-gradient(140deg, var(--orange2), var(--orange-deep));
+}
+.nav-profile.signin { padding: 8px 15px; color: var(--muted); font-weight: 650; }
+.nav-profile.signin:hover { color: var(--text); }
+/* The handle is the first thing to go when the bar runs out of room — the
+   avatar alone still says "signed in, this is you". */
+@media (max-width: 1010px) { .nav-profile-handle { display: none; } }
+@media (max-width: 470px) { .nav-profile { padding: 5px; margin-left: 4px; } }
+
 
 /* The "Watch Live" pill: a real call-to-action, not a text link — it has to
    read as "click here to watch streams" at a glance, and it survives mobile


### PR DESCRIPTION
> *"can you add a little profile button in the papertrench.com header"*

Signed out it''s a sign-in link; signed in it''s the user''s avatar and handle, pointing at their own profile. One element in one slot either way, sized like the pills beside it, so **the nav doesn''t reflow when the answer arrives**.

## Standalone on purpose

Only 8 of the 27 pages load `arena.js`, and this belongs on all of them. So `site/nav-profile.js` shares no module with it and must never throw into a page that is otherwise static — every failure path returns quietly and leaves whatever is already on screen.

## Painted from cache, then revalidated

The nav is above the fold on every page. A control that arrives a beat late reads as the page still loading — and one that **flips from "Sign in" to a handle looks like it signed you in on arrival**. So the last known answer paints immediately and the network confirms it.

**Only a definite signed-out answer clears the cache.** A 500, an offline tab, or a blocked request leaves the control alone — *"you are signed out"* is a claim, and a failed request hasn''t earned it.

## Details worth a look

- The handle is stripped to `[A-Za-z0-9_]` before it goes into a URL. It comes from X via OAuth so it already is — but this file doesn''t get to assume that.
- The avatar URL is rejected unless it''s `https:`.
- The handle is the first thing dropped when the bar runs out of room; the avatar alone still says *"signed in, and this is you"*, which is the whole job of the control.

## preflight checks it''s on every page

A header that identifies you on the leaderboard but not on a news article reads as a **broken sign-in**, not a missing include — so it''s all pages or none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
