### PR TITLE
feat(dashboard): the leaderboard tab leads with the board

### DIFF
--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -689,6 +689,45 @@
     .lb-step.done .lb-step-body > p.dim, .lb-step.later .lb-step-body > p.dim { margin-bottom: 0; }
     .lb-step-wait { margin: 0; font-size: 12px; font-style: italic; }
 
+    /* ---------- leaderboard hero + folds ----------
+       The tab used to open on two dense cards of chain vocabulary before the
+       reader reached a single standing. The hero answers "how am I doing" in
+       one row; the evidence that backs it is one disclosure away. */
+    .lb-hero {
+      display: flex; align-items: center; gap: 18px; flex-wrap: wrap;
+      padding: 18px 20px;
+      background: linear-gradient(150deg, rgba(255,255,255,0.05), rgba(255,255,255,0.014));
+      border: 1px solid var(--line-2); border-radius: var(--r-xl);
+      box-shadow: var(--shadow-md);
+    }
+    .lb-hero-me { display: flex; align-items: center; gap: 8px; min-width: 0; }
+    .lb-hero-handle { font-size: 15px; font-weight: 800; letter-spacing: -0.2px; }
+    .lb-hero-roi {
+      margin-left: auto; text-align: right;
+      font-size: 26px; font-weight: 800; letter-spacing: -0.8px; line-height: 1.05;
+    }
+    .lb-hero-roi-lab {
+      display: block; margin-top: 2px;
+      font-size: 9.5px; font-weight: 700; letter-spacing: 1.1px;
+      text-transform: uppercase; color: var(--faint);
+    }
+    /* The verify chip drops to its own line rather than squeezing the ROI. */
+    .lb-hero-verify { flex: 1 0 100%; margin: 0; }
+
+    .lb-fold {
+      background: linear-gradient(155deg, rgba(255,255,255,0.03), rgba(255,255,255,0.008));
+      border: 1px solid var(--line); border-radius: var(--r-lg);
+    }
+    .lb-fold > summary {
+      cursor: pointer; padding: 13px 18px; list-style: none;
+      font-size: 12px; font-weight: 750; letter-spacing: 0.9px;
+      text-transform: uppercase; color: var(--dim);
+    }
+    .lb-fold > summary::-webkit-details-marker { display: none; }
+    .lb-fold > summary::after { content: " ▾"; color: var(--faint); }
+    .lb-fold[open] > summary::after { content: " ▴"; }
+    .lb-fold > summary:hover { color: var(--text); }
+    .lb-fold-body { padding: 0 18px 16px; }
     /* ---------- Live board ---------- */
     .lb-live-head { display: flex; align-items: center; gap: 12px; margin-bottom: 4px; }
     .lb-live-head .btn-sec { margin-left: auto; }

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -3626,59 +3626,22 @@ function renderLeaderboard(el) {
   const steps = lbSteps(identity, chain.length);
   if (!lbReady(steps)) return renderLbWizard(el, steps, identity, chain.length);
 
+  // The board leads. Everything that explains the board is one disclosure
+  // away — this tab used to open on two dense cards of chain vocabulary
+  // (committed fills, derived P&L, a full SHA-256 head) before the reader
+  // reached a single standing. Reported as too much text, and dated beside
+  // the newer surfaces.
+  const roiUp = roiPct >= 0;
   el.innerHTML = `
-    <div class="grid2">
-      <div class="card">
-        <h3>Verified record</h3>
-        <div id="lb-verify" class="${verify.cls}">${verify.html}</div>
-        <div class="stat" style="margin-top:14px"><span>Committed fills</span><span style="font-weight:750">${chain.length}</span></div>
-        <div class="stat"><span>Claimed realized P&amp;L</span><span class="${stats.realizedPnlSol >= 0 ? 'green' : 'red'}" style="font-weight:750">${stats.realizedPnlSol >= 0 ? '+' : ''}${fmt(stats.realizedPnlSol, 3)} SOL · ${roiPct >= 0 ? '+' : ''}${roiPct.toFixed(1)}% ROI</span></div>
-        <div class="stat"><span>Declared starting bankroll</span><span style="font-weight:750">${fmt(settings.balanceStartSol, 2)} SOL</span></div>
-        <div class="stat" id="lb-derived"><span>Derived from chain</span>${verify.derivedHtml}</div>
-        <h4>Chain head</h4>
-        <div class="lb-proof" id="lb-head">${chain.length
-          ? esc(chain[chain.length - 1].hash)
-          : '<span class="dim">Not started — your first paper fill anchors the chain.</span>'}</div>
+    <div class="lb-hero">
+      <div class="lb-hero-me">
+        <span class="lb-hero-handle">@${esc(identity.handle)}</span>
+        <span class="lb-x ${identity.verified ? 'verified' : ''}">${identity.verified ? 'verified' : 'not verified yet'}</span>
       </div>
-
-      <div class="card">
-        <h3>Identity</h3>
-        ${identity ? `
-          <div class="stat"><span>Linked account</span><span style="font-weight:750">@${esc(identity.handle)}
-            <span class="lb-x ${identity.verified ? 'verified' : ''}">${identity.verified ? 'verified' : 'not verified yet'}</span></span></div>
-          <div class="stat"><span>Linked at</span><span class="dim">${formatDateTime(identity.linkedAt)}</span></div>
-          ${identity.verified ? '' : `
-          <p class="dim" style="font-size:12px;line-height:1.55;margin:12px 0 0">
-            Verification happens on papertrench.com, not here: sign in with X there and
-            this chip goes green on its own — the signed-in page hands your handle to
-            the extension, which is the one direction that keeps the extension from
-            ever phoning a server. The board still goes by the site's word, not this
-            chip.
-          </p>
-          <a class="btn" href="https://papertrench.com/leaderboard" target="_blank" rel="noopener"
-             style="margin-top:10px;display:inline-block">Sign in on papertrench.com →</a>
-          `}
-          <p class="dim" style="font-size:12px;line-height:1.55;margin:12px 0 0">
-            Ranking is bound to this account, so competing under many identities costs
-            a real, publicly visible X account each time.
-          </p>
-          <button class="btn-sec" id="lb-unlink" style="margin-top:12px">Unlink</button>
-        ` : `
-          <p class="dim" style="font-size:12.5px;line-height:1.6;margin-top:0">
-            Link your X account to appear on the leaderboard. The easy way: sign in with X
-            on <a href="https://papertrench.com/leaderboard" target="_blank" rel="noopener"
-            style="color:var(--orange2)">papertrench.com</a> and this links itself. Or type
-            the handle below — stored locally, submitted with your signed chain; a server
-            verifies ownership before ranking you either way.
-          </p>
-          <div class="field">
-            <label for="lb-handle">X handle</label>
-            <input id="lb-handle" type="text" placeholder="yourhandle" autocomplete="off">
-            <small>Without the @. Verification is completed by the leaderboard service.</small>
-          </div>
-          <button class="btn" id="lb-link">Link account</button>
-        `}
+      <div class="lb-hero-roi ${roiUp ? 'green' : 'red'}">${roiUp ? '+' : ''}${roiPct.toFixed(1)}%
+        <span class="lb-hero-roi-lab">return on bankroll</span>
       </div>
+      <div id="lb-verify" class="${verify.cls} lb-hero-verify">${verify.html}</div>
     </div>
 
     <div class="card" style="margin-top:16px">
@@ -3693,27 +3656,53 @@ function renderLeaderboard(el) {
     </div>
 
     <div class="card" style="margin-top:16px">
-      <h3>Standings</h3>
+      <h3>Your row</h3>
       <div id="lb-standings">
         ${renderStandingsPlaceholder(identity, stats)}
       </div>
     </div>
 
-    <div class="card" style="margin-top:16px">
-      <details>
-      <summary>How ranking is kept honest</summary>
-      <ul style="margin:8px 0 0;padding-left:18px;color:var(--dim);font-size:12.5px;line-height:1.65">
-        <li><strong>Ordering is provable.</strong> Each fill commits to the hash of the one before it, so a trade cannot be inserted, removed, or reordered afterwards.</li>
-        <li><strong>Entries are pre-committed.</strong> A fill is hashed when it is made, before the outcome is known, so a winning entry cannot be backdated.</li>
-        <li><strong>Prices are re-checkable.</strong> Every fill records mint, price and timestamp, so a verifier can re-fetch real price history and reject fills at prices that never existed.</li>
-        <li><strong>Identity costs something.</strong> One ranked record per verified X account.</li>
-        <li><strong>Bankroll travels with the record.</strong> Your declared starting balance is part of the committed data, so results are compared by return on bankroll — not by absolute SOL, which a bigger deposit would inflate for free.</li>
-        <li><strong>Stated plainly:</strong> this is evidence, not proof. Anyone can run modified code locally, so final standings must be recomputed server-side from the chain — never from the number this app displays.</li>
-      </ul>
-      </details>
-    </div>`;
-}
+    <details class="lb-fold" style="margin-top:16px">
+      <summary>The evidence behind your row</summary>
+      <div class="lb-fold-body">
+        <div class="stat"><span>Committed fills</span><span style="font-weight:750">${chain.length}</span></div>
+        <div class="stat"><span>Claimed realized P&amp;L</span><span class="${stats.realizedPnlSol >= 0 ? 'green' : 'red'}" style="font-weight:750">${stats.realizedPnlSol >= 0 ? '+' : ''}${fmt(stats.realizedPnlSol, 3)} SOL</span></div>
+        <div class="stat" id="lb-derived"><span>Derived from chain</span>${verify.derivedHtml}</div>
+        <div class="stat"><span>Declared starting bankroll</span><span style="font-weight:750">${fmt(settings.balanceStartSol, 2)} SOL</span></div>
+        <div class="stat"><span>Linked</span><span class="dim">${formatDateTime(identity.linkedAt)}</span></div>
+        <h4>Chain head</h4>
+        <div class="lb-proof" id="lb-head">${chain.length
+          ? esc(chain[chain.length - 1].hash)
+          : '<span class="dim">Not started — your first paper fill anchors the chain.</span>'}</div>
+        ${identity.verified ? '' : `
+        <p class="dim" style="font-size:12px;line-height:1.55;margin:12px 0 0">
+          Verification happens on papertrench.com, not here: sign in with X there and
+          this chip goes green on its own. The board goes by the site’s word, not this chip.
+        </p>
+        <a class="btn-sec" href="https://papertrench.com/leaderboard" target="_blank" rel="noopener"
+           style="margin-top:10px;display:inline-block;text-decoration:none">Sign in on papertrench.com →</a>`}
+        <p class="dim" style="font-size:12px;line-height:1.55;margin:12px 0 0">
+          Ranking is bound to this account, so competing under many identities costs a real,
+          publicly visible X account each time.
+        </p>
+        <button class="btn-sec" id="lb-unlink" style="margin-top:12px">Unlink @${esc(identity.handle)}</button>
+      </div>
+    </details>
 
+    <details class="lb-fold" style="margin-top:10px">
+      <summary>How ranking is kept honest</summary>
+      <div class="lb-fold-body">
+        <ul style="margin:0;padding-left:18px;color:var(--dim);font-size:12.5px;line-height:1.65">
+          <li><strong>Ordering is provable.</strong> Each fill commits to the hash of the one before it, so a trade cannot be inserted, removed, or reordered afterwards.</li>
+          <li><strong>Entries are pre-committed.</strong> A fill is hashed when it is made, before the outcome is known, so a winning entry cannot be backdated.</li>
+          <li><strong>Prices are re-checkable.</strong> Every fill records mint, price and timestamp, so a verifier can re-fetch real price history and reject fills at prices that never existed.</li>
+          <li><strong>Identity costs something.</strong> One ranked record per verified X account.</li>
+          <li><strong>Bankroll travels with the record.</strong> Your declared starting balance is part of the committed data, so results are compared by return on bankroll — not by absolute SOL.</li>
+          <li><strong>Stated plainly:</strong> this is evidence, not proof. Anyone can run modified code locally, so final standings must be recomputed server-side from the chain — never from the number this app displays.</li>
+        </ul>
+      </div>
+    </details>`;
+}
 function renderStandingsPlaceholder(identity, stats) {
   // Remote standings are never invented here: this card shows YOUR row and
   // the two hand-off paths to the board at papertrench.com. The extension

--- a/extension/test/u7-brand-ux.test.js
+++ b/extension/test/u7-brand-ux.test.js
@@ -230,3 +230,42 @@ test('every icon in the repo still matches brand/logo.png', () => {
     { cwd: REPO, encoding: 'utf8' });
   assert.match(out, /all icons match the master/);
 });
+
+/* ---------------- the tab once onboarding is done ---------------- */
+
+test('the board comes before the vocabulary that explains it', () => {
+  const render = fnBlock(dashJs, 'function renderLeaderboard(');
+  const board = render.indexOf('id="lb-live"');
+  const evidence = render.indexOf('The evidence behind your row');
+  assert.ok(board !== -1 && evidence !== -1, 'both sections must exist');
+  assert.ok(board < evidence, 'standings must render above the chain evidence');
+});
+
+test('the chain vocabulary is folded away, not deleted', () => {
+  const render = fnBlock(dashJs, 'function renderLeaderboard(');
+  // Density was the complaint; losing the evidence would be a different bug.
+  for (const kept of ['Committed fills', 'Derived from chain', 'Chain head', 'lb-head', 'lb-derived']) {
+    assert.ok(render.includes(kept), kept + ' must survive the redesign');
+  }
+  const foldAt = render.indexOf('<details class="lb-fold"');
+  assert.ok(foldAt !== -1 && foldAt < render.indexOf('Chain head'),
+    'and it must sit inside a collapsed disclosure');
+});
+
+test('the post-gate view no longer carries the never-linked branch', () => {
+  const render = fnBlock(dashJs, 'function renderLeaderboard(');
+  // Unreachable by construction: the gate cannot be passed without an
+  // identity, so a 'link your account' form here is dead markup that still
+  // has to be read past.
+  assert.ok(!render.includes('id="lb-handle"'),
+    'the link form belongs to onboarding, not to the finished tab');
+});
+
+test('the hero states the return without making the reader derive it', () => {
+  const render = fnBlock(dashJs, 'function renderLeaderboard(');
+  assert.match(render, /lb-hero-roi/, 'the headline number is the return on bankroll');
+  assert.match(render, /roiPct\.toFixed\(1\)/);
+  // D-06: that percentage denominates on the wallet's birth anchor.
+  assert.match(render, /E\.anchorStartSol\(state, settings\)/,
+    'and it must keep using the birth anchor, never the live setting');
+});


### PR DESCRIPTION
> Reported as **too much text** and **dated beside the newer surfaces**.

The tab opened on two dense cards — committed fills, claimed vs derived P&L, declared bankroll, and a full SHA-256 chain head — **before the reader reached a single standing**. All of that is evidence *for* the row, and none of it is the row.

## Now

1. **Hero strip** — who you are, and your return on bankroll, in one line
2. **The live board**, directly under it
3. **Your own row**
4. Chain evidence → collapsed disclosure
5. Honesty notes → collapsed disclosure

## Folded, not deleted

Density was the complaint; losing the evidence would be a different bug. A test asserts `Committed fills`, `Derived from chain`, `Chain head`, `lb-head` and `lb-derived` all survive — **inside** the disclosure.

## One piece is genuinely gone

The *"link your X account"* form. It''s **unreachable by construction** here — the gate can''t be passed without an identity — so it was dead markup that still had to be read past. It lives in onboarding, which is where it applies. `bindLeaderboard` already guards that binding, so nothing breaks.

## The one correctness trap in a redesign like this

The headline percentage keeps denominating on the wallet''s **birth anchor** (`E.anchorStartSol`), not `settings.balanceStartSol`.

Reaching for the live setting here would silently reintroduce **D-06** — where editing "Starting paper balance" retroactively rewrites a live wallet''s return. That''s pinned by a test alongside the layout ones, because it''s exactly the kind of thing a visual refactor loses without anyone noticing.

```
extension  1771/1771
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
