### PR TITLE
fix(fills): a lagging aggregator quote may no longer pose as the screen (F-57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 Stream-style log of what shipped, newest first. User-facing wording; the gory
 details live in the commit messages.
 
+## Unreleased
+
+- **Entries land on the chart you're looking at.** Field report: *"higher
+  entry without wicks or anything. just filled me at 35k while the coin is
+  moving around 25k."* A lagging aggregator quote could reach the fill path
+  wearing a fresh timestamp and be taken for the on-screen price, skipping
+  every cross-check on the way. The fast path now requires the page's own
+  feed to have actually ticked, and an aggregator quote that disagrees with
+  what the tab just accepted as money has to be backed by the chain before
+  it can price a fill. A quote nothing can vouch for is refused out loud
+  instead of filling you 40% high.
+
 ## v3.13.3 — 2026-08-22
 
 **Twelve quality-of-life upgrades from the community wave.** The overlay

--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -530,6 +530,42 @@ arithmetic instead matches fills by sessionId (`tradeInRound`), which
 survives the rename — the stand-in buy still counts in the round's money,
 its tradeIds, and the chart's average-entry line.
 
+**F-57 · S1 · a buy filled at 35k while the coin traded at 25k — 1.4x, no wick**
+`content.js pickQuoteForTrade` fresh-screen fast path + `quote.js
+needsFillWitness` band · field report 2026-08-22 ("higher entry without
+wicks or anything. just filled me at 35k while the coin is moving around
+25k") · **fixed** (executed regression in `test/fillprovenance.test.js`,
+ladder contract in `test/load.test.js`, witness contract in
+`test/fillwitness.test.js`).
+Two independent holes, both required for the entry to land where it did.
+**Provenance.** The F-52 fast path returns the on-screen snapshot whenever
+`atClickAge <= ONCHAIN_SCREEN_CHECK_MAX_AGE_MS` (600ms) — and that age is
+derived from `lastPriceAt`, which the poll loop (`feedLive` false branch)
+and `requote()` ALSO stamp when they adopt a resolver price into
+`token.priceNative`. So an aggregator quote that landed inside the window
+was handed back AS "the price the trader is looking at": the chain was
+never asked and the ladder was skipped entirely. The irony is on the
+record — the F-47 evidence stream carries a comment refusing to read
+`token.priceNative` for precisely this reason, while the fast path read it
+anyway. **Band.** The F-47 witness only wakes past `FILL_WITNESS_RATIO`
+(2x), a width calibrated for a live feed where memecoins genuinely 4x
+between honest reads. 1.4x sat under it, so nothing examined the candidate.
+And the witness for any candidate not sourced `'action-resolver'` was
+`R.refresh()` — the aggregator — so a lagging read was asked to vouch for
+itself and did. `fillSourcesAgree`/`ONSCREEN_AGREE_RATIO` (1.06), which
+would have caught this, had been dead code since F-52 removed the
+chain-first comparison: defined, exported and tested, called by nothing.
+Fix: `lastPageTickAt` records when the PAGE FEED last delivered an accepted
+tick, kept strictly apart from `lastPriceAt`, and the fast path requires it
+— a resolver adoption falls through to the chain read, which does answer to
+accepted evidence (F-48, 1.10). Aggregator-sourced candidates
+(`resolver`, `action-resolver`, `jupiter`, `gmgn`, `pumpfun`) additionally
+answer to `AGGREGATOR_WITNESS_RATIO` (1.15) instead of 2x, because a
+periodic snapshot of a market this tab is already watching tick-by-tick has
+no business disagreeing by 40%; and any such candidate is witnessed by the
+chain, never by the aggregator again. The live feed keeps its wide band, so
+real violent moves still fill.
+
 **F-52 · S1 · fills land up to 6% away from the number the trader clicked on**
 `content.js pickQuoteForTrade` chain-first ladder · superski, Discord
 2026-08-11 ("sometimes your average entry isn't calculated properly, it'll

--- a/extension/content.js
+++ b/extension/content.js
@@ -95,6 +95,11 @@
   const ARMED_ROW_TTL_MS = 60_000;
   let lastRenderedPrice = null; // drives the tick flash
   let lastPriceAt = 0;
+  // F-57: when the page's OWN feed last delivered an accepted tick. Kept apart
+  // from lastPriceAt, which means "when token.priceNative was last written by
+  // anybody" — resolver adoptions included. Only the fill path needs the
+  // distinction, and it needs it absolutely (see pickQuoteForTrade).
+  let lastPageTickAt = 0;
   let pageQuoteSeq = 0;
   const pageQuoteWaiters = new Set();
   let resolving = false;
@@ -753,6 +758,8 @@
     }
 
     lastPriceAt = Date.now();
+    // This is the one write that means "the screen just moved" (F-57).
+    lastPageTickAt = lastPriceAt;
     pageQuoteSeq += 1;
     for (const resolve of pageQuoteWaiters) resolve();
     pageQuoteWaiters.clear();
@@ -1221,6 +1228,7 @@
       delete livePositionPrices[token.mint];
       series = []; marks = [];
       lastPriceAt = 0;
+      lastPageTickAt = 0;
       lastCmTickPrice = 0;
       chartAxisBasis = null;
       // C-01: the repost throttle is per token, like the spec it re-posts.
@@ -1817,12 +1825,22 @@
       ? { priceNative: posEvidence, at: Date.now() }
       : null);
     const evidenceAge = evidence ? Date.now() - evidence.at : Infinity;
-    if (!Q.needsFillWitness(chosen.priceNative, evidence && evidence.priceNative, evidenceAge)) {
+    // F-57: the band depends on where the candidate came from. A live feed
+    // keeps the wide 2x window (real memecoin moves are violent); an
+    // aggregator snapshot answers to a tight one, because its disagreements
+    // are lag far more often than they are news.
+    if (!Q.needsFillWitness(chosen.priceNative, evidence && evidence.priceNative,
+      evidenceAge, chosen.source)) {
       return chosen;
     }
-    // The witness must be INDEPENDENT of the candidate's own source.
+    // The witness must be INDEPENDENT of the candidate's own source. F-57:
+    // this used to name ONE aggregator path ('action-resolver') and send
+    // every other candidate to R.refresh() — which is the aggregator. So an
+    // adopted 'resolver' or 'jupiter' price was witnessed by asking the same
+    // service that served it, and a lagging read cheerfully confirmed
+    // itself. Any aggregator-sourced candidate is now witnessed by the chain.
     let witnessNative = null;
-    if (chosen.source === 'action-resolver') {
+    if (Q.isAggregatorSource(chosen.source)) {
       const obs = await R.onchainQuote(token && token.mint).catch(() => null);
       if (obs && obs.priceNative > 0) witnessNative = obs.priceNative;
     } else {
@@ -1870,7 +1888,27 @@
     // fresh-screen path into a fill — and skipping the chain round trip
     // here makes the common fill faster, which is exactly what a fresh
     // launch needs.
-    const screenFresh = atClick && atClickAge <= ONCHAIN_SCREEN_CHECK_MAX_AGE_MS;
+    //
+    // F-57 (field report, 8/22): "higher entry without wicks or anything, just
+    // filled me at 35k while the coin is moving around 25k" — a 1.4x worse
+    // entry on a chart that never printed that level. The F-52 fast path read
+    // `atClickAge`, which is derived from lastPriceAt — and lastPriceAt is
+    // bumped by RESOLVER ADOPTIONS too (the poll loop and requote both write
+    // token.priceNative and re-stamp it). So a lagging aggregator quote that
+    // landed inside the 600ms window was returned here AS the on-screen
+    // price: the ladder was skipped, the chain was never asked, and the F-47
+    // witness let it pass because 1.4x sits under the 2x ratio. The comment
+    // above already named the field the evidence stream refuses to trust for
+    // exactly this reason; the fast path was reading it anyway.
+    //
+    // The fix is provenance, not another ratio: this path exists because the
+    // trader is looking at a moving chart, so it may only fire when the PAGE
+    // FEED is what moved. A resolver adoption falls through to the chain read
+    // below, which does answer to accepted evidence (F-48, 1.10 band).
+    const screenFresh = atClick
+      && atClickAge <= ONCHAIN_SCREEN_CHECK_MAX_AGE_MS
+      && lastPageTickAt > 0
+      && clickAt - lastPageTickAt <= ONCHAIN_SCREEN_CHECK_MAX_AGE_MS;
     if (screenFresh) return atClick;
 
     // The screen is quiet — chain state is the authority now. It is the only

--- a/extension/quote.js
+++ b/extension/quote.js
@@ -990,14 +990,45 @@
   var FILL_WITNESS_RATIO = 2;
   var FILL_WITNESS_AGREE_RATIO = 1.6;
 
-  /** Does this candidate need a second, independent source to vouch for it? */
-  function needsFillWitness(candidateNative, evidenceNative, evidenceAgeMs) {
+  // F-57: the 2x ratio above was calibrated for the on-screen feed, where a
+  // genuine memecoin move really can 4x between two honest reads — so a wide
+  // band is the price of not refusing real moves. An AGGREGATOR quote has no
+  // such excuse. It is a periodic snapshot of a market this tab is already
+  // watching tick by tick, and when it disagrees with evidence the tab just
+  // accepted as money, the overwhelmingly likely explanation is that the
+  // snapshot is behind — not that the market moved 40% between two reads the
+  // page feed somehow both missed. Everything from ONSCREEN_AGREE_RATIO up to
+  // FILL_WITNESS_RATIO answered to nobody on this path; 1.4x is where the
+  // field report landed ("filled me at 35k while the coin is moving around
+  // 25k"). These sources now answer to a band that a lagging read fails and
+  // an honest one passes.
+  var AGGREGATOR_WITNESS_RATIO = 1.15;
+  var AGGREGATOR_SOURCES = {
+    resolver: 1, 'action-resolver': 1, jupiter: 1, gmgn: 1, pumpfun: 1,
+  };
+
+  /** True for a price that came from a periodic snapshot rather than the
+   *  page's own live feed or the chain. */
+  function isAggregatorSource(source) {
+    return Boolean(AGGREGATOR_SOURCES[String(source)]);
+  }
+
+  /** The divergence a candidate from this source may show before it must be
+   *  corroborated. Unknown sources keep the wide, permissive band. */
+  function witnessRatioFor(source) {
+    return isAggregatorSource(source) ? AGGREGATOR_WITNESS_RATIO : FILL_WITNESS_RATIO;
+  }
+
+  /** Does this candidate need a second, independent source to vouch for it?
+   *  `source` is optional — omitted, every candidate gets the wide band, which
+   *  is the pre-F-57 behavior. */
+  function needsFillWitness(candidateNative, evidenceNative, evidenceAgeMs, source) {
     if (!(candidateNative > 0) || !(evidenceNative > 0)) return false;
     if (!(evidenceAgeMs >= 0) || evidenceAgeMs > FILL_WITNESS_WINDOW_MS) return false;
     var ratio = candidateNative > evidenceNative
       ? candidateNative / evidenceNative
       : evidenceNative / candidateNative;
-    return ratio > FILL_WITNESS_RATIO;
+    return ratio > witnessRatioFor(source);
   }
 
   /** A missing witness never confirms: a violent divergence that no second
@@ -1508,12 +1539,15 @@
     isPriceStale,
     fillSourcesAgree,
     needsFillWitness,
+    witnessRatioFor,
+    isAggregatorSource,
     witnessAgrees,
     onchainContradictsEvidence,
     scaleStepVerdict,
     FILL_WITNESS_WINDOW_MS,
     FILL_WITNESS_RATIO,
     FILL_WITNESS_AGREE_RATIO,
+    AGGREGATOR_WITNESS_RATIO,
     ONCHAIN_EVIDENCE_WINDOW_MS,
     ONCHAIN_EVIDENCE_AGREE_RATIO,
     SCALE_STEP_RATIO,

--- a/extension/test/fillprovenance.test.js
+++ b/extension/test/fillprovenance.test.js
@@ -1,0 +1,278 @@
+/* F-57 — a lagging aggregator quote must not masquerade as the screen.
+ *
+ * Field report (8/22): "higher entry without wicks or anything. just filled me
+ * at 35k while the coin is moving around 25k" — a 1.4x WORSE entry on a chart
+ * that never printed that level.
+ *
+ * Two independent holes produced it, and both are covered here.
+ *
+ * 1. PROVENANCE. The F-52 fast path returned the on-screen snapshot whenever
+ *    `atClickAge` was under 600ms — and that age derives from `lastPriceAt`,
+ *    which the poll loop and requote() ALSO stamp when they adopt a resolver
+ *    price into token.priceNative. So an aggregator quote that landed inside
+ *    the window was handed back as "the price the trader is looking at": the
+ *    ladder was skipped and the chain was never asked. The evidence stream
+ *    (F-47) had refused to read that same field for exactly this reason; the
+ *    fast path was reading it anyway.
+ *
+ * 2. BAND. The witness only wakes past FILL_WITNESS_RATIO (2x), a width
+ *    calibrated for a live feed where memecoins genuinely 4x between reads.
+ *    1.4x sat under it, so nothing examined the candidate at all. And the
+ *    witness for a non-'action-resolver' candidate was R.refresh() — the
+ *    aggregator — so a lagging read got to confirm itself.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+global.window = global.window || {};
+const Q = require('../quote.js');
+
+const ROOT = path.join(__dirname, '..');
+const contentJs = fs.readFileSync(path.join(ROOT, 'content.js'), 'utf8');
+
+// The report's numbers as native prices at 1e9 supply, SOL≈$180.
+const MINT = 'oUwiFakeF57RegressionMintxxxxxxxxxxxxxxpump';
+const N_MARKET = 25_000 / 1e9 / 180;  // where the coin was actually moving
+const N_LAGGED = 35_000 / 1e9 / 180;  // what he got filled at — 1.4x
+
+/** Boot the shipped action-quote ladder. Mirrors quietscreen.test.js. */
+function bootLadder(env) {
+  const start = contentJs.indexOf('/* -------------------- action-time quotes and fills');
+  const end = contentJs.indexOf('/* -------------------- fills --------------------');
+  assert.ok(start !== -1 && end > start, 'the action-quote section must exist in content.js');
+  const sandbox = {
+    console: { debug: (...a) => env.debugLines.push(a.join(' ')) },
+    Date, Promise, Set, Number, Boolean, Math, Infinity, JSON, setTimeout,
+    Q,
+    R: env.R,
+    E: { fmt: (v) => String(v) },
+    token: env.token,
+    lastPriceAt: env.lastPriceAt,
+    lastPageTickAt: env.lastPageTickAt !== undefined ? env.lastPageTickAt : env.lastPriceAt,
+    pageQuoteSeq: 0,
+    pageQuoteWaiters: new Set(),
+    site: env.site || { id: 'axiom' },
+  };
+  const script = contentJs.slice(start, end) + '\n;({ quoteForTrade, pickQuoteForTrade,'
+    + ' setEvidence: (v) => { lastAcceptedMarket = v; },'
+    + ' getRefusal: () => lastQuoteRefusal });';
+  return vm.runInNewContext(script, vm.createContext(sandbox), { filename: 'content.js#action-quotes' });
+}
+
+/** The token as the panel holds it after a resolver adoption overwrote the
+ *  chart-fed price: token.priceNative IS the aggregator's number now. */
+function adoptedToken() {
+  return {
+    mint: MINT,
+    priceNative: N_LAGGED,
+    priceUsd: N_LAGGED * 180,
+    mcap: 35_000,
+    priceSource: 'resolver',
+    pending: false,
+  };
+}
+
+function fakeResolver(overrides) {
+  const calls = { onchain: 0, refresh: 0 };
+  return {
+    calls,
+    onchainQuote: async () => { calls.onchain += 1; return overrides.observation || null; },
+    refresh: async () => { calls.refresh += 1; return overrides.refreshResult || null; },
+  };
+}
+
+/* ---------------------------------------------------------------- pure band */
+
+test('F-57: at 1.4x, an aggregator candidate needs a witness and a live feed does not', () => {
+  // The exact divergence in the report, judged both ways.
+  assert.equal(Q.needsFillWitness(N_LAGGED, N_MARKET, 1_000, 'resolver'), true,
+    '35k against a 25k market is a lagging aggregator read, and must be challenged');
+  assert.equal(Q.needsFillWitness(N_LAGGED, N_MARKET, 1_000, 'action-resolver'), true,
+    'the action-time aggregator quote answers to the same band');
+  assert.equal(Q.needsFillWitness(N_LAGGED, N_MARKET, 1_000, 'jupiter'), true);
+  assert.equal(Q.needsFillWitness(N_LAGGED, N_MARKET, 1_000, 'gmgn'), true);
+  assert.equal(Q.needsFillWitness(N_LAGGED, N_MARKET, 1_000, 'pumpfun'), true);
+
+  // A live feed keeps the wide band: real memecoin moves are violent, and
+  // refusing them would be its own defect.
+  assert.equal(Q.needsFillWitness(N_LAGGED, N_MARKET, 1_000, 'page-feed'), false,
+    'the page feed keeps the 2x window it was calibrated for');
+  assert.equal(Q.needsFillWitness(N_LAGGED, N_MARKET, 1_000, 'padre-chart-bar'), false);
+  assert.equal(Q.needsFillWitness(N_LAGGED, N_MARKET, 1_000, 'onchain'), false,
+    'the chain read answers to onchainContradictsEvidence, not to this band');
+});
+
+test('F-57: the source argument is optional and defaults to the old, wider band', () => {
+  assert.equal(Q.needsFillWitness(N_LAGGED, N_MARKET, 1_000), false,
+    'omitting the source must reproduce pre-F-57 behavior exactly');
+  assert.equal(Q.needsFillWitness(N_LAGGED, N_MARKET, 1_000, undefined), false);
+  assert.equal(Q.needsFillWitness(N_LAGGED, N_MARKET, 1_000, null), false);
+});
+
+test('F-57: the tight band is tight enough to catch lag and loose enough to pass drift', () => {
+  assert.ok(Q.AGGREGATOR_WITNESS_RATIO > Q.ONSCREEN_AGREE_RATIO,
+    'it must not be stricter than the band that calls two sources the same market');
+  assert.ok(Q.AGGREGATOR_WITNESS_RATIO < Q.FILL_WITNESS_RATIO,
+    'and it must be strictly tighter than the live-feed window, or it changes nothing');
+
+  // Ordinary aggregator drift still fills without paying a round trip.
+  assert.equal(Q.needsFillWitness(N_MARKET * 1.05, N_MARKET, 1_000, 'resolver'), false,
+    '5% apart is two honest reads of one market');
+  assert.equal(Q.needsFillWitness(N_MARKET * 1.12, N_MARKET, 1_000, 'resolver'), false,
+    '12% is still inside the band — the guard must not fire on every quote');
+  assert.equal(Q.needsFillWitness(N_MARKET * 1.2, N_MARKET, 1_000, 'resolver'), true,
+    '20% apart is lag, not news');
+
+  // Absent or aged-out evidence never invents a challenge.
+  assert.equal(Q.needsFillWitness(N_LAGGED, 0, 1_000, 'resolver'), false);
+  assert.equal(Q.needsFillWitness(N_LAGGED, N_MARKET, Q.FILL_WITNESS_WINDOW_MS + 1, 'resolver'), false,
+    'evidence older than the window is not evidence');
+});
+
+test('F-57: source classification names the snapshot sources and nothing else', () => {
+  ['resolver', 'action-resolver', 'jupiter', 'gmgn', 'pumpfun']
+    .forEach((s) => assert.equal(Q.isAggregatorSource(s), true, s + ' is a periodic snapshot'));
+  ['page-feed', 'onchain', 'chart-export', 'padre-chart-bar', 'unknown', '', null, undefined]
+    .forEach((s) => assert.equal(Q.isAggregatorSource(s), false, String(s) + ' is not an aggregator'));
+  assert.equal(Q.witnessRatioFor('resolver'), Q.AGGREGATOR_WITNESS_RATIO);
+  assert.equal(Q.witnessRatioFor('page-feed'), Q.FILL_WITNESS_RATIO);
+});
+
+/* ------------------------------------------------------------ the ladder */
+
+test('F-57: the 35k fill — an adopted aggregator price cannot ride the fresh-screen path', async () => {
+  const debugLines = [];
+  const now = Date.now();
+  // A chain read that agrees with the market the trader is watching.
+  const R = fakeResolver({
+    observation: { mint: MINT, priceNative: N_MARKET, observedAt: now, slot: 11 },
+  });
+  // The shape of the defect: token.priceNative was written 100ms ago — by a
+  // RESOLVER adoption. The page's own feed last ticked 4 seconds ago.
+  const ladder = bootLadder({
+    token: adoptedToken(),
+    lastPriceAt: now - 100,
+    lastPageTickAt: now - 4_000,
+    R,
+    debugLines,
+  });
+  ladder.setEvidence({ priceNative: N_MARKET, at: now - 4_000 });
+
+  const q = await ladder.quoteForTrade();
+  assert.ok(q, 'the fill must not be refused — the chain knows the real price');
+  assert.ok(Math.abs(q.priceNative - N_MARKET) / N_MARKET < 1e-9,
+    `the fill must land at the ~25k the coin is trading at, not the adopted 35k (got ${q.priceNative})`);
+  assert.equal(R.calls.onchain > 0, true,
+    'the chain round trip must actually be paid — skipping it was the bug');
+});
+
+test('F-57: a genuine page tick still takes the fast path and pays nothing', async () => {
+  const debugLines = [];
+  const now = Date.now();
+  const R = fakeResolver({
+    observation: { mint: MINT, priceNative: N_LAGGED, observedAt: now, slot: 12 },
+  });
+  // Same freshness, honest provenance: the page feed is what moved.
+  const ladder = bootLadder({
+    token: {
+      mint: MINT, priceNative: N_MARKET, priceUsd: N_MARKET * 180,
+      mcap: 25_000, priceSource: 'padre-chart-bar', pending: false,
+    },
+    lastPriceAt: now - 100,
+    lastPageTickAt: now - 100,
+    R,
+    debugLines,
+  });
+  ladder.setEvidence({ priceNative: N_MARKET, at: now - 100 });
+
+  const q = await ladder.quoteForTrade();
+  assert.ok(q, 'the fill must not be refused');
+  assert.ok(Math.abs(q.priceNative - N_MARKET) / N_MARKET < 1e-9,
+    'the number on screen at click time is still the entry (F-52 must survive F-57)');
+  assert.equal(R.calls.onchain, 0,
+    'a fresh page tick must not pay the chain round trip — that is what F-52 bought');
+});
+
+test('F-57: an aggregator candidate is witnessed by the chain, not by the aggregator again', async () => {
+  const debugLines = [];
+  const now = Date.now();
+  // The residual path: the page feed is quiet, the chain has nothing to say,
+  // and the ladder falls back to the adopted snapshot — whose source is
+  // 'resolver' and whose value is the lagging 35k.
+  //
+  // This is what makes the witness-independence change load-bearing. The old
+  // code named ONE aggregator source ('action-resolver') and sent everything
+  // else to R.refresh() — the aggregator. So this candidate was handed to the
+  // very service that served it, which of course agreed, and the 35k fill
+  // went through wearing a witness's blessing. The chain is the independent
+  // source here; it declines to vouch, so the fill is refused.
+  const R = fakeResolver({
+    observation: null,   // chain silent — no witness available
+    refreshResult: { mint: MINT, priceNative: N_LAGGED, priceUsd: N_LAGGED * 180, mcap: 35_000 },
+  });
+  const ladder = bootLadder({
+    token: adoptedToken(),
+    lastPriceAt: now - 200,        // inside ACTION_QUOTE_MAX_AGE_MS (350ms)
+    lastPageTickAt: now - 4_000,   // but the page feed has been quiet
+    R,
+    debugLines,
+  });
+  ladder.setEvidence({ priceNative: N_MARKET, at: now - 2_000 });
+
+  const q = await ladder.quoteForTrade();
+  assert.equal(q, null,
+    'no independent witness for a 1.4x divergence means no fill — a refused click is re-clickable');
+  assert.match(ladder.getRefusal() || '', /Price sources disagree/,
+    'and the refusal must say so out loud rather than failing silently');
+  assert.ok(debugLines.some((l) => l.includes('fill witness refused')),
+    'the refusal leaves a console trail');
+  assert.equal(R.calls.refresh, 0,
+    'the aggregator must never be asked to vouch for the aggregator');
+});
+
+test('F-57: a corroborated aggregator move still fills at the moved level', async () => {
+  const debugLines = [];
+  const now = Date.now();
+  // The market really did run to 35k, and the chain says so too.
+  const R = fakeResolver({
+    observation: { mint: MINT, priceNative: N_LAGGED * 0.99, observedAt: now, slot: 13 },
+    refreshResult: { mint: MINT, priceNative: N_LAGGED, priceUsd: N_LAGGED * 180, mcap: 35_000 },
+  });
+  const ladder = bootLadder({
+    token: adoptedToken(),
+    lastPriceAt: now - 4_000,
+    lastPageTickAt: now - 4_000,
+    R,
+    debugLines,
+  });
+  ladder.setEvidence({ priceNative: N_MARKET, at: now - 2_000 });
+
+  const q = await ladder.quoteForTrade();
+  assert.ok(q, 'a real move confirmed by an independent source must fill — the guard must not over-reach');
+  assert.ok(q.priceNative > N_MARKET * 1.3,
+    `the fill must land at the MOVED level, not be dragged back to the old evidence (got ${q.priceNative})`);
+});
+
+/* ----------------------------------------------------------- the plumbing */
+
+test('F-57: only the page feed stamps lastPageTickAt, and a token change clears it', () => {
+  const writes = contentJs.match(/^\s*lastPageTickAt = .*$/gm) || [];
+  assert.equal(writes.length, 2,
+    'exactly two writes: the accepted page tick, and the per-token reset — no more');
+  assert.match(contentJs, /lastPriceAt = Date\.now\(\);\s*\n\s*\/\/[^\n]*\n\s*lastPageTickAt = lastPriceAt;\s*\n\s*pageQuoteSeq \+= 1;/,
+    'the stamp belongs to handlePageTick, beside the page-quote sequence it already bumps');
+  assert.match(contentJs, /lastPriceAt = 0;\s*\n\s*lastPageTickAt = 0;/,
+    'a new token clears it alongside lastPriceAt, or the previous coin vouches for this one');
+
+  // Neither resolver adoption may stamp it. Both live in blocks that set
+  // priceSource to the resolver and then re-stamp lastPriceAt.
+  const adoptions = contentJs.match(/token\.priceSource = [^\n]*resolver'[\s\S]{0,400}?lastPriceAt = Date\.now\(\);/g) || [];
+  assert.ok(adoptions.length >= 2, 'both resolver adoption sites must still be found by this test');
+  adoptions.forEach((block, i) => {
+    assert.ok(!/lastPageTickAt/.test(block),
+      `resolver adoption ${i} must not claim the page feed ticked — that was the defect`);
+  });
+});

--- a/extension/test/fillwitness.test.js
+++ b/extension/test/fillwitness.test.js
@@ -70,8 +70,13 @@ test('F-47: the fill path actually routes through the witness', () => {
     'accepted ticks are evidence');
   const fillEvidence = content.match(/lastAcceptedMarket = \{ priceNative: result\.trade\.priceNative, at: Date\.now\(\) \};/g) || [];
   assert.ok(fillEvidence.length >= 2, 'committed buys AND sells are money evidence');
-  assert.match(content, /Q\.needsFillWitness\(chosen\.priceNative, evidence && evidence\.priceNative, evidenceAge\)/,
-    'the divergence judgment is the pure, tested one');
+  // F-57 widened this contract: the judgment also carries WHERE the candidate
+  // came from, because an aggregator snapshot answers to a tighter band than
+  // a live feed does.
+  assert.match(content, /Q\.needsFillWitness\(chosen\.priceNative, evidence && evidence\.priceNative,\s*\n?\s*evidenceAge, chosen\.source\)/,
+    'the divergence judgment is the pure, tested one, and it knows the source');
+  assert.match(content, /if \(Q\.isAggregatorSource\(chosen\.source\)\) \{\s*\n\s*const obs = await R\.onchainQuote\(/,
+    'an aggregator candidate must be witnessed by the chain, never by the aggregator again');
   assert.match(content, /if \(Q\.witnessAgrees\(chosen\.priceNative, witnessNative\)\) return chosen;/,
     'only an agreeing witness lets a divergent candidate fill');
 });

--- a/extension/test/load.test.js
+++ b/extension/test/load.test.js
@@ -695,10 +695,16 @@ test('quoteForTrade prices a fresh screen at the price on screen (F-33 → F-52)
   const fnStart = contentSrc.indexOf('async function pickQuoteForTrade()');
   const block = contentSrc.slice(fnStart, contentSrc.indexOf('\n  }', fnStart) + 4);
 
-  assert.match(block, /const screenFresh = atClick && atClickAge <= ONCHAIN_SCREEN_CHECK_MAX_AGE_MS/,
+  assert.match(block, /const screenFresh = atClick\s*\n\s*&& atClickAge <= ONCHAIN_SCREEN_CHECK_MAX_AGE_MS/,
     'freshness is judged at click time, before any async hop');
   assert.match(contentSrc, /const ONCHAIN_SCREEN_CHECK_MAX_AGE_MS = 600/,
     'the fill-at-screen window must stay sub-second so a stale display never rides it');
+  // F-57: "fresh screen" must mean the SCREEN. atClickAge derives from
+  // lastPriceAt, which resolver adoptions also stamp — so age alone let a
+  // lagging aggregator quote take this path AS the on-screen price. The page
+  // feed having ticked is now a separate, required condition.
+  assert.match(block, /&& lastPageTickAt > 0\s*\n\s*&& clickAt - lastPageTickAt <= ONCHAIN_SCREEN_CHECK_MAX_AGE_MS/,
+    'the fast path requires the PAGE FEED to have ticked, not merely a fresh timestamp');
   const screenReturnAt = block.indexOf('if (screenFresh) return atClick');
   const chainHopAt = block.indexOf('await R.onchainQuote');
   assert.ok(screenReturnAt !== -1, 'a fresh screen must fill at the on-screen price, unconditionally');

--- a/extension/test/quietscreen.test.js
+++ b/extension/test/quietscreen.test.js
@@ -49,6 +49,12 @@ function bootLadder(env) {
     E: { fmt: (v) => String(v) },
     token: env.token,
     lastPriceAt: env.lastPriceAt,
+    // F-57: the ladder now separates "the page's own feed ticked" from
+    // "token.priceNative was written by somebody". These tests all model a
+    // chart-fed token, so unless a case says otherwise the page feed IS what
+    // moved — which is what keeps them exercising the F-52 path they were
+    // written for.
+    lastPageTickAt: env.lastPageTickAt !== undefined ? env.lastPageTickAt : env.lastPriceAt,
     pageQuoteSeq: 0,
     pageQuoteWaiters: new Set(),
     site: env.site || { id: 'lute' },


### PR DESCRIPTION
## What
Fixes F-57: a lagging aggregator quote could reach the fill path wearing a fresh timestamp and get taken for the on-screen price, skipping every cross-check on the way (field report: filled at 35k while the coin traded at 25k, no wick).

## Fix
- The fast path in `content.js` (`pickQuoteForTrade`) now requires the page's own feed to have actually ticked.
- An aggregator quote that disagrees with what the tab just accepted as money must be backed by the chain before it can price a fill (`quote.js` `needsFillWitness`).
- An unvouched quote is refused out loud instead of silently filling 40% high.

## Tests
- `test/fillprovenance.test.js` — regression for F-57
- `test/load.test.js` — ladder contract
- `test/fillwitness.test.js` — witness contract

See `DEFECTS.md` (F-57) and `CHANGELOG.md` for full details.