### PR TITLE
feat(dashboard): onboarding asks one question at a time, centred

### DIFF
--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -664,6 +664,43 @@
     .lb-progress-label { margin-left: 6px; font-size: 11.5px; font-weight: 650; color: var(--dim); }
 
     .lb-steps { list-style: none; margin: 0; padding: 0; display: grid; gap: 12px; }
+    /* ---------- onboarding: one centred question ----------
+       The list showed all three steps at once, two of which the reader could
+       not act on yet — a step you cannot do is a step you have to read past. */
+    .lb-onboard { max-width: 520px; margin: 40px auto 0; text-align: center; }
+    .lb-onboard-card {
+      padding: 34px 32px 30px;
+      background: linear-gradient(160deg, rgba(255,255,255,0.05), rgba(255,255,255,0.014));
+      border: 1px solid var(--line-2); border-radius: var(--r-xl);
+      box-shadow: var(--shadow-lg);
+    }
+    .lb-onboard .lb-progress { justify-content: center; margin: 0 0 14px; }
+    .lb-onboard .lb-pip.now { background: rgba(255,157,69,0.45); }
+    .lb-onboard-count {
+      font-size: 10px; font-weight: 800; letter-spacing: 1.4px;
+      text-transform: uppercase; color: var(--faint);
+    }
+    .lb-onboard-q { margin: 10px 0 0; font-size: 23px; font-weight: 800; letter-spacing: -0.4px; }
+    .lb-onboard-why {
+      margin: 10px auto 0; max-width: 420px;
+      font-size: 13.5px; line-height: 1.65; color: var(--dim);
+    }
+    /* The action is the only thing here that is not prose, so it gets the
+       whitespace that makes it read as the thing to do. */
+    .lb-onboard-do { margin-top: 22px; text-align: left; }
+    .lb-onboard-do > .btn { display: block; text-align: center; }
+    .lb-onboard-do .field { text-align: left; }
+    .lb-onboard-do p.dim { text-align: center; }
+
+    .lb-onboard-done {
+      list-style: none; margin: 22px 0 0; padding: 16px 0 0;
+      border-top: 1px solid var(--line);
+      display: flex; flex-direction: column; gap: 5px;
+      font-size: 12px; color: var(--green);
+    }
+    .lb-onboard-more { margin-top: 20px; text-align: left; }
+    .lb-onboard-more summary { cursor: pointer; font-size: 12.5px; color: var(--dim); }
+    .lb-onboard-more ul { margin: 10px 0 0; padding-left: 18px; color: var(--dim); font-size: 12.5px; line-height: 1.65; }
     .lb-step {
       display: flex; gap: 14px; padding: 16px 18px;
       background: linear-gradient(155deg, rgba(255,255,255,0.042), rgba(255,255,255,0.012));

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -3544,7 +3544,7 @@ function renderLbWizard(el, steps, identity, chainLen) {
 
   const action = (step, i) => {
     if (step.done) return '';
-    if (i !== current) return '<p class="lb-step-wait dim">Finish the step above first.</p>';
+    if (i !== current) return '';   // only the current step is ever rendered
     if (step.id === 'link') {
       return `
         <a class="btn" href="https://papertrench.com/leaderboard" target="_blank" rel="noopener"
@@ -3573,35 +3573,32 @@ function renderLbWizard(el, steps, identity, chainLen) {
       </div>`;
   };
 
+  const step = steps[current];
+
+  // One question, centred, with the finished ones behind it as pips. The
+  // list form showed all three at once: two of them were things the reader
+  // could not act on yet, and a step they cannot do is a step they have to
+  // read past. Requested as "center the questions one by one".
   el.innerHTML = `
-    <div class="card lb-intro">
-      <h3>Get on the leaderboard</h3>
-      <p class="dim" style="font-size:13px;line-height:1.6;margin:6px 0 0">
-        Three steps, once. The board ranks a hash-chained record of real fills, so
-        it needs an identity to rank, a chain to read, and your permission to read it.
-      </p>
-      <div class="lb-progress" role="img" aria-label="${doneCount} of ${steps.length} steps complete">
-        ${steps.map((s) => `<span class="lb-pip ${s.done ? 'on' : ''}"></span>`).join('')}
-        <span class="lb-progress-label">${doneCount} of ${steps.length} done</span>
+    <div class="lb-onboard">
+      <div class="lb-onboard-card">
+        <div class="lb-progress" role="img" aria-label="Step ${current + 1} of ${steps.length}">
+          ${steps.map((x, i) => `<span class="lb-pip ${x.done ? 'on' : i === current ? 'now' : ''}"></span>`).join('')}
+        </div>
+        <div class="lb-onboard-count">Step ${current + 1} of ${steps.length}</div>
+
+        <h2 class="lb-onboard-q">${esc(step.title)}</h2>
+        <p class="lb-onboard-why">${esc(step.blurb)}</p>
+
+        <div class="lb-onboard-do">${action(step, current)}</div>
+
+        ${doneCount ? `<ul class="lb-onboard-done">${steps.filter((x) => x.done).map((x) =>
+          `<li>✓ ${esc(x.title)}${x.id === 'link' && identity ? ` — @${esc(identity.handle)}` : ''}</li>`).join('')}</ul>` : ''}
       </div>
-    </div>
 
-    <ol class="lb-steps">
-      ${steps.map((s, i) => `
-        <li class="lb-step ${s.done ? 'done' : i === current ? 'now' : 'later'}">
-          <div class="lb-step-n">${s.done ? '✓' : i + 1}</div>
-          <div class="lb-step-body">
-            <h4>${esc(s.title)}${s.done && s.id === 'link' && identity ? ` <span class="dim" style="font-weight:600">— @${esc(identity.handle)}</span>` : ''}</h4>
-            <p class="dim">${esc(s.blurb)}</p>
-            ${action(s, i)}
-          </div>
-        </li>`).join('')}
-    </ol>
-
-    <div class="card" style="margin-top:16px">
-      <details>
+      <details class="lb-onboard-more">
         <summary>What the board does with it</summary>
-        <ul style="margin:8px 0 0;padding-left:18px;color:var(--dim);font-size:12.5px;line-height:1.65">
+        <ul>
           <li>Standings are recomputed server-side from the chain, never from a number this app reports.</li>
           <li>Every fill is hashed when made, before the outcome is known, so a winning entry cannot be backdated.</li>
           <li>Results compare return on your declared bankroll, not absolute SOL — a bigger starting balance buys no rank.</li>
@@ -3610,7 +3607,6 @@ function renderLbWizard(el, steps, identity, chainLen) {
       </details>
     </div>`;
 }
-
 function renderLeaderboard(el) {
   const chain = attestChain; // F-14: loaded from the segmented store
   const stats = E.sessionStats(state, settings);

--- a/extension/test/u7-brand-ux.test.js
+++ b/extension/test/u7-brand-ux.test.js
@@ -230,3 +230,28 @@ test('every icon in the repo still matches brand/logo.png', () => {
     { cwd: REPO, encoding: 'utf8' });
   assert.match(out, /all icons match the master/);
 });
+
+test('onboarding shows one step at a time, and it is the current one', () => {
+  // The list form rendered all three, two of which could not be acted on.
+  const wizard = fnBlock(dashJs, 'function renderLbWizard(');
+  assert.match(wizard, /const step = steps\[current\];/,
+    'exactly one step is selected for rendering');
+  assert.ok(!/steps\.map\(\(s, i\) =>/.test(wizard),
+    'the every-step list must be gone, or two of them are unreachable furniture');
+  // The finished ones survive as a summary, so progress is still visible.
+  assert.match(wizard, /steps\.filter\(\(x\) => x\.done\)/,
+    'completed steps are still shown, as a recap rather than as steps');
+});
+
+test('the step count and the pips agree with the step being shown', () => {
+  const wizard = fnBlock(dashJs, 'function renderLbWizard(');
+  assert.match(wizard, /Step \$\{current \+ 1\} of \$\{steps\.length\}/,
+    'the counter is derived from the same index that picked the step');
+  assert.match(wizard, /i === current \? 'now'/,
+    'and the pips mark that same index as current');
+});
+
+test('the onboarding card is centred', () => {
+  assert.match(dashHtml, /\.lb-onboard \{[^}]*margin: 40px auto 0;[^}]*text-align: center;/,
+    'the request was specifically that the questions be centred');
+});


### PR DESCRIPTION
> *"i love the onboarding just center the questions one by one"*

The list rendered **all three steps at once**. Two of them were always things the reader couldn''t act on yet — and a step you can''t do is a step you have to read past to find the one you can. The *"Finish the step above first"* line existed only to apologise for showing them; it''s gone with them.

Now: **one card, centred**, holding the current question, why it exists, and the single control that answers it. Finished steps stay as a short recap underneath, so progress is still visible without competing with the thing to do.

Pips and the *"Step 2 of 3"* counter both derive from **the same index that selected the step**, so they can''t disagree with what''s on screen.

Nothing about the gate changed — same three conditions, same order, and the full tab still opens only when all three are met.

## Tests

Three, mutation-checked: pinning the current step to `steps[0]` turns the first one red.

The one that matters asserts the every-step `map` is **gone**, not merely unused. Leaving it in place would quietly reintroduce the two unreachable steps the moment someone edited the markup.

```
extension  1770/1770
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
