### PR TITLE
feat(popup): three panes, so the popup stops being a scroll

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -132,6 +132,23 @@
     }
     .btn-backup:hover { background: rgba(255,255,255,0.09); border-color: rgba(255,255,255,0.22); }
 
+    /* Pane tabs. The panes are hidden with the attribute, which works here
+       because of the [hidden] guard at the top of this file — the same rule
+       whose absence kept the update banner permanently on screen. */
+    .ptabs {
+      display: flex; gap: 4px; margin: 12px 16px 0;
+      padding: 3px; border-radius: 10px;
+      background: rgba(0, 0, 0, 0.3); border: 1px solid var(--line);
+    }
+    .ptab {
+      flex: 1; padding: 6px 4px; border: 0; border-radius: 7px;
+      background: transparent; color: var(--faint);
+      font-family: inherit; font-size: 11.5px; font-weight: 700; cursor: pointer;
+      transition: color 0.14s, background 0.14s;
+    }
+    .ptab:hover { color: var(--text); }
+    .ptab.on { color: var(--text); background: rgba(255, 255, 255, 0.08); }
+    .ppane { padding-top: 4px; }
     .hint {
       margin: 12px 16px 0; padding: 9px 11px;
       background: rgba(255,255,255,0.028); border: 1px solid var(--line); border-radius: 10px;
@@ -224,53 +241,56 @@
 
   <div class="delta dim" id="flow" style="text-align:center"></div>
 
-  <div class="section-label">Recent round trips</div>
-  <div id="recent"></div>
-
-  <div class="btns">
-    <button id="power" class="btn-backup">⏻ Turn PaperTrench off</button>
-  </div>
-  <div class="btns">
+  <div class="btns" style="padding-top:10px">
     <button id="dash" class="btn-pri">Dashboard</button>
-    <button id="toggle">Toggle overlay</button>
-  </div>
-  <div class="btns">
-    <button id="backup" class="btn-backup">⬇ Backup wallet</button>
-    <button id="restore" class="btn-backup">⬆ Restore backup</button>
-  </div>
-  <div class="btns">
-    <button id="overlay-window" class="btn-backup">🎥 Stream overlay</button>
-  </div>
-  <div class="btns">
-    <button id="warmx" class="btn-backup">⚡ Instant X links: Off</button>
-  </div>
-  <div class="btns">
-    <button id="warmdest" class="btn-backup">⚡ Instant terminal links: Off</button>
-  </div>
-  <div id="turbo-receipts" style="display:none;padding:4px 2px 0;font-size:11px;color:#8D97A9"></div>
-  <div class="btns">
-    <button id="xray" class="btn-backup">⌖ X-Ray on x.com: Off</button>
   </div>
 
-  <div class="section-label" style="padding-top:14px">Quick settings</div>
-  <div class="qs">
-    <div class="qs-field"><label for="qs-balance">Starting balance (SOL)</label><input id="qs-balance" type="number" min="0.1" step="0.1"></div>
-    <div class="qs-field"><label for="qs-presets">Quick-buy presets (SOL)</label><input id="qs-presets" type="text" placeholder="0.1, 0.5, 1, 2"></div>
-    <div class="qs-field"><label for="qs-sellpcts">Quick-sell presets (%)</label><input id="qs-sellpcts" type="text" placeholder="25, 50, 75, 100"></div>
-    <div class="qs-field"><label for="qs-fees">Fees &amp; costs</label>
-      <select id="qs-fees">
-        <option value="custom">Keep current</option>
-        <option value="bot">≈ Axiom/Padre bot</option>
-        <option value="fast">≈ Aggressive sniper</option>
-        <option value="zero">No costs</option>
-      </select>
+  <!-- Everything below the wallet lives in one of three panes. The popup was
+       a single ~1100px column in a 316px window: checking a balance and
+       flipping a toggle were at opposite ends of a scroll. The wallet stays
+       pinned above because it is why the popup gets opened; the rest swaps. -->
+  <div class="ptabs" role="tablist">
+    <button class="ptab on" data-pane="pane-recent" role="tab" aria-selected="true">Recent</button>
+    <button class="ptab" data-pane="pane-features" role="tab" aria-selected="false">Features</button>
+    <button class="ptab" data-pane="pane-setup" role="tab" aria-selected="false">Setup</button>
+  </div>
+
+  <div id="pane-recent" class="ppane">
+    <div id="recent"></div>
+  </div>
+
+  <div id="pane-features" class="ppane" hidden>
+    <div class="btns"><button id="toggle">Toggle overlay</button></div>
+    <div class="btns"><button id="warmx" class="btn-backup">⚡ Instant X links: Off</button></div>
+    <div class="btns"><button id="warmdest" class="btn-backup">⚡ Instant terminal links: Off</button></div>
+    <div id="turbo-receipts" style="display:none;padding:4px 2px 0;font-size:11px;color:#8D97A9"></div>
+    <div class="btns"><button id="xray" class="btn-backup">⌖ X-Ray on x.com: Off</button></div>
+    <div class="btns"><button id="overlay-window" class="btn-backup">🎥 Stream overlay</button></div>
+    <div class="btns" style="padding-top:10px"><button id="power" class="btn-backup">⏻ Turn PaperTrench off</button></div>
+  </div>
+
+  <div id="pane-setup" class="ppane" hidden>
+    <div class="qs">
+      <div class="qs-field"><label for="qs-balance">Starting balance (SOL)</label><input id="qs-balance" type="number" min="0.1" step="0.1"></div>
+      <div class="qs-field"><label for="qs-presets">Quick-buy presets (SOL)</label><input id="qs-presets" type="text" placeholder="0.1, 0.5, 1, 2"></div>
+      <div class="qs-field"><label for="qs-sellpcts">Quick-sell presets (%)</label><input id="qs-sellpcts" type="text" placeholder="25, 50, 75, 100"></div>
+      <div class="qs-field"><label for="qs-fees">Fees &amp; costs</label>
+        <select id="qs-fees">
+          <option value="custom">Keep current</option>
+          <option value="bot">≈ Axiom/Padre bot</option>
+          <option value="fast">≈ Aggressive sniper</option>
+          <option value="zero">No costs</option>
+        </select>
+      </div>
+      <div class="btns"><button id="qs-apply" class="btn-backup">Apply quick settings</button></div>
     </div>
-    <div class="btns"><button id="qs-apply" class="btn-backup">Apply quick settings</button></div>
+    <div class="btns" style="padding-top:10px">
+      <button id="backup" class="btn-backup">⬇ Backup wallet</button>
+      <button id="restore" class="btn-backup">⬆ Restore backup</button>
+    </div>
+    <input type="file" id="restoreFile" accept=".json,application/json" style="display:none">
+    <button id="reset" class="btn-sec">Reset wallet</button>
   </div>
-
-  <input type="file" id="restoreFile" accept=".json,application/json" style="display:none">
-  <button id="reset" class="btn-sec">Reset wallet</button>
-
   <div class="hint">Open a token page on Axiom, Padre, Photon, GMGN, BullX, Dexscreener, Birdeye, or Jupiter to start paper trading.</div>
   <div id="status"></div>
   <script src="attest.js"></script>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -129,6 +129,24 @@ const UPDATER = (() => {
 
 UPDATER.render();
 
+/* Pane switching. Every pane stays in the DOM — popup.js binds all of these
+ * ids at load, and a pane that was removed rather than hidden would take its
+ * controls with it. */
+(() => {
+  const tabs = document.querySelectorAll(".ptab");
+  if (!tabs.length) return;
+  tabs.forEach((tab) => tab.addEventListener("click", () => {
+    tabs.forEach((t) => {
+      const on = t === tab;
+      t.classList.toggle("on", on);
+      t.setAttribute("aria-selected", on ? "true" : "false");
+      const pane = document.getElementById(t.dataset.pane);
+      if (pane) pane.hidden = !on;
+    });
+  }));
+})();
+
+
 function fmt(n, dp = 4) {
   if (n === null || n === undefined || Number.isNaN(Number(n))) return '—';
   return Number(n).toLocaleString(undefined, { maximumFractionDigits: dp });

--- a/extension/test/updatebanner.test.js
+++ b/extension/test/updatebanner.test.js
@@ -66,6 +66,10 @@ function loadPopupPage({ release, checkedAt, seenVersion, manifestVersion }) {
   const documentStub = {
     getElementById: (id) => els[id] || null,
     createElement: (tag) => makeEl('el-' + tag + '-' + Math.random()),
+    // popup.js also wires the pane tabs at load. This suite is about the
+    // update banner and has no tabs to find, but the stub has to answer the
+    // call or the script throws before the banner is ever rendered.
+    querySelectorAll: () => [],
   };
 
   const sandbox = {
@@ -181,7 +185,7 @@ test('popup update nudge: fetch failure leaves the popup exactly as it was', asy
     els[id] = makeEl(id);
   }
   const sandbox = {
-    document: { getElementById: (id) => els[id] || null, createElement: (t) => makeEl('x-' + t) },
+    document: { getElementById: (id) => els[id] || null, createElement: (t) => makeEl('x-' + t), querySelectorAll: () => [] },
     console, setTimeout, Date, Number, String, JSON, Math,
     fetch: async () => { throw new Error('offline'); },
     chrome: {
@@ -253,4 +257,62 @@ test('the update banner in particular cannot render while hidden', () => {
     'this test is about the banner being display-styled — if that changed, revisit it');
   assert.match(css, /\[hidden\]\s*\{[^}]*display:\s*none\s*!important/,
     'and the guard that makes hiding it actually work');
+});
+
+/* ------------------------------------------------------------------------
+ * Pane tabs.
+ *
+ * The popup was one ~1100px column in a 316px window: checking a balance and
+ * flipping a toggle sat at opposite ends of a scroll. The wallet stays pinned
+ * and the rest swaps between three panes.
+ * ---------------------------------------------------------------------- */
+
+const popupHtmlTabs = fs.readFileSync(path.join(ROOT, 'popup.html'), 'utf8');
+const popupJsTabs = fs.readFileSync(path.join(ROOT, 'popup.js'), 'utf8');
+
+test('every control still exists — panes hide, they never remove', () => {
+  // popup.js binds all of these at load. A pane built by removing markup
+  // instead of hiding it would take its controls' listeners with it.
+  const ids = ['equity', 'cash', 'pnl', 'open', 'rounds', 'flow', 'recent',
+    'power', 'dash', 'toggle', 'backup', 'restore', 'restoreFile', 'overlay-window',
+    'warmx', 'warmdest', 'turbo-receipts', 'xray', 'qs-balance', 'qs-presets',
+    'qs-sellpcts', 'qs-fees', 'qs-apply', 'reset', 'status'];
+  for (const id of ids) {
+    const count = popupHtmlTabs.split(`id="${id}"`).length - 1;
+    assert.equal(count, 1, `${id} must appear exactly once`);
+  }
+});
+
+test('the wallet is pinned above the tabs, not inside one', () => {
+  // It is why the popup gets opened; putting it in a pane would mean a click
+  // to see your balance.
+  const tabsAt = popupHtmlTabs.indexOf('class="ptabs"');
+  assert.ok(tabsAt !== -1, 'the tab strip must exist');
+  for (const id of ['equity', 'cash', 'rounds', 'dash']) {
+    assert.ok(popupHtmlTabs.indexOf(`id="${id}"`) < tabsAt,
+      `${id} must sit above the tab strip`);
+  }
+});
+
+test('exactly one pane starts open', () => {
+  const panes = [...popupHtmlTabs.matchAll(/<div id="(pane-[a-z]+)" class="ppane"( hidden)?>/g)];
+  assert.equal(panes.length, 3, 'three panes');
+  const open = panes.filter((m) => !m[2]);
+  assert.equal(open.length, 1, 'exactly one pane may be visible on open');
+  assert.equal(open[0][1], 'pane-recent', 'and it is the one showing wallet activity');
+});
+
+test('the tab strip and the panes cannot drift apart', () => {
+  const tabbed = [...popupHtmlTabs.matchAll(/data-pane="(pane-[a-z]+)"/g)].map((m) => m[1]).sort();
+  const panes = [...popupHtmlTabs.matchAll(/<div id="(pane-[a-z]+)"/g)].map((m) => m[1]).sort();
+  assert.deepEqual(tabbed, panes, 'every tab points at a pane, and every pane has a tab');
+});
+
+test('switching panes uses the hidden attribute the CSS guard backs', () => {
+  // Without [hidden] { display: none !important } in this file, setting
+  // .hidden on a styled element does nothing — the exact bug that kept the
+  // update banner on screen. The panes rely on the same rule.
+  assert.match(popupJsTabs, /pane\.hidden = !on/, 'panes toggle via the attribute');
+  assert.match(popupHtmlTabs, /\[hidden\] \{ display: none !important; \}/,
+    'and the guard that makes it take effect must still be here');
 });


### PR DESCRIPTION
> *"you always have to scroll up and down to look at random stuff"*

Measured on the reported build: roughly **1100px of stacked content in a 316px window**. Checking a balance and flipping a toggle sat at opposite ends of a scroll, with quick settings and Reset wallet below both.

## The wallet stays pinned

Equity, the four tiles, flow, and **Dashboard**. That''s what the popup gets opened for — putting it in a pane would mean a click to see your own balance.

Everything under it swaps between three panes:

| Pane | |
| --- | --- |
| **Recent** | round trips |
| **Features** | overlay, instant X, instant terminal, X-Ray, stream overlay, app-wide power switch |
| **Setup** | quick settings, backup/restore, reset |

## Nothing is removed

`popup.js` binds every one of these ids at load, so a pane built by **deleting** markup would take its controls'' listeners with it. The panes hide with the `hidden` attribute, and a test asserts all **25 ids still appear exactly once**.

## A nice coupling worth noting

That attribute only works here because of the `[hidden]` guard added in #43, when the update banner turned out to be permanently visible. The panes now depend on **the same rule** — so there''s a test pinning it: remove the guard and both features break together, loudly, instead of the panes silently all rendering at once.

## One test-harness fix

`popup.js` now calls `document.querySelectorAll` at load to wire the tabs, and `updatebanner.test.js` stubs a document with only `getElementById` and `createElement`.

I gave the **stub** the method rather than giving the **source** a guard. The DOM in a real popup always has it, and coding defensively around an incomplete stub would just hide the next thing the stub is missing.

```
extension  1772/1772
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
