### PR TITLE
feat(overlay): round ledger - invested, sold, remaining, change

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -4308,6 +4308,24 @@
 
     /* ---------------- sell row ---------------- */
 
+    /* Round ledger — what went in, what came back, what is still held. */
+    .pt-ledger {
+      display: grid; grid-template-columns: repeat(4, 1fr); gap: 4px;
+      margin-top: 8px; padding: 7px 8px;
+      background: rgba(0, 0, 0, 0.22); border: 1px solid var(--pt-line);
+      border-radius: 9px;
+    }
+    .pt-led { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+    .pt-led .k {
+      font-size: 8.5px; font-weight: 700; letter-spacing: 0.7px;
+      text-transform: uppercase; color: var(--pt-faint); white-space: nowrap;
+    }
+    .pt-led .v {
+      font-size: 11.5px; font-weight: 750; font-variant-numeric: tabular-nums;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    /* The bag has already returned its cost — what is left is house money. */
+    .pt-ledger.pt-house { border-color: rgba(52, 211, 153, 0.35); background: rgba(52, 211, 153, 0.07); }
     .pt-sell-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 5px; margin-top: 6px; }
     .pt-sell {
       padding: 9px 2px; border-radius: var(--pt-r-sm);
@@ -7087,9 +7105,42 @@
       void posEls.pnl.offsetWidth;
       posEls.pnl.classList.add(cls);
     }
+    renderPositionLedger(pos, mark);
     lastRenderedPrice = mark.price;
   }
 
+  /**
+   * Invested / sold / remaining / change, for a round that has been sold into.
+   *
+   * Hidden until the first partial sell: before then it would restate the
+   * Position size and Unrealized P&L rows directly above it in different
+   * words. It earns its space the moment some of the bag has been returned,
+   * which is when "am I ahead overall" stops being the same question as
+   * "is this position up".
+   */
+  function renderPositionLedger(pos, mark) {
+    if (!posEls || !posEls.ledger) return;
+    const led = Q.positionLedger(state.journal, pos, mark.valueSol);
+    if (!led || led.sells === 0) { posEls.ledger.classList.add('pt-hidden'); return; }
+    posEls.ledger.classList.remove('pt-hidden');
+
+    // The panel speaks the venue's currency: dollars off Solana, SOL on it.
+    const rate = panelUsd() ? panelUsdRate() : null;
+    const money = (sol) => (rate ? E.fmtUsd(sol * rate) : `${E.fmt(sol, 3)} SOL`);
+
+    posEls.ledIn.textContent = money(led.investedSol);
+    posEls.ledOut.textContent = money(led.soldSol);
+    posEls.ledLeft.textContent = money(led.remainingSol);
+
+    const up = led.changeSol >= 0;
+    posEls.ledChg.textContent = `${up ? '+' : ''}${money(led.changeSol)}`
+      + ` (${up ? '+' : ''}${led.changePct.toFixed(0)}%)`;
+    posEls.ledChg.classList.toggle('pt-green', up);
+    posEls.ledChg.classList.toggle('pt-red', !up);
+    // Once the sells alone cover what went in, the rest of the bag is
+    // house money — worth saying, because it changes how it should be held.
+    posEls.ledger.classList.toggle('pt-house', led.houseMoney);
+  }
   /**
    * Keep the newest realized result visible after a sell. Full exits show the
    * complete round-trip result; partial exits show the realized slice.
@@ -7604,6 +7655,12 @@
       <div class="row pt-detail"><span class="k">Avg entry</span><span class="v" data-f="entry"></span></div>
       <div class="row pt-detail"><span class="k">Value</span><span class="v" data-f="value"></span></div>
       <div class="row row-pnl"><span class="k">Unrealized P&amp;L</span><span class="v pnl" data-f="pnl"></span></div>
+      <div class="pt-ledger" data-f="ledger">
+        <div class="pt-led"><span class="k">Invested</span><span class="v" data-f="led-in"></span></div>
+        <div class="pt-led"><span class="k">Sold</span><span class="v" data-f="led-out"></span></div>
+        <div class="pt-led"><span class="k">Remaining</span><span class="v" data-f="led-left"></span></div>
+        <div class="pt-led"><span class="k">P&amp;L change</span><span class="v" data-f="led-chg"></span></div>
+      </div>
       <div class="pt-label" style="margin-top:10px">Quick sell</div>
       <div class="pt-sell-row" data-f="sell"></div>
     `;
@@ -7614,6 +7671,11 @@
       entry: card.querySelector('[data-f="entry"]'),
       value: card.querySelector('[data-f="value"]'),
       pnl: card.querySelector('[data-f="pnl"]'),
+      ledger: card.querySelector('[data-f="ledger"]'),
+      ledIn: card.querySelector('[data-f="led-in"]'),
+      ledOut: card.querySelector('[data-f="led-out"]'),
+      ledLeft: card.querySelector('[data-f="led-left"]'),
+      ledChg: card.querySelector('[data-f="led-chg"]'),
     };
 
     const row = card.querySelector('[data-f="sell"]');

--- a/extension/quote.js
+++ b/extension/quote.js
@@ -1087,6 +1087,59 @@
    * current price. Pure, so the P&L shown on screen is exactly what tests
    * assert — this is the number the user watches tick.
    */
+  /**
+   * The money story of one open round: what went in, what has come back, and
+   * what is still on the table.
+   *
+   * positionMark answers "what is this worth now"; this answers "am I ahead",
+   * which is the question a partially-sold bag actually raises. A position
+   * sold down to house money shows a red unrealized P&L on the remainder
+   * while the round as a whole is up — the card said one thing and the trader
+   * meant the other.
+   *
+   * Derived, never stored (doctrine: derive, don't store). Sells are matched
+   * by sessionId, which is stamped per position-open, so a previous round in
+   * the same token cannot leak in. Chains predating sessionIds fall back to
+   * mint, bounded by openedAt for the same reason.
+   */
+  function positionLedger(journal, pos, remainingValueSol) {
+    if (!pos) return null;
+    var list = Array.isArray(journal) ? journal : [];
+    var sid = pos.sessionId || null;
+    var openedAt = Number(pos.openedAt) || 0;
+    var soldSol = 0;
+    var realizedSol = 0;
+    var sells = 0;
+
+    for (var i = 0; i < list.length; i++) {
+      var t = list[i];
+      if (!t || t.side !== 'sell') continue;
+      var mine = sid && t.sessionId ? t.sessionId === sid : t.mint === pos.mint;
+      if (!mine) continue;
+      // A sell older than this position belongs to a previous round.
+      if (openedAt && Number(t.ts) < openedAt) continue;
+      soldSol += Number(t.solNet) || 0;
+      realizedSol += Number(t.pnlSol) || 0;
+      sells += 1;
+    }
+
+    var invested = Number(pos.investedSol) || 0;
+    var remaining = Number(remainingValueSol) || 0;
+    // Gross in, versus everything that has come back plus what is still held.
+    var change = soldSol + remaining - invested;
+    return {
+      investedSol: invested,
+      soldSol: soldSol,
+      remainingSol: remaining,
+      realizedSol: realizedSol,
+      changeSol: change,
+      changePct: invested > 0 ? (change / invested) * 100 : 0,
+      sells: sells,
+      // Has the round already returned more than it cost? The state the
+      // "sell initial" move exists to reach.
+      houseMoney: soldSol >= invested && invested > 0,
+    };
+  }
   function positionMark(pos, priceNative, priceUsd) {
     if (!pos || !(pos.qty > 0)) return null;
     var px = Number(priceNative) > 0 ? Number(priceNative) : Number(pos.lastPriceNative);
@@ -1431,6 +1484,7 @@
     sameAddress,
     pricesFromBatch,
     positionRows,
+    positionLedger,
     portfolioSummary,
     headerFields,
     shortAddress,

--- a/extension/test/positionledger.test.js
+++ b/extension/test/positionledger.test.js
@@ -1,0 +1,90 @@
+/* The round ledger: invested / sold / remaining / change.
+ *
+ * Requested from a venue screenshot — INVESTED, SOLD, REMAINING, PNL CHANGE.
+ * The question it answers is not the one positionMark answers. A bag sold
+ * halfway down shows a RED unrealized P&L on what is left while the round as
+ * a whole is up, so the card stated one thing and the trader meant the other.
+ *
+ * Derived, never stored, so the tests are about what it must never count.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const Q = require('../quote.js');
+const content = fs.readFileSync(path.join(__dirname, '..', 'content.js'), 'utf8');
+
+const POS = { mint: 'MINT', sessionId: 'S1', openedAt: 1000, investedSol: 2, qty: 10, costSol: 1 };
+// mint rides on every real journal fill, and the sessionId-less fallback path
+// matches on it — a fixture without one exercises neither branch.
+const sell = (o) => Object.assign(
+  { side: 'sell', mint: 'MINT', sessionId: 'S1', ts: 2000, solNet: 0, pnlSol: 0 }, o);
+
+test('no sells yet means no ledger to show', () => {
+  const led = Q.positionLedger([], POS, 3);
+  assert.equal(led.sells, 0, 'nothing has come back');
+  assert.equal(led.soldSol, 0);
+});
+
+test('the change is money back plus money still held, against money in', () => {
+  const led = Q.positionLedger([sell({ solNet: 1.5, pnlSol: 0.5 })], POS, 1.2);
+  assert.equal(led.investedSol, 2);
+  assert.equal(led.soldSol, 1.5);
+  assert.equal(led.remainingSol, 1.2);
+  // 1.5 returned + 1.2 still held − 2 in = +0.7
+  assert.ok(Math.abs(led.changeSol - 0.7) < 1e-9);
+  assert.ok(Math.abs(led.changePct - 35) < 1e-9);
+});
+
+test('a previous round in the same token is not counted', () => {
+  // sessionId is stamped per position-open, so the earlier round has its own.
+  const led = Q.positionLedger([
+    sell({ solNet: 1, pnlSol: 0.4 }),
+    sell({ sessionId: 'OLD-ROUND', solNet: 99, pnlSol: 99 }),
+  ], POS, 0.5);
+  assert.equal(led.sells, 1);
+  assert.equal(led.soldSol, 1, 'the old round must not inflate this one');
+});
+
+test('a sell older than the position is not counted, even without a sessionId', () => {
+  // Chains predating sessionIds fall back to matching by mint, which alone
+  // would sweep in every earlier round the token ever had.
+  const led = Q.positionLedger([
+    sell({ sessionId: null, ts: 500, solNet: 50, pnlSol: 50 }),
+    sell({ sessionId: null, ts: 3000, solNet: 1, pnlSol: 0.2 }),
+  ], POS, 0.5);
+  assert.equal(led.sells, 1, 'only the sell that belongs to THIS open round');
+  assert.equal(led.soldSol, 1);
+});
+
+test('buys are never mistaken for money coming back', () => {
+  const led = Q.positionLedger([
+    { side: 'buy', sessionId: 'S1', ts: 1500, solNet: 5 },
+    sell({ solNet: 1, pnlSol: 0.1 }),
+  ], POS, 0.5);
+  assert.equal(led.soldSol, 1);
+});
+
+test('house money is the sells alone covering what went in', () => {
+  const under = Q.positionLedger([sell({ solNet: 1.99, pnlSol: 0.2 })], POS, 5);
+  assert.equal(under.houseMoney, false, 'unrealised value must not count toward it');
+  const over = Q.positionLedger([sell({ solNet: 2.0, pnlSol: 0.3 })], POS, 0.1);
+  assert.equal(over.houseMoney, true);
+});
+
+test('a zero-invested position cannot produce an infinite percentage', () => {
+  const led = Q.positionLedger([sell({ solNet: 1 })], { ...POS, investedSol: 0 }, 1);
+  assert.equal(led.changePct, 0, 'no denominator means no percentage claim');
+  assert.ok(Number.isFinite(led.changeSol));
+});
+
+test('the panel renders it in the venue currency, and only after a sell', () => {
+  const fn = content.slice(
+    content.indexOf('function renderPositionLedger('),
+    content.indexOf('\n  }', content.indexOf('function renderPositionLedger(')) + 4);
+  assert.match(fn, /led\.sells === 0/, 'it must stay hidden until something has been sold');
+  assert.match(fn, /panelUsd\(\)/, 'dollars off Solana');
+  assert.match(fn, /E\.fmt\(sol, 3\)} SOL/, 'SOL on Solana');
+  assert.match(fn, /pt-house/, 'and it must mark the house-money state');
+});


### PR DESCRIPTION
> Requested from a venue screenshot: **INVESTED / SOLD / REMAINING / PNL CHANGE** on the trade panel.

## Why it isn''t a restatement of the rows above it

`positionMark` says what the bag is worth **now**. A bag sold halfway down shows a **red** Unrealized P&L on what''s left while the round as a whole is well up — the card stated one thing and the trader meant the other.

## Derived, never stored

`Q.positionLedger` walks the journal and sums the sells belonging to this open round:

| | |
| --- | --- |
| **invested** | `pos.investedSol` — gross, never shrinks |
| **sold** | Σ `solNet` over this round''s sells |
| **remaining** | current market value of what''s still held |
| **change** | `sold + remaining − invested`, and that over invested |

## Two scoping rules, because both failure modes over-count

- Sells match on **`sessionId`**, stamped per position-open — so a *previous round in the same token* can''t leak in
- Chains predating sessionIds fall back to **mint**, which alone would sweep in every earlier round the token ever had — so that fallback is bounded by `openedAt`

Both are pinned by tests. (The second one caught a bug in my own fixture: my `sell()` helper omitted `mint`, so neither branch was actually being exercised.)

## Hidden until the first sell

Before that it restates Position size and Unrealized P&L in different words. It earns its space the moment some of the bag has come back — which is exactly when *"am I ahead overall"* stops being the same question as *"is this position up"*.

Prints in the venue''s currency — **dollars off Solana, SOL on it** — using the rate already recorded on the token, never a fresh guess.

## House money

When the sells **alone** cover what went in, the strip turns green: the rest of the bag is house money, which changes how it should be held.

That state is computed from realised proceeds only — **unrealised value must not count toward it**, and a test pins that specifically. Otherwise a bag that merely *looks* profitable would claim to be de-risked.

```
extension  1769/1769
```

Next up in this batch: the sell-initial button (which uses `houseMoney` from here), then the compact-mode cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
