### PR TITLE
feat(site): paper balance in the header

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -2684,7 +2684,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
       case 'pt_bridge_ping': {
         if (!senderOnBridgeOrigin(sender)) { sendResponse({ ok: false, reason: 'origin-not-allowed' }); break; }
-        sendResponse({ ok: true, bridgeEnabled: settings.leaderboardBridge === true });
+        // The wallet rides on the ping so the site can show a balance without
+        // a second round trip — and ONLY when Site sync is on, which is the
+        // same consent gate the record itself sits behind. With it off this
+        // stays exactly what it was: a yes/no about the extension existing.
+        sendResponse({
+          ok: true,
+          bridgeEnabled: settings.leaderboardBridge === true,
+          wallet: settings.leaderboardBridge === true ? await bridgeWallet() : null,
+        });
         break;
       }
 
@@ -3313,6 +3321,42 @@ function senderOnBridgeOrigin(sender) {
   try { return BRIDGE_ORIGINS.has(new URL(url).origin); } catch (_) { return false; }
 }
 
+/**
+ * The wallet summary the site header shows: cash, equity, open positions.
+ *
+ * Deliberately NOT a chain replay. bridgeRecord exists to hand over evidence
+ * and costs a full verification; this is a number for a header chip and must
+ * not make opening papertrench.com expensive.
+ *
+ * Equity marks open bags at the last price the extension itself observed —
+ * the same figure the popup and the positions bar already display, so the
+ * site cannot disagree with the app about the user's own balance. No price
+ * is fetched to produce it: an unmarked bag contributes its last known mark
+ * or nothing, never a guess.
+ */
+async function bridgeWallet() {
+  const state = (await getState()) || {};
+  const cash = Number(state.cashSol) || 0;
+  const positions = state.positions && typeof state.positions === 'object' ? state.positions : {};
+  let open = 0;
+  let held = 0;
+  for (const pos of Object.values(positions)) {
+    const qty = Number(pos && pos.qty) || 0;
+    if (!(qty > 0)) continue;
+    open += 1;
+    const px = Number(pos.lastPriceNative) || 0;
+    if (px > 0) held += qty * px;
+  }
+  return {
+    cashSol: cash,
+    equitySol: cash + held,
+    openPositions: open,
+    // Says whether every open bag actually had a mark. The site can then
+    // show the number plainly or say it is partial, rather than presenting
+    // an understated equity as though it were complete.
+    marked: open === 0 || held > 0,
+  };
+}
 async function bridgeRecord() {
   const settings = await getSettings();
   if (!settings.leaderboardBridge) return { ok: false, reason: 'bridge-disabled' };

--- a/extension/test/statepersist.test.js
+++ b/extension/test/statepersist.test.js
@@ -1095,3 +1095,61 @@ test("focus mode is compact and carries the two-step quick reset (community: lev
   assert.match(resetBlock, /pt_clear_recordings/, "recordings are erased like every other reset path");
   assert.match(resetBlock, /paper-lines-clear/, "chart drawings of the old wallet are cleared");
 });
+
+/* ---------------- the site's paper-balance chip ----------------
+ *
+ * papertrench.com cannot know your paper wallet on its own — it lives in the
+ * extension, on your machine. The chip is fed over the same bridge the
+ * leaderboard Sync uses, so the tests are about the gate and the cost.
+ */
+
+const bgSrc = fs.readFileSync(path.join(__dirname, '..', 'background.js'), 'utf8');
+
+function walletFn() {
+  const at = bgSrc.indexOf('async function bridgeWallet(');
+  assert.ok(at !== -1, 'bridgeWallet must exist');
+  return bgSrc.slice(at, bgSrc.indexOf('\n}', at) + 2);
+}
+
+test('the wallet is only handed over when Site sync is on', () => {
+  // Same consent gate the record sits behind. With it off, the ping stays
+  // exactly what it was: a yes/no about the extension existing.
+  assert.match(bgSrc, /leaderboardBridge === true \? await bridgeWallet\(\) : null/,
+    'the balance must never ride an un-consented ping');
+});
+
+test('the header chip costs no network and no chain replay', () => {
+  // bridgeRecord exists to hand over evidence and verifies the whole chain.
+  // Opening papertrench.com must not pay that for a header chip.
+  const fn = walletFn();
+  assert.ok(!/fetch\(/.test(fn), 'no price may be fetched to answer this');
+  assert.ok(!/replayChain|readChainStore/.test(fn), 'and no chain replay');
+});
+
+test('an unpriced bag contributes its last mark or nothing, never a guess', () => {
+  const fn = walletFn();
+  assert.match(fn, /const px = Number\(pos\.lastPriceNative\) \|\| 0;/);
+  assert.match(fn, /if \(px > 0\) held \+= qty \* px;/,
+    'a bag with no mark adds nothing rather than an invented value');
+  assert.match(fn, /marked:/,
+    'and the reply must say whether every open bag was actually marked');
+});
+
+test('the site says nothing at all when it has not been told', () => {
+  const site = fs.readFileSync(path.join(__dirname, '..', '..', 'site', 'nav-wallet.js'), 'utf8');
+  assert.match(site, /if \(!wallet\) return;/, 'no answer renders no chip');
+  assert.match(site, /reply\.ok && reply\.bridgeEnabled/, 'and a refusal renders no chip');
+  // The render path must have exactly one way to put a chip on the page, and
+  // it must sit after the guards — no placeholder balance on any other route.
+  const render = site.slice(site.indexOf('function render('), site.indexOf('// The relay only'));
+  const appends = render.match(/slot\.appendChild/g) || [];
+  assert.equal(appends.length, 1, 'one and only one way to render a balance');
+  assert.ok(render.indexOf('if (!wallet) return;') < render.indexOf('slot.appendChild'),
+    'the guards must come before anything is appended');
+});
+
+test('the chip always labels the money as paper', () => {
+  const site = fs.readFileSync(path.join(__dirname, '..', '..', 'site', 'nav-wallet.js'), 'utf8');
+  assert.match(site, /nav-wallet-tag">PAPER</,
+    'this number shares a bar with a leaderboard and a sign-in — it must never read as real');
+});

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -87,6 +87,8 @@ for page in site/*.html; do
   grep -q 'class="nav-links"' "$page" || continue
   grep -q 'id="nav-profile"' "$page" || PROFILE_MISSING="$PROFILE_MISSING $(basename "$page"):slot"
   grep -q 'nav-profile.js' "$page"    || PROFILE_MISSING="$PROFILE_MISSING $(basename "$page"):script"
+  grep -q 'id="nav-wallet"' "$page"  || PROFILE_MISSING="$PROFILE_MISSING $(basename "$page"):wallet-slot"
+  grep -q 'nav-wallet.js' "$page"     || PROFILE_MISSING="$PROFILE_MISSING $(basename "$page"):wallet-script"
 done
 [ -z "$PROFILE_MISSING" ] || fail "pages missing the header profile control —$PROFILE_MISSING"
 echo "profile control OK (slot + script on every page)"

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -79,6 +79,18 @@ done
 [ -z "$A11Y_MISSING" ] || fail "pages missing accessibility landmarks —$A11Y_MISSING"
 echo "a11y OK (skip link, main landmark and named nav on $(grep -lc 'class="skip-link"' site/*.html | wc -l) pages)"
 
+# The profile control is on every page or it is on none: a header that shows
+# who you are on the leaderboard and not on a news article reads as a bug in
+# the sign-in, not as a missing include.
+PROFILE_MISSING=""
+for page in site/*.html; do
+  grep -q 'class="nav-links"' "$page" || continue
+  grep -q 'id="nav-profile"' "$page" || PROFILE_MISSING="$PROFILE_MISSING $(basename "$page"):slot"
+  grep -q 'nav-profile.js' "$page"    || PROFILE_MISSING="$PROFILE_MISSING $(basename "$page"):script"
+done
+[ -z "$PROFILE_MISSING" ] || fail "pages missing the header profile control —$PROFILE_MISSING"
+echo "profile control OK (slot + script on every page)"
+
 # Every public page must be in sitemap.xml, or deliberately named as excluded.
 #
 # A sitemap is the one file that rots without any symptom: pages get added, the

--- a/site/404.html
+++ b/site/404.html
@@ -67,6 +67,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -130,6 +131,7 @@
     if (path && path !== '/') document.getElementById('badPath').textContent = path;
   })();
 </script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/404.html
+++ b/site/404.html
@@ -67,6 +67,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -129,5 +130,6 @@
     if (path && path !== '/') document.getElementById('badPath').textContent = path;
   })();
 </script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/admin.html
+++ b/site/admin.html
@@ -103,6 +103,7 @@
       <a href="/clans">Clans</a>
       <a href="/streamer-signup">Streamer signup</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -182,5 +183,6 @@
 </footer>
 
 <script src="admin.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/admin.html
+++ b/site/admin.html
@@ -103,6 +103,7 @@
       <a href="/clans">Clans</a>
       <a href="/streamer-signup">Streamer signup</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -183,6 +184,7 @@
 </footer>
 
 <script src="admin.js"></script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/clan.html
+++ b/site/clan.html
@@ -32,6 +32,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -502,6 +503,7 @@
   })();
 })();
 </script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/clan.html
+++ b/site/clan.html
@@ -32,6 +32,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -501,5 +502,6 @@
   })();
 })();
 </script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/clans.html
+++ b/site/clans.html
@@ -32,6 +32,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -535,6 +536,7 @@
   })();
 })();
 </script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/clans.html
+++ b/site/clans.html
@@ -32,6 +32,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -534,5 +535,6 @@
   })();
 })();
 </script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/duel.html
+++ b/site/duel.html
@@ -323,6 +323,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -1352,6 +1353,7 @@
   })();
 })();
 </script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/duel.html
+++ b/site/duel.html
@@ -323,6 +323,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -1351,5 +1352,6 @@
   })();
 })();
 </script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/duels.html
+++ b/site/duels.html
@@ -474,6 +474,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -1421,5 +1422,6 @@
   loadDuels();
 })();
 </script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/duels.html
+++ b/site/duels.html
@@ -474,6 +474,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -1422,6 +1423,7 @@
   loadDuels();
 })();
 </script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -33,6 +33,7 @@
       <a href="/news">News</a>
       <a href="#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -530,5 +531,6 @@
   })();
 })();
 </script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -33,6 +33,7 @@
       <a href="/news">News</a>
       <a href="#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -531,6 +532,7 @@
   })();
 })();
 </script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/leaderboard.html
+++ b/site/leaderboard.html
@@ -32,6 +32,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -552,5 +553,6 @@
   });
 })();
 </script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/leaderboard.html
+++ b/site/leaderboard.html
@@ -32,6 +32,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -553,6 +554,7 @@
   });
 })();
 </script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/nav-profile.js
+++ b/site/nav-profile.js
@@ -1,0 +1,84 @@
+/* The profile control in the site header.
+ *
+ * Every page carries it, but only eight of the twenty-seven load arena.js, so
+ * this is deliberately standalone — no shared module, no build step, and it
+ * must never throw into a page that is otherwise static.
+ *
+ * Signed out it is a sign-in link; signed in it is the user's avatar and handle
+ * pointing at their own profile. Both are one element in the same slot, so the
+ * nav does not reflow when the answer arrives.
+ */
+(() => {
+  'use strict';
+
+  // Same origin and session transport as arena.js. See the comments there on
+  // why the API is cross-site and why the token rides in localStorage as well
+  // as a cookie.
+  const API = 'https://papertrench-api.onerobby.workers.dev';
+  const TOKEN_KEY = 'pt_session_token';
+  const CACHE_KEY = 'pt_nav_identity';
+
+  const slot = document.getElementById('nav-profile');
+  if (!slot) return;
+
+  const esc = (s) => String(s == null ? '' : s).replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ));
+
+  /** Only an https image we serve or X serves may be used as an avatar. */
+  function safeAvatar(url) {
+    try {
+      const u = new URL(String(url));
+      return u.protocol === 'https:' ? u.toString() : null;
+    } catch { return null; }
+  }
+
+  function renderSignedOut() {
+    slot.innerHTML = `<a class="nav-profile signin" href="${API}/api/auth/x/start">Sign in</a>`;
+  }
+
+  function renderSignedIn(me) {
+    const handle = String(me.handle || '').replace(/[^A-Za-z0-9_]/g, '');
+    if (!handle) { renderSignedOut(); return; }
+    const avatar = safeAvatar(me.avatarUrl);
+    slot.innerHTML = `
+      <a class="nav-profile" href="/profile?handle=${encodeURIComponent(handle)}" title="Your PaperTrench profile">
+        ${avatar
+          ? `<img src="${esc(avatar)}" alt="" width="22" height="22" loading="lazy">`
+          : '<span class="nav-profile-dot" aria-hidden="true"></span>'}
+        <span class="nav-profile-handle">@${esc(handle)}</span>
+      </a>`;
+  }
+
+  // Paint from the last known answer first. The nav is above the fold on every
+  // page, and a control that appears a beat late reads as the page still
+  // loading — worse, one that flips from "Sign in" to a handle looks like it
+  // signed you in on arrival.
+  let cached = null;
+  try { cached = JSON.parse(localStorage.getItem(CACHE_KEY) || 'null'); } catch (_) {}
+  if (cached && cached.handle) renderSignedIn(cached); else renderSignedOut();
+
+  (async () => {
+    let me = null;
+    try {
+      const token = localStorage.getItem(TOKEN_KEY);
+      const res = await fetch(API + '/api/me', {
+        credentials: 'include',
+        headers: token ? { Authorization: 'Bearer ' + token } : {},
+      });
+      if (!res.ok) return;              // transient: keep whatever is on screen
+      me = await res.json();
+    } catch (_) {
+      return; // offline or blocked — the cached control stays, and it is honest
+    }
+
+    if (me && me.signedIn) {
+      renderSignedIn(me);
+      try { localStorage.setItem(CACHE_KEY, JSON.stringify({ handle: me.handle, avatarUrl: me.avatarUrl })); } catch (_) {}
+    } else {
+      // A definite signed-out answer is the one thing that may clear the cache.
+      renderSignedOut();
+      try { localStorage.removeItem(CACHE_KEY); } catch (_) {}
+    }
+  })();
+})();

--- a/site/nav-wallet.js
+++ b/site/nav-wallet.js
@@ -1,0 +1,73 @@
+/* The paper-balance chip in the site header.
+ *
+ * The website cannot know your paper wallet on its own — it lives in the
+ * extension, on your machine. It is asked for over the same bridge the
+ * leaderboard Sync uses, which answers only when Site sync is switched on.
+ *
+ * So the chip is absent for most visitors, and that is correct: no extension,
+ * or sync off, means the site genuinely does not know, and inventing a
+ * balance would be the one thing this project refuses to do.
+ */
+(() => {
+  'use strict';
+
+  const slot = document.getElementById('nav-wallet');
+  if (!slot) return;
+
+  const NONCE = 'ptw-' + Math.random().toString(36).slice(2);
+  const TIMEOUT_MS = 1500;
+
+  function fmt(sol) {
+    const n = Number(sol) || 0;
+    if (n >= 1000) return n.toLocaleString(undefined, { maximumFractionDigits: 0 });
+    if (n >= 100) return n.toFixed(1);
+    return n.toFixed(2).replace(/\.00$/, '');
+  }
+
+  function render(wallet) {
+    if (!wallet) return;                       // no answer: show nothing at all
+    const equity = Number(wallet.equitySol);
+    if (!Number.isFinite(equity)) return;
+
+    const chip = document.createElement('span');
+    chip.className = 'nav-wallet';
+    // "Paper" is not decoration. This number sits in the same bar as a
+    // leaderboard and a sign-in, and must never be mistaken for real money.
+    chip.innerHTML = '<span class="nav-wallet-tag">PAPER</span>'
+      + '<span class="nav-wallet-num"></span>';
+    chip.querySelector('.nav-wallet-num').textContent = fmt(equity) + ' SOL';
+    chip.title = wallet.openPositions
+      ? `${fmt(wallet.cashSol)} SOL cash · ${wallet.openPositions} open position`
+        + `${wallet.openPositions === 1 ? '' : 's'}`
+        + (wallet.marked ? '' : ' · some positions have no recent price, so this is partial')
+      : 'Your paper wallet, read from the extension on this machine.';
+    slot.appendChild(chip);
+  }
+
+  // The relay only answers a page on its own origin, and only for the two
+  // request types it allow-lists. Ping is the cheap one; the wallet rides on it.
+  let done = false;
+  const onReply = (event) => {
+    if (event.source !== window || event.origin !== location.origin) return;
+    const data = event.data;
+    if (!data || data.type !== 'pt_site_bridge_reply' || data.nonce !== NONCE) return;
+    window.removeEventListener('message', onReply);
+    if (done) return;
+    done = true;
+    const reply = data.reply;
+    if (reply && reply.ok && reply.bridgeEnabled) render(reply.wallet);
+  };
+  window.addEventListener('message', onReply);
+
+  window.postMessage(
+    { type: 'pt_site_bridge', nonce: NONCE, request: { type: 'pt_bridge_ping' } },
+    location.origin
+  );
+
+  // No extension, or it never answered. Nothing to say, so nothing is said.
+  setTimeout(() => {
+    if (done) return;
+    done = true;
+    window.removeEventListener('message', onReply);
+  }, TIMEOUT_MS);
+})();

--- a/site/news-chain.html
+++ b/site/news-chain.html
@@ -59,6 +59,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -242,5 +243,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-chain.html
+++ b/site/news-chain.html
@@ -59,6 +59,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -243,6 +244,7 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-fees.html
+++ b/site/news-fees.html
@@ -47,6 +47,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -197,6 +198,7 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-fees.html
+++ b/site/news-fees.html
@@ -47,6 +47,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -196,5 +197,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-fills.html
+++ b/site/news-fills.html
@@ -64,6 +64,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -249,6 +250,7 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-fills.html
+++ b/site/news-fills.html
@@ -64,6 +64,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -248,5 +249,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-flex.html
+++ b/site/news-flex.html
@@ -73,6 +73,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -323,6 +324,7 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-flex.html
+++ b/site/news-flex.html
@@ -73,6 +73,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -322,5 +323,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-instant-x.html
+++ b/site/news-instant-x.html
@@ -54,6 +54,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -294,5 +295,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-instant-x.html
+++ b/site/news-instant-x.html
@@ -54,6 +54,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -295,6 +296,7 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-perps.html
+++ b/site/news-perps.html
@@ -41,6 +41,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -159,6 +160,7 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-perps.html
+++ b/site/news-perps.html
@@ -41,6 +41,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -158,5 +159,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-quickedit.html
+++ b/site/news-quickedit.html
@@ -58,6 +58,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -220,6 +221,7 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-quickedit.html
+++ b/site/news-quickedit.html
@@ -58,6 +58,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -219,5 +220,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-rugguard.html
+++ b/site/news-rugguard.html
@@ -58,6 +58,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -254,6 +255,7 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-rugguard.html
+++ b/site/news-rugguard.html
@@ -58,6 +58,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -253,5 +254,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-the-after.html
+++ b/site/news-the-after.html
@@ -54,6 +54,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -254,5 +255,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-the-after.html
+++ b/site/news-the-after.html
@@ -54,6 +54,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -255,6 +256,7 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-trench-rank.html
+++ b/site/news-trench-rank.html
@@ -50,6 +50,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -137,5 +138,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-trench-rank.html
+++ b/site/news-trench-rank.html
@@ -50,6 +50,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -138,6 +139,7 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-turbo.html
+++ b/site/news-turbo.html
@@ -61,6 +61,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -296,6 +297,7 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-turbo.html
+++ b/site/news-turbo.html
@@ -61,6 +61,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -295,5 +296,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-v2.html
+++ b/site/news-v2.html
@@ -47,6 +47,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -245,5 +246,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-v2.html
+++ b/site/news-v2.html
@@ -47,6 +47,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -246,6 +247,7 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-xray.html
+++ b/site/news-xray.html
@@ -68,6 +68,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -356,5 +357,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news-xray.html
+++ b/site/news-xray.html
@@ -68,6 +68,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -357,6 +358,7 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news.html
+++ b/site/news.html
@@ -44,6 +44,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -292,6 +293,7 @@
 
 <script src="news.js"></script>
 <script src="reveal.js"></script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/news.html
+++ b/site/news.html
@@ -44,6 +44,7 @@
       <a href="/news" aria-current="page">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -291,5 +292,6 @@
 
 <script src="news.js"></script>
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -29,6 +29,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -119,5 +120,6 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -29,6 +29,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -120,6 +121,7 @@
 </footer>
 
 <script src="reveal.js"></script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/profile.html
+++ b/site/profile.html
@@ -374,6 +374,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -1503,5 +1504,6 @@
   })();
 })();
 </script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/profile.html
+++ b/site/profile.html
@@ -374,6 +374,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -1504,6 +1505,7 @@
   })();
 })();
 </script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/sprint.html
+++ b/site/sprint.html
@@ -153,6 +153,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -620,5 +621,6 @@
   })();
 })();
 </script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/sprint.html
+++ b/site/sprint.html
@@ -153,6 +153,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -621,6 +622,7 @@
   })();
 })();
 </script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/streamer-signup.html
+++ b/site/streamer-signup.html
@@ -92,6 +92,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -245,6 +246,7 @@
 </footer>
 
 <script src="streamer-signup.js"></script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/streamer-signup.html
+++ b/site/streamer-signup.html
@@ -92,6 +92,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -244,5 +245,6 @@
 </footer>
 
 <script src="streamer-signup.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/streams.html
+++ b/site/streams.html
@@ -153,6 +153,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch" aria-current="page"><span class="dot"></span>Watch Live</a>
+      <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
   </div>
@@ -280,5 +281,6 @@
 </footer>
 
 <script src="streams.js"></script>
+<script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/streams.html
+++ b/site/streams.html
@@ -153,6 +153,7 @@
       <a href="/news">News</a>
       <a href="/#install">Install</a>
       <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch" aria-current="page"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
       <span id="nav-profile"></span>
       <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
     </div>
@@ -281,6 +282,7 @@
 </footer>
 
 <script src="streams.js"></script>
+<script src="/nav-wallet.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/style.css
+++ b/site/style.css
@@ -112,6 +112,30 @@ nav {
   box-shadow: 0 0 0 rgba(255,157,69,0);
 }
 .nav-cta:hover { transform: translateY(-1px); box-shadow: 0 6px 24px rgba(255,157,69,0.35); }
+/* Profile control — the one nav item whose content depends on who is looking.
+   Sized like the pills beside it so the bar does not reflow when the answer
+   arrives, and painted from cache first for the same reason. */
+.nav-profile {
+  display: inline-flex; align-items: center; gap: 7px;
+  margin-left: 8px; padding: 6px 13px 6px 7px; border-radius: 999px;
+  font-size: 13px; font-weight: 700; white-space: nowrap;
+  color: var(--text); background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--line2);
+  transition: background .2s, border-color .2s;
+}
+.nav-profile:hover { background: rgba(255, 255, 255, 0.1); border-color: rgba(255, 157, 69, 0.4); }
+.nav-profile img { width: 22px; height: 22px; border-radius: 50%; flex: none; }
+.nav-profile-dot {
+  width: 22px; height: 22px; border-radius: 50%; flex: none;
+  background: linear-gradient(140deg, var(--orange2), var(--orange-deep));
+}
+.nav-profile.signin { padding: 8px 15px; color: var(--muted); font-weight: 650; }
+.nav-profile.signin:hover { color: var(--text); }
+/* The handle is the first thing to go when the bar runs out of room — the
+   avatar alone still says "signed in, this is you". */
+@media (max-width: 1010px) { .nav-profile-handle { display: none; } }
+@media (max-width: 470px) { .nav-profile { padding: 5px; margin-left: 4px; } }
+
 
 /* The "Watch Live" pill: a real call-to-action, not a text link — it has to
    read as "click here to watch streams" at a glance, and it survives mobile

--- a/site/style.css
+++ b/site/style.css
@@ -131,6 +131,26 @@ nav {
 }
 .nav-profile.signin { padding: 8px 15px; color: var(--muted); font-weight: 650; }
 .nav-profile.signin:hover { color: var(--text); }
+/* Paper balance, read from the extension over the site bridge.
+   Absent unless the extension is installed AND Site sync is on — the site
+   cannot know this number otherwise, and would not invent one. */
+.nav-wallet {
+  display: inline-flex; align-items: center; gap: 6px;
+  margin-left: 8px; padding: 5px 11px 5px 6px; border-radius: 999px;
+  background: rgba(255, 157, 69, 0.09);
+  border: 1px solid rgba(255, 157, 69, 0.28);
+  white-space: nowrap;
+}
+.nav-wallet-tag {
+  font-size: 8.5px; font-weight: 800; letter-spacing: 0.9px;
+  color: #2a1400; background: var(--orange2);
+  padding: 2px 5px; border-radius: 999px;
+}
+.nav-wallet-num { font-size: 12.5px; font-weight: 750; color: var(--orange2); font-variant-numeric: tabular-nums; }
+/* The number goes before the handle does — on a narrow bar the PAPER tag
+   alone still says the wallet is connected. */
+@media (max-width: 1010px) { .nav-wallet-num { display: none; } }
+@media (max-width: 640px) { .nav-wallet { display: none; } }
 /* The handle is the first thing to go when the bar runs out of room — the
    avatar alone still says "signed in, this is you". */
 @media (max-width: 1010px) { .nav-profile-handle { display: none; } }


### PR DESCRIPTION
> **Stacked on #51** — it uses the header slot from there.

> *"is it possible to add a small area where it shows how much paper money you have on the website UI"*

The website **cannot know this on its own** — the wallet lives in the extension, on your machine. It''s asked for over the same bridge the leaderboard Sync already uses.

## Carried on the existing ping

No new message type and no new relay entry. `site-bridge.js` allow-lists exactly two request types, and `pt_bridge_ping` is already the cheap one the site sends to detect the extension.

The wallet rides on its reply — and **only when Site sync is on**, the same consent gate the record sits behind. With it off, the ping is exactly what it was: a yes/no about the extension existing.

## Cheap on purpose

`bridgeWallet` does **no chain replay and no price fetch**. `bridgeRecord` exists to hand over evidence and verifies everything; opening papertrench.com must not pay that for a header chip.

Equity marks open bags at the last price the extension itself observed — the same figure the popup and positions bar already show, so **the site cannot disagree with the app about the user''s own balance**.

A bag with no mark contributes **nothing** rather than a guess, and the reply carries `marked` so a partial total can say so instead of being presented as complete.

## Absent for most visitors, and that''s correct

No extension, or sync off, means the site genuinely doesn''t know. It renders **no chip at all** — not a zero, not a placeholder. A made-up balance is the one thing this project refuses to print.

Tests pin that there''s exactly **one** code path that can put a number on the page, and that every guard precedes it. (My first version of that test was junk — it grepped for an em dash and matched my own header comment. Rewritten to check the render path.)

The chip always carries a **PAPER** tag. This number sits in the same bar as a leaderboard and a sign-in; it must never be mistaken for real money.

```
extension  1772/1772
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
