### PR TITLE
feat(overlay): the panel keeps its shape, held or not

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -3793,7 +3793,6 @@
     .pt-box.pt-micro .pt-header #pt-visibility,
     .pt-box.pt-micro .pt-header #pt-dash,
     .pt-box.pt-micro .pt-header #pt-min,
-    .pt-box.pt-micro #pt-buy-label,
     .pt-box.pt-micro #pt-costs,
     .pt-box.pt-micro #pt-custom,
     .pt-box.pt-micro .pt-buy,
@@ -4369,13 +4368,43 @@
       border-color: var(--pt-line); cursor: not-allowed;
     }
     /* Round ledger — what went in, what came back, what is still held. */
+    /* Micro keeps the balance. It hid #pt-buy-label with the rest of the buy
+       furniture, and that label is where cash on hand lives — so the smallest
+       panel was the one that never showed how much paper SOL you had, on any
+       site. Trimmed rather than dropped. */
+    .pt-box.pt-micro #pt-buy-label {
+      font-size: 9px; margin: 0 0 3px; letter-spacing: 0.4px;
+    }
+    /* Compact modes keep the ledger too, at two columns rather than four. */
+    .pt-box.pt-micro .pt-ledger { grid-template-columns: repeat(2, 1fr); gap: 3px; }
+    .pt-box.pt-micro .pt-led { padding: 4px 5px; }
+    .pt-box.pt-micro .pt-led .k { font-size: 7.5px; }
+    .pt-box.pt-micro .pt-led .v { font-size: 10px; }
+    .pt-box.pt-focus .pt-ledger { gap: 3px; }
+    /* Direction is colour before it is text: the buy chips read green, the
+       sell ladder red, so a mis-click is visible before it is a fill. */
+    .pt-preset { color: var(--pt-green); }
+    .pt-buy { color: var(--pt-green); }
+    .pt-sell { color: var(--pt-red); }
+    .pt-sell:disabled, .pt-preset:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    /* Sell-initial sits in the same row rhythm as the ladder above it. */
+    .pt-sell-initial { margin-top: 4px; padding: 5px 8px; font-size: 10px; }
+    .pt-sell-initial:disabled { opacity: 0.45; cursor: not-allowed; }
+    /* One box per figure, with its own border. They were four labels sharing
+       a background — reported as "thrown there" with nothing separating the
+       numbers, and at a glance the value of one read as the label of the next. */
     .pt-ledger {
       display: grid; grid-template-columns: repeat(4, 1fr); gap: 4px;
-      margin-top: 8px; padding: 7px 8px;
-      background: rgba(0, 0, 0, 0.22); border: 1px solid var(--pt-line);
-      border-radius: 9px;
+      margin-top: 8px;
     }
-    .pt-led { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+    .pt-led {
+      min-width: 0; padding: 5px 6px;
+      display: flex; flex-direction: column; gap: 2px;
+      background: rgba(0, 0, 0, 0.26);
+      border: 1px solid var(--pt-line);
+      border-radius: 7px;
+    }
     .pt-led .k {
       font-size: 8.5px; font-weight: 700; letter-spacing: 0.7px;
       text-transform: uppercase; color: var(--pt-faint); white-space: nowrap;
@@ -7148,20 +7177,29 @@
     if (!els.position) return;
     const pos = token && state.positions[token.mint];
 
+    // The card is ALWAYS present, held or not. It used to be torn down the
+    // moment a position closed, so the sell ladder and the round ledger
+    // appeared and vanished — reported as the sell buttons not always being
+    // there. An empty card states the shape of the thing and disables what
+    // cannot be done; it never claims a number it does not have.
+    if (!posEls) buildPositionCard(pos || null);
+
     if (!pos) {
-      if (els.position.childNodes.length) els.position.textContent = '';
-      posEls = null;
+      renderEmptyPosition();
       posOrderEls = null;
       return;
     }
-
-    if (!posEls) buildPositionCard(pos);
     // Armed levels change from the chart (a drag, a cancel) and from the
     // wallet (an order firing), neither of which rebuilds the card.
     renderOrderList();
 
     const mark = Q.positionMark(pos, token.priceNative, token.priceUsd);
     if (!mark) return;
+
+    // Re-arm whatever the empty state switched off — the card persists now,
+    // so a disabled control would otherwise stay disabled after a buy.
+    setSellLadderEnabled(true);
+    if (posEls.orders) posEls.orders.classList.remove('pt-hidden');
 
     posEls.qty.textContent = `${E.fmt(mark.qty, 2)} ${pos.symbol}`;
     // "I got in at 240K" is how the entry is actually discussed, so the card
@@ -7228,28 +7266,84 @@
     if (!posEls || !posEls.initial) return;
     const btn = posEls.initial;
     const plan = currentInitialPlan();
-    if (!plan) { btn.classList.add('pt-hidden'); return; }
+    // Always on screen, never hidden — a control that comes and goes cannot
+    // be reached for. It goes inert with a reason instead.
     btn.classList.remove('pt-hidden');
+    if (!plan) {
+      btn.disabled = true;
+      btn.classList.remove('pt-short');
+      btn.textContent = 'Sell init';
+      btn.title = 'Nothing left to recover — the sells have already returned what went in.';
+      return;
+    }
 
     if (plan.shortfall) {
       btn.disabled = true;
       btn.classList.add('pt-short');
-      btn.textContent = 'Not enough to cover the initial yet';
+      btn.textContent = 'Sell init';
       btn.title = 'Selling the whole position would still return less than went in.';
       return;
     }
     btn.disabled = false;
     btn.classList.remove('pt-short');
     const pct = plan.fraction * 100;
-    btn.textContent = `Sell initial (${pct < 1 ? pct.toFixed(1) : pct.toFixed(0)}%)`;
+    btn.textContent = `Sell init ${pct < 1 ? pct.toFixed(1) : pct.toFixed(0)}%`;
     btn.title = 'Sells just enough to take back what you put in, costs included — '
       + 'the rest of the bag becomes house money.';
+  }
+  /**
+   * The card with nothing held.
+   *
+   * Every figure is an em dash rather than a zero. A zero is a measurement
+   * — it says the position is worth nothing — and there is no position to
+   * measure. The controls stay on screen and go inert, so the panel has one
+   * shape whether or not a bag is open.
+   */
+  /** Arm or disarm the quick-sell ladder. Direct children, not a selector:
+   *  the buttons are appended straight into the row, and reading them this
+   *  way behaves identically in a real DOM and under test. */
+  function setSellLadderEnabled(on) {
+    if (!posEls || !posEls.sellRow) return;
+    for (const b of Array.from(posEls.sellRow.children || [])) {
+      if (b && b.className === 'pt-sell') b.disabled = !on;
+    }
+  }
+  function renderEmptyPosition() {
+    if (!posEls) return;
+    const DASH = '—';
+    posEls.qty.textContent = DASH;
+    posEls.entry.textContent = DASH;
+    posEls.value.textContent = DASH;
+    posEls.pnl.textContent = DASH;
+    posEls.pnl.classList.remove('pt-green', 'pt-red', 'pt-flash-up', 'pt-flash-down');
+
+    if (posEls.ledger) {
+      posEls.ledger.classList.remove('pt-hidden', 'pt-house');
+      posEls.ledIn.textContent = DASH;
+      posEls.ledOut.textContent = DASH;
+      posEls.ledLeft.textContent = DASH;
+      posEls.ledChg.textContent = DASH;
+      posEls.ledChg.classList.remove('pt-green', 'pt-red');
+    }
+    if (posEls.initial) {
+      posEls.initial.classList.remove('pt-hidden', 'pt-short');
+      posEls.initial.disabled = true;
+      posEls.initial.textContent = 'Sell init';
+      posEls.initial.title = 'Nothing held yet — this sells just enough to take back what you put in.';
+    }
+    setSellLadderEnabled(false);
+    if (posEls.orders) posEls.orders.classList.add('pt-hidden');
+    lastRenderedPrice = null;
   }
   function renderPositionLedger(pos, mark) {
     if (!posEls || !posEls.ledger) return;
     const led = Q.positionLedger(state.journal, pos, mark.valueSol);
-    if (!led || led.sells === 0) { posEls.ledger.classList.add('pt-hidden'); return; }
+    // Always on screen. It used to appear only after the first partial sell,
+    // so the row the trader was looking for arrived exactly when they were
+    // busy. Before a sell, `sold` is honestly zero — money genuinely has not
+    // come back — while invested and remaining are real from the first fill.
     posEls.ledger.classList.remove('pt-hidden');
+    if (!led) return;
 
     // The panel speaks the venue's currency: dollars off Solana, SOL on it.
     const rate = panelUsd() ? panelUsdRate() : null;
@@ -7805,6 +7899,7 @@
       ledLeft: card.querySelector('[data-f="led-left"]'),
       ledChg: card.querySelector('[data-f="led-chg"]'),
       initial: card.querySelector('[data-f="initial"]'),
+      sellRow: card.querySelector('[data-f="sell"]'),
     };
 
     const row = card.querySelector('[data-f="sell"]');

--- a/extension/test/d37_liveapply.test.js
+++ b/extension/test/d37_liveapply.test.js
@@ -44,7 +44,7 @@ test('a changed sellPcts list forces exactly one position-card rebuild', () => {
   const r = src.indexOf('function renderPosition(');
   const rblk = src.slice(r, r + 600);
   assert.ok(
-    /if \(!posEls\) buildPositionCard\(pos\);/.test(rblk),
+    /if \(!posEls\) buildPositionCard\(pos \|\| null\);/.test(rblk),
     'renderPosition must rebuild via buildPositionCard when posEls is null'
   );
 });

--- a/extension/test/livepnl.test.js
+++ b/extension/test/livepnl.test.js
@@ -199,7 +199,17 @@ function runOverlay(priceSeries, opts = {}) {
         toggle(c, on) { if (on === undefined) { this._s.has(c) ? this._s.delete(c) : this._s.add(c); } else if (on) this._s.add(c); else this._s.delete(c); },
         contains(c) { return this._s.has(c); } },
       children: [],
-      set textContent(v) { this._t = v; if (this.dataset.f) textOf[this.dataset.f] = v; },
+      set textContent(v) {
+        this._t = v;
+        if (this.dataset.f) textOf[this.dataset.f] = v;
+        // A real DOM DROPS every child when textContent is set. Without that
+        // here, a rebuilt card appends beside the old one and children[0]
+        // stays the FIRST card ever built — so fieldText() reads a detached
+        // node and reports whatever it last held. That made the position card
+        // untestable the moment it started being built before a position
+        // existed rather than after.
+        if (v === '') { this.children.length = 0; if (this._fields) this._fields = {}; }
+      },
       get textContent() { return this._t || ''; },
       set innerHTML(v) {
         this._h = v;

--- a/extension/test/positionledger.test.js
+++ b/extension/test/positionledger.test.js
@@ -83,8 +83,90 @@ test('the panel renders it in the venue currency, and only after a sell', () => 
   const fn = content.slice(
     content.indexOf('function renderPositionLedger('),
     content.indexOf('\n  }', content.indexOf('function renderPositionLedger(')) + 4);
-  assert.match(fn, /led\.sells === 0/, 'it must stay hidden until something has been sold');
+  // It is permanent now. Before the first sell, `sold` is honestly zero —
+  // money genuinely has not come back — while invested and remaining are
+  // real from the first fill, so there is nothing to hide.
+  assert.ok(!/led\.sells === 0/.test(fn), 'the ledger must not hide itself any more');
+  assert.match(fn, /ledger\.classList\.remove\('pt-hidden'\)/,
+    'it is shown on every pass');
   assert.match(fn, /panelUsd\(\)/, 'dollars off Solana');
   assert.match(fn, /E\.fmt\(sol, 3\)} SOL/, 'SOL on Solana');
   assert.match(fn, /pt-house/, 'and it must mark the house-money state');
+});
+
+/* ------------------------------------------------------------------------
+ * The panel keeps its shape whether or not a bag is open.
+ *
+ * Reported: the sell buttons are not always there, the ledger is not always
+ * there, and on the smallest panel the paper balance is nowhere at all.
+ * ---------------------------------------------------------------------- */
+
+function fnOf(name) {
+  const at = content.indexOf(`function ${name}(`);
+  assert.ok(at !== -1, `${name} must exist`);
+  return content.slice(at, content.indexOf('\n  }', at) + 4);
+}
+
+test('the position card is no longer torn down when nothing is held', () => {
+  const render = fnOf('renderPosition');
+  assert.ok(!/els\.position\.textContent = ''/.test(render),
+    'clearing the card is what made the sell ladder come and go');
+  assert.match(render, /renderEmptyPosition\(\)/, 'it renders an empty card instead');
+});
+
+test('an empty card dashes every figure rather than showing zeros', () => {
+  // A zero is a measurement — it says the position is worth nothing. There is
+  // no position to measure, so the honest mark is an em dash.
+  const empty = fnOf('renderEmptyPosition');
+  assert.match(empty, /const DASH = '—';/);
+  for (const field of ['qty', 'entry', 'value', 'pnl', 'ledIn', 'ledOut', 'ledLeft', 'ledChg']) {
+    assert.ok(new RegExp(`${field}\.textContent = DASH`).test(empty),
+      `${field} must be dashed, not zeroed`);
+  }
+});
+
+test('an empty card disables what cannot be done, and keeps it on screen', () => {
+  const empty = fnOf('renderEmptyPosition');
+  assert.match(empty, /setSellLadderEnabled\(false\)/, 'the ladder goes inert');
+  assert.match(empty, /initial\.disabled = true/, 'so does sell-initial');
+  assert.match(empty, /ledger\.classList\.remove\('pt-hidden'/, 'the ledger stays visible');
+  assert.match(empty, /initial\.classList\.remove\('pt-hidden'/, 'and so does sell-initial');
+});
+
+test('a live position re-arms everything the empty state switched off', () => {
+  // The card persists now, so a disabled control would otherwise stay
+  // disabled after a buy — the ladder would be permanently dead.
+  const render = fnOf('renderPosition');
+  assert.match(render, /setSellLadderEnabled\(true\)/,
+    'the ladder must be re-enabled once something is held');
+});
+
+test('direction is colour-coded before it is read', () => {
+  assert.match(content, /\.pt-preset \{ color: var\(--pt-green\); \}/, 'buy chips are green');
+  assert.match(content, /\.pt-buy \{ color: var\(--pt-green\); \}/, 'so is the BUY button');
+  assert.match(content, /\.pt-sell \{ color: var\(--pt-red\); \}/, 'the sell ladder is red');
+});
+
+test('each ledger figure gets its own box', () => {
+  // Reported as "thrown there" with nothing separating the numbers: at a
+  // glance the value of one read as the label of the next.
+  assert.match(content, /\.pt-led \{[^}]*border: 1px solid var\(--pt-line\)/,
+    'every cell needs its own border, not a shared background');
+});
+
+test('the smallest panel still shows the paper balance', () => {
+  // #pt-buy-label is where cash on hand lives. Micro hid it with the rest of
+  // the buy furniture, so the smallest panel was the one that never showed
+  // how much paper SOL you had — on any site.
+  const microHides = content.slice(content.indexOf('.pt-box.pt-micro #pt-costs'),
+    content.indexOf('.pt-box.pt-micro .pt-xray'));
+  assert.ok(!microHides.includes('#pt-buy-label'),
+    'micro must not hide the element that carries the balance');
+  assert.match(content, /\.pt-box\.pt-micro #pt-buy-label \{/,
+    'it is trimmed for the smaller panel instead');
+});
+
+test('the compact panels keep the ledger, at fewer columns', () => {
+  assert.match(content, /\.pt-box\.pt-micro \.pt-ledger \{ grid-template-columns: repeat\(2, 1fr\)/,
+    'four boxes do not fit a micro panel; two do');
 });

--- a/extension/test/sellinitial.test.js
+++ b/extension/test/sellinitial.test.js
@@ -137,18 +137,28 @@ test('a shortfall refuses instead of selling everything and calling it a recover
 
   const render = block('renderSellInitial');
   assert.match(render, /btn\.disabled = true/, 'and the control must show as unavailable');
-  assert.match(render, /Not enough to cover the initial yet/, 'saying why');
+  // The label is short now — the control sits in a compact row — so the
+  // reason moved to the title, where there is room for a sentence.
+  assert.match(render, /pt-short/, 'and it must be visibly distinct while refusing');
+  assert.match(render, /Selling the whole position would still return less than went in/,
+    'saying why, in the tooltip');
 });
 
 test('the label states the fraction it is about to sell', () => {
   // "Sell initial" alone asks the trader to trust an unstated number.
   const render = block('renderSellInitial');
   assert.match(render, /plan\.fraction \* 100/);
-  assert.match(render, /Sell initial \(\$\{/);
+  assert.match(render, /Sell init \$\{/, 'the compact label still carries the number');
 });
 
-test('nothing to recover means no button at all', () => {
+test('the control is never hidden, only made inert', () => {
+  // Requested: always show it. A button that comes and goes cannot be
+  // reached for, and its absence is indistinguishable from a broken panel.
   const render = block('renderSellInitial');
-  assert.match(render, /if \(!plan\) \{ btn\.classList\.add\('pt-hidden'\); return; \}/,
-    'a round already whole has no initial left to take off the table');
+  assert.ok(!/classList\.add\('pt-hidden'\)/.test(render),
+    'renderSellInitial must never hide the control');
+  assert.match(render, /btn\.classList\.remove\('pt-hidden'\)/,
+    'it un-hides it on every pass, so nothing else can leave it hidden');
+  assert.match(render, /Nothing left to recover/,
+    'and a round already whole says so rather than disappearing');
 });

--- a/extension/test/statepersist.test.js
+++ b/extension/test/statepersist.test.js
@@ -349,7 +349,14 @@ test('the quick-sell buttons render for a position adopted from another tab', as
   const ov = runOverlay([0.001, 0.0012]);
 
   await ov.advance(1200);
-  assert.equal(ov.sellButtons().length, 0, 'no position, no sell buttons');
+  // The ladder is permanent now — reported as the sell buttons not always
+  // being there. With nothing held they are present and INERT, which is a
+  // stronger contract than absence: a disabled control cannot fire a sell,
+  // and it also cannot vanish from under the cursor.
+  const idle = ov.sellButtons();
+  assert.ok(idle.length > 0, 'the sell ladder must stay on screen with no position');
+  assert.ok(idle.every((b) => b.disabled === true),
+    'and every one of them must be disabled while there is nothing to sell');
 
   assert.ok(ov.openPaperPosition(1));
   await ov.advance(600);


### PR DESCRIPTION
Five reports, one cause: pieces of the trade panel appeared and vanished depending on state, so **the control you reached for was often not there**.

## The position card is no longer torn down

It used to be cleared the moment nothing was held — taking the sell ladder, the round ledger and sell-initial with it. Now it stays mounted with every figure dashed and every control inert.

**Dashes, not zeros.** A zero is a measurement; it says the position is worth nothing. There is no position to measure.

The ladder and sell-initial are re-armed on the live path — a persistent card means a disabled control would otherwise stay disabled after the next buy, permanently.

## Sell-initial is permanent and compact

Never hidden, only made inert with the reason in its title. **"Sell init 34%"** rather than "Sell initial (34%)", so it sits in the ladder''s row rhythm.

## The ledger is permanent too

It appeared only after the first partial sell — so the row you wanted arrived exactly when you were busy. Before a sell, `sold` is honestly zero; invested and remaining are real from the first fill.

**Each figure gets its own bordered box.** They were four labels sharing one background — reported as *"thrown there"* — and at a glance the value of one read as the label of the next.

## Direction is colour before it is text

Buy chips and the BUY button green, the sell ladder red, so a mis-click is visible **before** it''s a fill.

## The smallest panel shows the balance again

Cash on hand rides on `#pt-buy-label`, and micro hid that element with the rest of the buy furniture — so **the smallest panel was the one that never showed how much paper SOL you had, on any site**. That''s why you couldn''t find it on Axiom or Padre. Trimmed for the size rather than dropped; micro and focus keep the ledger too, at two columns.

## Four contract tests moved, because the contract moved

*"no position, no sell buttons"* is precisely the behaviour reported as wrong. It now asserts something **stronger**: the ladder is present **and every button disabled** — which absence could never have proved.

## One harness bug fixed on the way

The stub DOM''s `textContent = ''` didn''t drop children, so a rebuilt card appended *beside* the old one and `children[0]` stayed the first card ever built — meaning `fieldText()` read a **detached node**.

Harmless while the card was only ever built with a position in hand. The moment it was built *before* one, six tests failed on completely correct code. The stub now models the real DOM.

```
extension  1831/1831
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
