### PR TITLE
feat(overlay): sell your initial, costed exactly

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -4308,6 +4308,20 @@
 
     /* ---------------- sell row ---------------- */
 
+    .pt-sell-initial {
+      width: 100%; margin-top: 5px; padding: 7px 8px;
+      font: inherit; font-size: 11px; font-weight: 750; cursor: pointer;
+      color: var(--pt-green); background: rgba(52, 211, 153, 0.10);
+      border: 1px solid rgba(52, 211, 153, 0.32); border-radius: 8px;
+      transition: background 120ms linear, border-color 120ms linear;
+    }
+    .pt-sell-initial:hover { background: rgba(52, 211, 153, 0.18); border-color: rgba(52, 211, 153, 0.5); }
+    .pt-sell-initial:active { transform: scale(0.98); }
+    /* Refusing, not merely unavailable — it still says why. */
+    .pt-sell-initial.pt-short {
+      color: var(--pt-faint); background: rgba(255, 255, 255, 0.04);
+      border-color: var(--pt-line); cursor: not-allowed;
+    }
     /* Round ledger — what went in, what came back, what is still held. */
     .pt-ledger {
       display: grid; grid-template-columns: repeat(4, 1fr); gap: 4px;
@@ -7106,6 +7120,7 @@
       posEls.pnl.classList.add(cls);
     }
     renderPositionLedger(pos, mark);
+    renderSellInitial();
     lastRenderedPrice = mark.price;
   }
 
@@ -7118,6 +7133,51 @@
    * which is when "am I ahead overall" stops being the same question as
    * "is this position up".
    */
+  /** The live sell-initial plan for the open position, or null. */
+  function currentInitialPlan() {
+    const pos = token && state.positions[token.mint];
+    if (!pos) return null;
+    const mark = Q.positionMark(pos, token.priceNative, token.priceUsd);
+    if (!mark) return null;
+    const led = Q.positionLedger(state.journal, pos, mark.valueSol);
+    return Q.sellInitialPlan(pos, led, mark.price, {
+      feeBps: settings.feeBps,
+      slippageBps: settings.slippageBps,
+      flatSol: E.txCostSol(settings),
+    });
+  }
+
+  /**
+   * The sell-initial control.
+   *
+   * Absent while there is nothing to recover — a round already returning
+   * more than it cost has no initial left to take off the table. Present but
+   * refusing when the whole bag could not cover it: that is a fact about the
+   * position worth stating, and a button that silently sold 100% while
+   * calling it a recovery would be the exact lie this feature exists to
+   * prevent.
+   */
+  function renderSellInitial() {
+    if (!posEls || !posEls.initial) return;
+    const btn = posEls.initial;
+    const plan = currentInitialPlan();
+    if (!plan) { btn.classList.add('pt-hidden'); return; }
+    btn.classList.remove('pt-hidden');
+
+    if (plan.shortfall) {
+      btn.disabled = true;
+      btn.classList.add('pt-short');
+      btn.textContent = 'Not enough to cover the initial yet';
+      btn.title = 'Selling the whole position would still return less than went in.';
+      return;
+    }
+    btn.disabled = false;
+    btn.classList.remove('pt-short');
+    const pct = plan.fraction * 100;
+    btn.textContent = `Sell initial (${pct < 1 ? pct.toFixed(1) : pct.toFixed(0)}%)`;
+    btn.title = 'Sells just enough to take back what you put in, costs included — '
+      + 'the rest of the bag becomes house money.';
+  }
   function renderPositionLedger(pos, mark) {
     if (!posEls || !posEls.ledger) return;
     const led = Q.positionLedger(state.journal, pos, mark.valueSol);
@@ -7663,6 +7723,7 @@
       </div>
       <div class="pt-label" style="margin-top:10px">Quick sell</div>
       <div class="pt-sell-row" data-f="sell"></div>
+      <button class="pt-sell-initial pt-hidden" data-f="initial" type="button"></button>
     `;
     els.position.appendChild(card);
 
@@ -7676,6 +7737,7 @@
       ledOut: card.querySelector('[data-f="led-out"]'),
       ledLeft: card.querySelector('[data-f="led-left"]'),
       ledChg: card.querySelector('[data-f="led-chg"]'),
+      initial: card.querySelector('[data-f="initial"]'),
     };
 
     const row = card.querySelector('[data-f="sell"]');
@@ -7689,6 +7751,19 @@
       });
       row.appendChild(b);
     });
+
+    // Sell exactly enough to have the money that went in back out.
+    const initialBtn = card.querySelector('[data-f="initial"]');
+    if (initialBtn) {
+      initialBtn.addEventListener('click', () => {
+        const plan = currentInitialPlan();
+        // Refused rather than approximated: a shortfall sold as if it were a
+        // recovery is the one outcome this button must never produce.
+        if (!plan || plan.shortfall) return;
+        primeAudio();
+        doSell(plan.fraction);
+      });
+    }
 
     buildOrdersSection(card);
   }

--- a/extension/content.js
+++ b/extension/content.js
@@ -4308,6 +4308,24 @@
 
     /* ---------------- sell row ---------------- */
 
+    /* Round ledger — what went in, what came back, what is still held. */
+    .pt-ledger {
+      display: grid; grid-template-columns: repeat(4, 1fr); gap: 4px;
+      margin-top: 8px; padding: 7px 8px;
+      background: rgba(0, 0, 0, 0.22); border: 1px solid var(--pt-line);
+      border-radius: 9px;
+    }
+    .pt-led { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+    .pt-led .k {
+      font-size: 8.5px; font-weight: 700; letter-spacing: 0.7px;
+      text-transform: uppercase; color: var(--pt-faint); white-space: nowrap;
+    }
+    .pt-led .v {
+      font-size: 11.5px; font-weight: 750; font-variant-numeric: tabular-nums;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    }
+    /* The bag has already returned its cost — what is left is house money. */
+    .pt-ledger.pt-house { border-color: rgba(52, 211, 153, 0.35); background: rgba(52, 211, 153, 0.07); }
     .pt-sell-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 5px; margin-top: 6px; }
     .pt-sell {
       padding: 9px 2px; border-radius: var(--pt-r-sm);
@@ -7087,9 +7105,42 @@
       void posEls.pnl.offsetWidth;
       posEls.pnl.classList.add(cls);
     }
+    renderPositionLedger(pos, mark);
     lastRenderedPrice = mark.price;
   }
 
+  /**
+   * Invested / sold / remaining / change, for a round that has been sold into.
+   *
+   * Hidden until the first partial sell: before then it would restate the
+   * Position size and Unrealized P&L rows directly above it in different
+   * words. It earns its space the moment some of the bag has been returned,
+   * which is when "am I ahead overall" stops being the same question as
+   * "is this position up".
+   */
+  function renderPositionLedger(pos, mark) {
+    if (!posEls || !posEls.ledger) return;
+    const led = Q.positionLedger(state.journal, pos, mark.valueSol);
+    if (!led || led.sells === 0) { posEls.ledger.classList.add('pt-hidden'); return; }
+    posEls.ledger.classList.remove('pt-hidden');
+
+    // The panel speaks the venue's currency: dollars off Solana, SOL on it.
+    const rate = panelUsd() ? panelUsdRate() : null;
+    const money = (sol) => (rate ? E.fmtUsd(sol * rate) : `${E.fmt(sol, 3)} SOL`);
+
+    posEls.ledIn.textContent = money(led.investedSol);
+    posEls.ledOut.textContent = money(led.soldSol);
+    posEls.ledLeft.textContent = money(led.remainingSol);
+
+    const up = led.changeSol >= 0;
+    posEls.ledChg.textContent = `${up ? '+' : ''}${money(led.changeSol)}`
+      + ` (${up ? '+' : ''}${led.changePct.toFixed(0)}%)`;
+    posEls.ledChg.classList.toggle('pt-green', up);
+    posEls.ledChg.classList.toggle('pt-red', !up);
+    // Once the sells alone cover what went in, the rest of the bag is
+    // house money — worth saying, because it changes how it should be held.
+    posEls.ledger.classList.toggle('pt-house', led.houseMoney);
+  }
   /**
    * Keep the newest realized result visible after a sell. Full exits show the
    * complete round-trip result; partial exits show the realized slice.
@@ -7604,6 +7655,12 @@
       <div class="row pt-detail"><span class="k">Avg entry</span><span class="v" data-f="entry"></span></div>
       <div class="row pt-detail"><span class="k">Value</span><span class="v" data-f="value"></span></div>
       <div class="row row-pnl"><span class="k">Unrealized P&amp;L</span><span class="v pnl" data-f="pnl"></span></div>
+      <div class="pt-ledger" data-f="ledger">
+        <div class="pt-led"><span class="k">Invested</span><span class="v" data-f="led-in"></span></div>
+        <div class="pt-led"><span class="k">Sold</span><span class="v" data-f="led-out"></span></div>
+        <div class="pt-led"><span class="k">Remaining</span><span class="v" data-f="led-left"></span></div>
+        <div class="pt-led"><span class="k">P&amp;L change</span><span class="v" data-f="led-chg"></span></div>
+      </div>
       <div class="pt-label" style="margin-top:10px">Quick sell</div>
       <div class="pt-sell-row" data-f="sell"></div>
     `;
@@ -7614,6 +7671,11 @@
       entry: card.querySelector('[data-f="entry"]'),
       value: card.querySelector('[data-f="value"]'),
       pnl: card.querySelector('[data-f="pnl"]'),
+      ledger: card.querySelector('[data-f="ledger"]'),
+      ledIn: card.querySelector('[data-f="led-in"]'),
+      ledOut: card.querySelector('[data-f="led-out"]'),
+      ledLeft: card.querySelector('[data-f="led-left"]'),
+      ledChg: card.querySelector('[data-f="led-chg"]'),
     };
 
     const row = card.querySelector('[data-f="sell"]');

--- a/extension/engine.js
+++ b/extension/engine.js
@@ -2170,6 +2170,10 @@
     resetState,
     buy,
     sell,
+    // Exported so the panel can plan an exit against the SAME flat cost the
+    // fill will charge. Re-deriving it there would be a second copy of the
+    // clamp, free to drift from this one.
+    txCostSol,
     getPosition,
     rekeyMint,
     markPosition,

--- a/extension/quote.js
+++ b/extension/quote.js
@@ -1140,6 +1140,57 @@
       houseMoney: soldSol >= invested && invested > 0,
     };
   }
+
+  /**
+   * How much of the bag to sell so the money that went in has come back.
+   *
+   * "Sell your initial" is a real move with a real number behind it, and the
+   * number is not "half". Costs come off the top: to NET back what you put
+   * in you must sell MORE than the naive fraction, and by exactly how much
+   * depends on the fee, the flat tx cost and the slippage the fill will take.
+   * Getting that wrong leaves the trader believing they are de-risked when
+   * they are still a few percent short — the one belief this feature exists
+   * to make true.
+   *
+   * Solves for gross from the net that is actually wanted:
+   *   net   = gross - gross*fee - flat
+   *   gross = (need + flat) / (1 - fee)
+   * against the slipped price the engine will really fill at.
+   *
+   * Returns null when there is nothing to do, or { fraction, needSol,
+   * shortfall } — shortfall true when the WHOLE bag cannot cover it, which
+   * is a fact to state rather than a button to grey out silently.
+   */
+  function sellInitialPlan(pos, ledger, priceNative, costs) {
+    if (!pos || !(pos.qty > 0) || !ledger) return null;
+    var px = Number(priceNative) > 0 ? Number(priceNative) : Number(pos.lastPriceNative);
+    if (!(px > 0)) return null;
+
+    var need = Number(ledger.investedSol) - Number(ledger.soldSol);
+    if (!(need > 0)) return null;   // already whole — nothing to recover
+
+    var c = costs || {};
+    var feeRate = Math.min(0.95, Math.max(0, (Number(c.feeBps) || 0) / 10000));
+    var slipRate = Math.min(0.95, Math.max(0, (Number(c.slippageBps) || 0) / 10000));
+    var flat = Math.max(0, Number(c.flatSol) || 0);
+
+    // The engine fills a sell at the slipped price, so that is the price this
+    // plan has to be built on — not the quote on screen.
+    var fillPx = px * (1 - slipRate);
+    if (!(fillPx > 0)) return null;
+
+    var grossNeeded = (need + flat) / (1 - feeRate);
+    var qtyNeeded = grossNeeded / fillPx;
+    var fraction = qtyNeeded / pos.qty;
+
+    return {
+      needSol: need,
+      // Capped at the whole bag: a fraction over 1 would be silently clamped
+      // by the engine anyway, and the caller has to be able to SAY so.
+      fraction: Math.min(1, fraction),
+      shortfall: fraction > 1,
+    };
+  }
   function positionMark(pos, priceNative, priceUsd) {
     if (!pos || !(pos.qty > 0)) return null;
     var px = Number(priceNative) > 0 ? Number(priceNative) : Number(pos.lastPriceNative);
@@ -1485,6 +1536,7 @@
     pricesFromBatch,
     positionRows,
     positionLedger,
+    sellInitialPlan,
     portfolioSummary,
     headerFields,
     shortAddress,

--- a/extension/quote.js
+++ b/extension/quote.js
@@ -1087,6 +1087,59 @@
    * current price. Pure, so the P&L shown on screen is exactly what tests
    * assert — this is the number the user watches tick.
    */
+  /**
+   * The money story of one open round: what went in, what has come back, and
+   * what is still on the table.
+   *
+   * positionMark answers "what is this worth now"; this answers "am I ahead",
+   * which is the question a partially-sold bag actually raises. A position
+   * sold down to house money shows a red unrealized P&L on the remainder
+   * while the round as a whole is up — the card said one thing and the trader
+   * meant the other.
+   *
+   * Derived, never stored (doctrine: derive, don't store). Sells are matched
+   * by sessionId, which is stamped per position-open, so a previous round in
+   * the same token cannot leak in. Chains predating sessionIds fall back to
+   * mint, bounded by openedAt for the same reason.
+   */
+  function positionLedger(journal, pos, remainingValueSol) {
+    if (!pos) return null;
+    var list = Array.isArray(journal) ? journal : [];
+    var sid = pos.sessionId || null;
+    var openedAt = Number(pos.openedAt) || 0;
+    var soldSol = 0;
+    var realizedSol = 0;
+    var sells = 0;
+
+    for (var i = 0; i < list.length; i++) {
+      var t = list[i];
+      if (!t || t.side !== 'sell') continue;
+      var mine = sid && t.sessionId ? t.sessionId === sid : t.mint === pos.mint;
+      if (!mine) continue;
+      // A sell older than this position belongs to a previous round.
+      if (openedAt && Number(t.ts) < openedAt) continue;
+      soldSol += Number(t.solNet) || 0;
+      realizedSol += Number(t.pnlSol) || 0;
+      sells += 1;
+    }
+
+    var invested = Number(pos.investedSol) || 0;
+    var remaining = Number(remainingValueSol) || 0;
+    // Gross in, versus everything that has come back plus what is still held.
+    var change = soldSol + remaining - invested;
+    return {
+      investedSol: invested,
+      soldSol: soldSol,
+      remainingSol: remaining,
+      realizedSol: realizedSol,
+      changeSol: change,
+      changePct: invested > 0 ? (change / invested) * 100 : 0,
+      sells: sells,
+      // Has the round already returned more than it cost? The state the
+      // "sell initial" move exists to reach.
+      houseMoney: soldSol >= invested && invested > 0,
+    };
+  }
   function positionMark(pos, priceNative, priceUsd) {
     if (!pos || !(pos.qty > 0)) return null;
     var px = Number(priceNative) > 0 ? Number(priceNative) : Number(pos.lastPriceNative);
@@ -1431,6 +1484,7 @@
     sameAddress,
     pricesFromBatch,
     positionRows,
+    positionLedger,
     portfolioSummary,
     headerFields,
     shortAddress,

--- a/extension/test/positionledger.test.js
+++ b/extension/test/positionledger.test.js
@@ -1,0 +1,90 @@
+/* The round ledger: invested / sold / remaining / change.
+ *
+ * Requested from a venue screenshot — INVESTED, SOLD, REMAINING, PNL CHANGE.
+ * The question it answers is not the one positionMark answers. A bag sold
+ * halfway down shows a RED unrealized P&L on what is left while the round as
+ * a whole is up, so the card stated one thing and the trader meant the other.
+ *
+ * Derived, never stored, so the tests are about what it must never count.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const Q = require('../quote.js');
+const content = fs.readFileSync(path.join(__dirname, '..', 'content.js'), 'utf8');
+
+const POS = { mint: 'MINT', sessionId: 'S1', openedAt: 1000, investedSol: 2, qty: 10, costSol: 1 };
+// mint rides on every real journal fill, and the sessionId-less fallback path
+// matches on it — a fixture without one exercises neither branch.
+const sell = (o) => Object.assign(
+  { side: 'sell', mint: 'MINT', sessionId: 'S1', ts: 2000, solNet: 0, pnlSol: 0 }, o);
+
+test('no sells yet means no ledger to show', () => {
+  const led = Q.positionLedger([], POS, 3);
+  assert.equal(led.sells, 0, 'nothing has come back');
+  assert.equal(led.soldSol, 0);
+});
+
+test('the change is money back plus money still held, against money in', () => {
+  const led = Q.positionLedger([sell({ solNet: 1.5, pnlSol: 0.5 })], POS, 1.2);
+  assert.equal(led.investedSol, 2);
+  assert.equal(led.soldSol, 1.5);
+  assert.equal(led.remainingSol, 1.2);
+  // 1.5 returned + 1.2 still held − 2 in = +0.7
+  assert.ok(Math.abs(led.changeSol - 0.7) < 1e-9);
+  assert.ok(Math.abs(led.changePct - 35) < 1e-9);
+});
+
+test('a previous round in the same token is not counted', () => {
+  // sessionId is stamped per position-open, so the earlier round has its own.
+  const led = Q.positionLedger([
+    sell({ solNet: 1, pnlSol: 0.4 }),
+    sell({ sessionId: 'OLD-ROUND', solNet: 99, pnlSol: 99 }),
+  ], POS, 0.5);
+  assert.equal(led.sells, 1);
+  assert.equal(led.soldSol, 1, 'the old round must not inflate this one');
+});
+
+test('a sell older than the position is not counted, even without a sessionId', () => {
+  // Chains predating sessionIds fall back to matching by mint, which alone
+  // would sweep in every earlier round the token ever had.
+  const led = Q.positionLedger([
+    sell({ sessionId: null, ts: 500, solNet: 50, pnlSol: 50 }),
+    sell({ sessionId: null, ts: 3000, solNet: 1, pnlSol: 0.2 }),
+  ], POS, 0.5);
+  assert.equal(led.sells, 1, 'only the sell that belongs to THIS open round');
+  assert.equal(led.soldSol, 1);
+});
+
+test('buys are never mistaken for money coming back', () => {
+  const led = Q.positionLedger([
+    { side: 'buy', sessionId: 'S1', ts: 1500, solNet: 5 },
+    sell({ solNet: 1, pnlSol: 0.1 }),
+  ], POS, 0.5);
+  assert.equal(led.soldSol, 1);
+});
+
+test('house money is the sells alone covering what went in', () => {
+  const under = Q.positionLedger([sell({ solNet: 1.99, pnlSol: 0.2 })], POS, 5);
+  assert.equal(under.houseMoney, false, 'unrealised value must not count toward it');
+  const over = Q.positionLedger([sell({ solNet: 2.0, pnlSol: 0.3 })], POS, 0.1);
+  assert.equal(over.houseMoney, true);
+});
+
+test('a zero-invested position cannot produce an infinite percentage', () => {
+  const led = Q.positionLedger([sell({ solNet: 1 })], { ...POS, investedSol: 0 }, 1);
+  assert.equal(led.changePct, 0, 'no denominator means no percentage claim');
+  assert.ok(Number.isFinite(led.changeSol));
+});
+
+test('the panel renders it in the venue currency, and only after a sell', () => {
+  const fn = content.slice(
+    content.indexOf('function renderPositionLedger('),
+    content.indexOf('\n  }', content.indexOf('function renderPositionLedger(')) + 4);
+  assert.match(fn, /led\.sells === 0/, 'it must stay hidden until something has been sold');
+  assert.match(fn, /panelUsd\(\)/, 'dollars off Solana');
+  assert.match(fn, /E\.fmt\(sol, 3\)} SOL/, 'SOL on Solana');
+  assert.match(fn, /pt-house/, 'and it must mark the house-money state');
+});

--- a/extension/test/sellinitial.test.js
+++ b/extension/test/sellinitial.test.js
@@ -1,0 +1,154 @@
+/* "Sell your initial" — recover what went in, hold the rest as house money.
+ *
+ * The number behind that move is not "half", and it is not the naive
+ * invested/value either: costs come off the top, so netting back what you put
+ * in means selling MORE. Get it wrong and the trader believes they are
+ * de-risked while still a few percent short — which is the exact belief this
+ * feature exists to make true.
+ *
+ * So these tests do not assert the formula back at itself. They run the plan
+ * through the REAL engine and check the money actually came back.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+global.window = global.window || {};
+const E = require('../engine.js');
+const Q = require('../quote.js');
+
+/** Open a position, then ask for the sell-initial plan and execute it. */
+function runScenario({ feeBps = 0, slippageBps = 0, gas = 0, tip = 0, buySol = 1, growth = 3 }) {
+  const settings = Object.assign(E.defaultSettings(), {
+    feeBps, slippageBps, gasSolPerTx: gas, tipSolPerTx: tip, balanceStartSol: 100,
+  });
+  const state = E.defaultState(settings);
+  const mint = 'MINT';
+  E.buy(state, settings, { ts: 1000, mint, symbol: 'T', site: 's', priceNative: 1, solAmount: buySol });
+
+  const pos = state.positions[mint];
+  const price = growth; // the token has run to `growth`x the entry price
+  const mark = Q.positionMark(pos, price, null);
+  const ledger = Q.positionLedger(state.journal, pos, mark.valueSol);
+  const plan = Q.sellInitialPlan(pos, ledger, price, {
+    feeBps, slippageBps, flatSol: gas + tip,
+  });
+
+  if (!plan) return { plan: null, state, settings, pos, ledger };
+  E.sell(state, settings, { ts: 2000, mint, qtyFraction: plan.fraction, priceNative: price });
+
+  const after = Q.positionLedger(state.journal, state.positions[mint] || pos,
+    (state.positions[mint] ? state.positions[mint].qty : 0) * price);
+  return { plan, state, settings, ledger, after };
+}
+
+test('with no costs, selling the plan returns exactly what went in', () => {
+  const { plan, ledger, after } = runScenario({ growth: 4 });
+  assert.ok(plan, 'a plan must exist while money is still out');
+  assert.ok(Math.abs(after.soldSol - ledger.investedSol) < 1e-9,
+    `sold ${after.soldSol} should equal invested ${ledger.investedSol}`);
+  assert.equal(after.houseMoney, true, 'the remainder is now house money');
+});
+
+test('a percentage fee is paid out of the sale, not out of the trader', () => {
+  // The naive fraction would net (1 - fee) of what was needed and leave the
+  // position quietly short.
+  const { plan, ledger, after } = runScenario({ feeBps: 100, growth: 4 });
+  assert.ok(Math.abs(after.soldSol - ledger.investedSol) < 1e-9,
+    'a 1% fee must not leave the recovery 1% short');
+  assert.ok(plan.fraction > 0 && plan.fraction < 1);
+});
+
+test('flat gas and tip are recovered too', () => {
+  const { ledger, after } = runScenario({ gas: 0.002, tip: 0.003, growth: 4 });
+  assert.ok(Math.abs(after.soldSol - ledger.investedSol) < 1e-9,
+    'the flat cost of the exit itself must be covered by the exit');
+});
+
+test('slippage is priced from the fill, not the quote on screen', () => {
+  // The engine fills a sell BELOW the displayed price. Planning on the quote
+  // would sell too little every time.
+  const { ledger, after } = runScenario({ slippageBps: 200, growth: 4 });
+  assert.ok(Math.abs(after.soldSol - ledger.investedSol) < 1e-9,
+    '2% slippage must be planned for, not discovered');
+});
+
+test('every cost at once still lands exactly whole', () => {
+  const { ledger, after } = runScenario({
+    feeBps: 100, slippageBps: 150, gas: 0.001, tip: 0.001, growth: 5,
+  });
+  assert.ok(Math.abs(after.soldSol - ledger.investedSol) < 1e-9,
+    'fee + slippage + flat compose without drift');
+});
+
+test('a position that has not run cannot recover its initial, and says so', () => {
+  // Down 50%: the whole bag is worth less than what went in.
+  const { plan } = runScenario({ growth: 0.5 });
+  assert.ok(plan, 'a plan is still returned — the shortfall is information');
+  assert.equal(plan.shortfall, true, 'it must state that the bag cannot cover it');
+  assert.equal(plan.fraction, 1, 'and cap at the whole position rather than over-ask');
+});
+
+test('an already-whole round offers nothing to do', () => {
+  const settings = Object.assign(E.defaultSettings(), { balanceStartSol: 100, feeBps: 0 });
+  const state = E.defaultState(settings);
+  E.buy(state, settings, { ts: 1000, mint: 'M', symbol: 'T', site: 's', priceNative: 1, solAmount: 1 });
+  // Sell most of it at 10x — proceeds far exceed what went in.
+  E.sell(state, settings, { ts: 2000, mint: 'M', qtyFraction: 0.5, priceNative: 10 });
+  const pos = state.positions.M;
+  const ledger = Q.positionLedger(state.journal, pos, pos.qty * 10);
+  assert.equal(ledger.houseMoney, true);
+  assert.equal(Q.sellInitialPlan(pos, ledger, 10, { flatSol: 0 }), null,
+    'nothing left to recover means no plan');
+});
+
+test('a priceless or empty position produces no plan rather than a guess', () => {
+  const ledger = { investedSol: 1, soldSol: 0 };
+  assert.equal(Q.sellInitialPlan({ qty: 0, lastPriceNative: 1 }, ledger, 1, {}), null);
+  assert.equal(Q.sellInitialPlan({ qty: 5, lastPriceNative: 0 }, ledger, 0, {}), null);
+  assert.equal(Q.sellInitialPlan(null, ledger, 1, {}), null);
+});
+
+/* ---------------- the control that acts on the plan ---------------- */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const content = fs.readFileSync(path.join(__dirname, '..', 'content.js'), 'utf8');
+
+function block(name) {
+  const at = content.indexOf(`function ${name}(`);
+  assert.ok(at !== -1, `${name} must exist`);
+  return content.slice(at, content.indexOf('\n  }', at) + 4);
+}
+
+test('the button plans against the same costs the fill will charge', () => {
+  // A plan built on different numbers from the sell is a plan that misses.
+  const fn = block('currentInitialPlan');
+  assert.match(fn, /feeBps: settings\.feeBps/);
+  assert.match(fn, /slippageBps: settings\.slippageBps/);
+  assert.match(fn, /flatSol: E\.txCostSol\(settings\)/,
+    'the flat cost must come from the engine, not a second copy of the clamp');
+});
+
+test('a shortfall refuses instead of selling everything and calling it a recovery', () => {
+  const click = content.slice(content.indexOf("initialBtn.addEventListener('click'"),
+    content.indexOf('buildOrdersSection(card)'));
+  assert.match(click, /if \(!plan \|\| plan\.shortfall\) return;/,
+    'the handler must refuse a shortfall outright');
+
+  const render = block('renderSellInitial');
+  assert.match(render, /btn\.disabled = true/, 'and the control must show as unavailable');
+  assert.match(render, /Not enough to cover the initial yet/, 'saying why');
+});
+
+test('the label states the fraction it is about to sell', () => {
+  // "Sell initial" alone asks the trader to trust an unstated number.
+  const render = block('renderSellInitial');
+  assert.match(render, /plan\.fraction \* 100/);
+  assert.match(render, /Sell initial \(\$\{/);
+});
+
+test('nothing to recover means no button at all', () => {
+  const render = block('renderSellInitial');
+  assert.match(render, /if \(!plan\) \{ btn\.classList\.add\('pt-hidden'\); return; \}/,
+    'a round already whole has no initial left to take off the table');
+});


### PR DESCRIPTION
> **Stacked on #53** — it uses `Q.positionLedger` from there. Merge that first and this reduces to the button plus its planner.

> *"a button where you can sell your initial buy in so the rest of the money your holding is profit"*

## The number is not "half"

It''s not `invested / value` either. **Costs come off the top**, so netting back what went in means selling *more* — and by exactly how much depends on the fee, the flat tx cost, and the slippage the fill will take.

Solved rather than approximated:

```
net   = gross − gross×fee − flat
gross = (need + flat) / (1 − fee)
```

...against the **slipped price the engine will really fill at**, not the quote on screen. Planning on the quote sells too little every single time.

## The tests don''t assert the formula back at itself

They run the plan through the **real engine** and check the money actually came back — no costs, fee only, flat only, slippage only, and all of them at once:

```
|sold − invested| < 1e-9    ✓ in every case
ledger.houseMoney === true  ✓ in every case
```

That''s the property the button *claims*. Anything less is a trader who believes they''re de-risked and isn''t — which is the exact belief this feature exists to make true.

## A shortfall refuses

When the whole bag couldn''t cover the initial, the control says so and stays disabled. **Selling 100% while calling it a recovery is the one outcome this button must never produce**, so the click handler bails on `plan.shortfall` independently of the `disabled` attribute — a disabled button is a UI state, not a guarantee.

The label carries the fraction — **"Sell initial (34%)"**. "Sell initial" alone asks the trader to trust an unstated number about their own money. And it disappears entirely once there''s nothing left to recover.

## One export

`E.txCostSol` is now exported so the panel plans against the same flat cost the fill charges. Re-deriving it in `content.js` would be a second copy of the clamp, free to drift from the one that actually bills.

```
extension  1781/1781
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
