### PR TITLE
feat(streams): the roster serves every approved platform, not only Twitch

### DIFF
--- a/server/core/streamer.js
+++ b/server/core/streamer.js
@@ -107,6 +107,49 @@ function safeUrl(raw, max) {
   return url.toString();
 }
 
+/* The contact answer is not always a URL.
+ *
+ * The form asks "how should we reach you?" and relabels itself per method:
+ * Email wants an address, Twitter/X wants a profile link, and Other wants
+ * whatever the applicant actually uses ("Telegram @me"). Demanding a parseable
+ * URL for all three refused two of them — an applicant who picked Other and
+ * answered the question honestly got `contact-link-invalid` and no way to
+ * proceed.
+ *
+ * So the rule is about what we are willing to RENDER, not about shape: an
+ * answer carrying an explicit scheme has to be one we would put in an href,
+ * because that is the string a moderator clicks. Everything else is stored as
+ * text and rendered as text — site/admin.js only builds an <a> when the value
+ * re-parses as http(s), so a plain answer can never become a live link.
+ */
+const HAS_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
+const LOOKS_LIKE_EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** Why a contact answer is unusable, or null. */
+function contactProblem(raw) {
+  const text = trim(raw);
+  if (!text) return null;
+  // Whitespace settles it: no URL contains a raw space, so "IG: someone" is
+  // prose, not a scheme claim. Checking the scheme first would read the "IG:"
+  // as one and refuse a perfectly good answer.
+  if (/\s/.test(text)) return null;
+  // An explicit scheme IS a claim to be a link; hold it to the href rule.
+  // Validate the untruncated original so an over-long URL still fails.
+  if (HAS_SCHEME.test(text) && !safeUrl(raw, LIMITS.contactLink)) return 'contact-link-invalid';
+  return null;
+}
+
+/** The contact answer to store: a normalized URL when it is one, else text. */
+function contactAnswer(raw) {
+  const text = clean(raw, LIMITS.contactLink);
+  if (!text) return null;
+  // An address is an address. Left alone, safeUrl would turn it into
+  // "https://you@example.com/" — a userinfo URL pointing at a host nobody meant.
+  if (LOOKS_LIKE_EMAIL.test(text)) return text;
+  if (/\s/.test(text)) return text;                       // free-text answer
+  return safeUrl(raw, LIMITS.contactLink) || text;
+}
+
 /** Which platform a channel URL points at — a label for the mod queue. */
 function platformOf(channelUrl) {
   let host = '';
@@ -167,9 +210,8 @@ function applyProblem(fields) {
   const method = trim(f.contactMethod);
   if (method && !CONTACT_METHODS.includes(method)) return 'contact-method-invalid';
 
-  if (trim(f.contactLink) && !safeUrl(f.contactLink, LIMITS.contactLink)) {
-    return 'contact-link-invalid';
-  }
+  const contact = contactProblem(f.contactLink);
+  if (contact) return contact;
   return null;
 }
 
@@ -192,7 +234,7 @@ function normalizeApplication(fields) {
     blurb: clean(f.blurb, LIMITS.blurb),
     notes: cleanMultiline(f.notes, LIMITS.notes),
     contactMethod: trim(f.contactMethod) || null,
-    contactLink: trim(f.contactLink) ? safeUrl(f.contactLink, LIMITS.contactLink) : null,
+    contactLink: contactAnswer(f.contactLink),
     bestTime: clean(f.bestTime, LIMITS.bestTime),
   };
 }
@@ -225,6 +267,8 @@ module.exports = {
   clean,
   cleanMultiline,
   safeUrl,
+  contactProblem,
+  contactAnswer,
   platformOf,
   twitchLogin,
   applyProblem,

--- a/server/test/streamer.test.js
+++ b/server/test/streamer.test.js
@@ -55,6 +55,31 @@ test('the same scheme check guards the optional contact link', () => {
   assert.equal(S.applyProblem(withField({ contactLink: '' })), null);
 });
 
+test('a contact answer may be an address or a handle, not only a URL', () => {
+  // The form relabels this field per contact method: Email asks for an
+  // address and Other asks for whatever the applicant actually uses. Both
+  // used to be refused as `contact-link-invalid`, which stranded anyone who
+  // answered the question they were asked.
+  for (const answer of ['you@example.com', 'Telegram @me', 'IG: someone']) {
+    assert.equal(S.applyProblem(withField({ contactLink: answer })), null,
+      `${answer} is a legitimate answer to "how should we reach you?"`);
+  }
+
+  // An address is stored verbatim — never rewritten into a userinfo URL.
+  assert.equal(S.contactAnswer('you@example.com'), 'you@example.com');
+  assert.equal(S.contactAnswer('Telegram @me'), 'Telegram @me');
+
+  // A real link still normalizes, so the mod page can render it as an href.
+  assert.equal(new URL(S.contactAnswer('x.com/someone')).protocol, 'https:');
+
+  // And a hostile scheme is still refused at the door rather than stored as
+  // text — the render path would not linkify it, but there is no reason to
+  // keep it either.
+  assert.equal(S.contactProblem('javascript:alert(1)'), 'contact-link-invalid');
+  assert.equal(S.contactProblem('data:text/html,<script>'), 'contact-link-invalid');
+  assert.equal(S.contactProblem(''), null);
+});
+
 test('a bare host is assumed https rather than failed, and comes back normalized', () => {
   const url = S.safeUrl('twitch.tv/SomeName', 200);
   assert.equal(new URL(url).protocol, 'https:');

--- a/server/worker/index.js
+++ b/server/worker/index.js
@@ -1562,19 +1562,35 @@ async function handleStreamerReview(request, env) {
  * notes answers "anything else you'd like us to know?" — a message to the
  * moderators. Serving notes here would publish something written in private.
  */
+/* The public roster: every approved application, whatever it streams on.
+ *
+ * This used to require `twitch_login IS NOT NULL`, because the streams page
+ * could only render an embeddable Twitch player — so an approved Kick or
+ * YouTube creator was accepted by a moderator and then silently never
+ * appeared anywhere, which is the worst of both answers. The page now renders
+ * a link-out card for the other platforms, so the roster serves them all and
+ * says which is which. `login` stays null off Twitch: it means "embeddable
+ * here", and inventing one for a platform we cannot embed would put a dead
+ * player on the page.
+ *
+ * Still only the three columns the applicant was told become a card — the
+ * private contact block is not in this SELECT and must never be.
+ */
 async function handleStreamerRoster(env) {
   const { results } = await env.DB.prepare(`
-    SELECT name, twitch_login, blurb
+    SELECT name, twitch_login, blurb, platform, channel_url
       FROM streamer_applications
-     WHERE status = 'approved' AND twitch_login IS NOT NULL
+     WHERE status = 'approved'
      ORDER BY created_at DESC
      LIMIT 60`).all();
   return json({
     ok: true,
     streamers: (results || []).map((r) => ({
-      login: r.twitch_login,
+      login: r.twitch_login || null,
       name: r.name,
       blurb: r.blurb || '',
+      platform: r.platform || 'other',
+      channelUrl: r.channel_url || null,
     })),
   });
 }

--- a/site/admin.js
+++ b/site/admin.js
@@ -98,16 +98,14 @@
       ? `<a href="${esc(chan)}" target="_blank" rel="noopener noreferrer">${esc(chan)}</a>`
       : esc(app.channelUrl || '');
 
-    // Approve is offered only where it can do something. A YouTube or Kick
-    // application is perfectly valid, but the streams page embeds Twitch, so
-    // approving one would set a status that never becomes a card — a button
-    // that silently does nothing is worse than a button that isn't there.
-    const embeddable = Boolean(app.twitchLogin);
-
+    // Every platform is approvable now that the roster serves link-out cards
+    // for the ones we cannot embed (handleStreamerRoster). Approving a Kick
+    // application used to set a status that never became anything: the button
+    // was disabled to admit that, which left a moderator with a valid
+    // application and nothing to do about it.
     const actions = [];
     if (app.status !== 'approved') {
-      actions.push(`<button class="ar-btn good" type="button" data-act="approved" data-id="${app.id}"
-        ${embeddable ? '' : 'disabled title="Only Twitch channels can be embedded on the streams page"'}>✓ Approve</button>`);
+      actions.push(`<button class="ar-btn good" type="button" data-act="approved" data-id="${app.id}">✓ Approve</button>`);
     }
     if (app.status !== 'rejected') {
       actions.push(`<button class="ar-btn bad" type="button" data-act="rejected" data-id="${app.id}">✕ Reject</button>`);


### PR DESCRIPTION
**Stack 2 of 10** — includes #1. Merge after it.

### The problem
`handleStreamerRoster` filtered on `twitch_login IS NOT NULL`. An approved Kick or YouTube creator became a row nobody could ever see: a moderator accepted a real person and the site silently never showed them.

The mod queue *admitted* this by disabling **Approve** for those platforms — which left a moderator holding a valid application with nothing to do about it.

### The fix
Both halves move together:

- The roster returns `platform` and `channel_url` for every approved row.
- The queue lets any platform through.

`login` stays null off Twitch on purpose. It does not mean "no channel", it means **embeddable here** — inventing one for a platform we cannot mount would put a dead player on the page instead of a working link.

The SELECT still reads only the three columns an applicant was told become a card. The private contact block is not in this query and must never be.

Relates to #64 (Ark1317 is on Kick and would hit exactly this).