### PR TITLE
feat(overlay): declutter the panel - custom amount opt-in, no MC alert when compact

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -4300,11 +4300,26 @@
       font-size: 12px; cursor: pointer; padding: 0 2px; line-height: 1;
     }
     .pt-akill:hover { color: #FFB3AE; }
-    /* Same rule as an armed stop: focus mode hides the ladder, never the
-       levels already armed. */
+    /* The compact sizes drop the market-cap alert.
+
+       Requested for both focus and micro: at those widths the arm row, the
+       entry box and the hint are three lines of furniture for a feature you
+       are not using in the moment you chose the smallest panel.
+
+       Levels ALREADY ARMED still show, in both. Same rule as an armed stop,
+       and for a stronger reason here: an alert is watching whether the panel
+       displays it or not, and hiding a live one leaves the trader unable to
+       see or cancel something that will fire at them. The label goes with the
+       controls, so an armed list does not sit under a heading for a form that
+       is not there. */
     .pt-box.pt-focus .pt-alerts .pt-alert-arm,
     .pt-box.pt-focus .pt-alerts .pt-alert-entry,
-    .pt-box.pt-focus .pt-alerts .pt-alert-hint { display: none; }
+    .pt-box.pt-focus .pt-alerts .pt-alert-hint,
+    .pt-box.pt-focus .pt-alerts > .pt-label,
+    .pt-box.pt-micro .pt-alerts .pt-alert-arm,
+    .pt-box.pt-micro .pt-alerts .pt-alert-entry,
+    .pt-box.pt-micro .pt-alerts .pt-alert-hint,
+    .pt-box.pt-micro .pt-alerts > .pt-label { display: none; }
 
     /* ---------------- sell row ---------------- */
 
@@ -5302,11 +5317,18 @@
     } else if (key === 'b') {
       setBarHidden(!positionsBarHidden);
     } else if (key === 'a') {
-      if (!els.custom || els.custom.offsetParent === null) return; // buy section hidden
       panelMinimized = false;
       setPanelVisible(true);
-      els.custom.focus();
-      els.custom.select();
+      // The amount box is optional now, so this key falls through to the
+      // first preset rather than becoming a key that does nothing.
+      if (els.custom && els.custom.offsetParent !== null) {
+        els.custom.focus();
+        els.custom.select();
+      } else {
+        const first = els.buyPresets && els.buyPresets.querySelector('.pt-preset');
+        if (!first) return;
+        first.focus();
+      }
     } else return;
 
     // Claimed only once we know we acted, so an unbound combo still reaches
@@ -5325,7 +5347,14 @@
     const sectionOn = settings.panelBuyEnabled !== false;
     const presetsOn = sectionOn && settings.panelPresetsEnabled !== false;
     if (els.buyLabel) els.buyLabel.style.display = sectionOn ? '' : 'none';
-    if (els.custom) els.custom.style.display = sectionOn ? '' : 'none';
+    // The free-text amount box is off by default now. It was three lines of
+    // panel for a field the preset row already covers: those became eight
+    // configurable boxes, so an arbitrary size is a setting away rather than
+    // a permanent tax on every panel. Hidden, never removed — BUY and the
+    // limit-arm both read it and both already fall back to the selected
+    // preset when it is empty, so nothing downstream has to know.
+    const customOn = sectionOn && settings.panelCustomAmount === true;
+    if (els.custom) els.custom.style.display = customOn ? '' : 'none';
     if (els.btnBuy) els.btnBuy.style.display = sectionOn ? '' : 'none';
     if (els.buyPresets) els.buyPresets.style.display = presetsOn ? '' : 'none';
 

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -4429,6 +4429,7 @@ function renderSettings(el) {
       <div class="field"><label for="set-list-quick-buy-placement">Buy-button position on lists</label><select id="set-list-quick-buy-placement"><option value="auto" ${settings.listQuickBuyPlacement !== 'bottom' ? 'selected' : ''}>Auto — next to each row (moves if it covers something)</option><option value="bottom" ${settings.listQuickBuyPlacement === 'bottom' ? 'selected' : ''}>Corner — always bottom-right of the row</option></select><small>Corner pins the P button to the row's bottom-right, clear of the market-cap readout on compact/ultra list formats.</small></div>
           <div class="field field-check"><label><input type="checkbox" id="set-panel-buy" ${settings.panelBuyEnabled !== false ? 'checked' : ''}> Buy section in the trade tab</label><small>Shows the quick-buy presets, custom amount and BUY button in the overlay. Off makes the trade tab view-only.</small></div>
           <div class="field field-check"><label><input type="checkbox" id="set-panel-presets" ${settings.panelPresetsEnabled !== false ? 'checked' : ''}> Quick-buy preset buttons</label><small>The one-tap SOL amount buttons. Off keeps the custom amount and BUY button.</small></div>
+        <div class="field field-check"><label><input type="checkbox" id="set-panel-custom" ${settings.panelCustomAmount === true ? 'checked' : ''}> Custom amount box</label><small>A free-text SOL amount under the presets. Off by default — the preset row is eight boxes you configure above, so an arbitrary size is rarely needed and the field costs three lines of panel on every token. BUY and limit orders use the selected preset when it is off.</small></div>
         </div>
         <div class="card">
           <h3>Exits — take profit &amp; stop loss</h3>
@@ -5038,6 +5039,7 @@ function gatherSettingsFromForm(notes = [], base = settings) {
     overlayEnabled: document.getElementById('set-overlay').checked,
     overlayHideWhenNoToken: document.getElementById('set-overlay-auto-hide').checked,
     panelFocusMode: document.getElementById('set-focus-mode').checked,
+    panelCustomAmount: document.getElementById('set-panel-custom').checked,
     // Closed set, validated here rather than trusted: content.js looks the
     // value up in SHORTCUT_SCHEMES, and anything unrecognised means no
     // shortcuts at all — which would be an invisible failure, not a refusal.

--- a/extension/test/statepersist.test.js
+++ b/extension/test/statepersist.test.js
@@ -392,8 +392,11 @@ test('the preset row hides alone while the BUY button stays', async () => {
     'the one-tap presets must be hidden');
   assert.notEqual(ov.shadowNodes['pt-buy'].style.display, 'none',
     'the BUY button must remain available');
-  assert.notEqual(ov.shadowNodes['pt-custom'].style.display, 'none',
-    'the custom amount input must remain available');
+  // The free-text amount box is OFF by default as of the panel declutter —
+  // the preset row it duplicates is now eight configurable boxes. It is
+  // hidden, never removed, so BUY and limit-arm still read it.
+  assert.equal(ov.shadowNodes['pt-custom'].style.display, 'none',
+    'the custom amount box is opt-in now');
 });
 
 test('with both toggles on, every buy control is visible', async () => {
@@ -401,12 +404,36 @@ test('with both toggles on, every buy control is visible', async () => {
 
   await ov.advance(1200);
 
-  for (const id of ['pt-buy-label', 'pt-buy-presets', 'pt-custom', 'pt-buy']) {
+  for (const id of ['pt-buy-label', 'pt-buy-presets', 'pt-buy']) {
     assert.notEqual(ov.shadowNodes[id].style.display, 'none',
       `${id} must be visible with default settings`);
   }
 });
 
+test('the custom amount box returns when the setting is switched on', async () => {
+  // Off by default, but nothing is removed — the request was for panel space,
+  // not for the capability. BUY reads this element either way and falls back
+  // to the selected preset when it is empty, so hiding it can never strand a
+  // trader without a way to size an order.
+  const ov = runOverlay([0.001], {
+    initialSettings: { panelCustomAmount: true, settingsRevision: E.SETTINGS_REVISION },
+  });
+  await ov.advance(1200);
+  assert.notEqual(ov.shadowNodes['pt-custom'].style.display, 'none',
+    'switching it on must bring the box back');
+});
+
+test('the buy-section switch still outranks the custom-amount setting', async () => {
+  const ov = runOverlay([0.001], {
+    initialSettings: {
+      panelBuyEnabled: false, panelCustomAmount: true,
+      settingsRevision: E.SETTINGS_REVISION,
+    },
+  });
+  await ov.advance(1200);
+  assert.equal(ov.shadowNodes['pt-custom'].style.display, 'none',
+    'a view-only trade tab shows no buy controls at all');
+});
 /* ---------------- reported: panel forgets its place on refresh ----------------
  *
  * levv6x: "make it remember its place — every time I refresh or open a new


### PR DESCRIPTION
Two requests, both about panel space.

## 1 · The custom amount box is now opt-in (default off)

> *"remove the custom buy amount since it takes so much space"*

**Hidden, never removed.** BUY and the limit-arm both read the element, and both already fall back to the selected preset when it''s empty — so nothing downstream needs to know it''s gone, and switching it back on restores it exactly.

### This is a genuine default change, and worth flagging

Existing users lose a control they may be using. The argument for it: the preset row it duplicates **became eight boxes the user configures themselves** (#46), so an arbitrary size went from *"the only way"* to *"a setting away"* — while the field cost three lines of panel on every token, forever.

### Two tests moved rather than were deleted

`statepersist.test.js` asserted `pt-custom` visible by default. That was the **old contract, correctly encoded** — so it moves because the contract moved, not because it was wrong.

Worth calling out: my first pass removed it from the wrong loop — the *"hidden when the buy section is off"* check — which would have **weakened** that test by silently dropping a case. Restored there (the buy-section switch still outranks this setting), dropped only from the *"visible by default"* list, and two cases added: the box returns when switched on, and the buy-section switch beats it.

## 2 · The market-cap alert leaves the compact sizes

> *"remove the market cap alert from the focus style and the micro style"*

Focus already hid the arm row, entry and hint; micro hid nothing. Both now hide all four — **including the section label**, since an armed list sitting under a heading for a form that isn''t there reads as a rendering bug.

**Levels already armed still show, in both.** Same rule focus mode already applied to stops, and for a stronger reason here: an alert is watching whether the panel draws it or not, and hiding a live one leaves the trader unable to see or cancel something that will fire at them.

## One knock-on

The `A` shortcut from #48 focused the amount box, and would have become a **dead key** once that box defaulted off. It now falls through to the first preset.

```
extension  1763/1763
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
