### PR TITLE
docs(streams): the runbook catches up with multi-platform and moderation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,30 @@
 Stream-style log of what shipped, newest first. User-facing wording; the gory
 details live in the commit messages.
 
+## Unreleased
+
+- **Streamers on Kick and YouTube can actually be featured.** The roster only
+  ever served Twitch, so a moderator could approve a Kick creator and the site
+  would silently never show them. Every approved platform now gets a card:
+  Twitch plays inline, the rest link out and are drawn as links rather than
+  imitating a player that will not open.
+- **The watch page claims less and shows more.** "Verified records" and
+  "giveaways" are replaced by the three checks a record actually passes, with
+  a panel stating what those checks do *not* cover. The live pill no longer
+  glows red at an empty roster, live channels sort to the top, and every card
+  links to its channel without going through the player first.
+- **The streamer form says what happens to an application.** It led with
+  PUBLISHED over the first question, which is the opposite of the truth —
+  nothing is published until a moderator approves it. It now says so, shows a
+  live preview of the card that would be built, picks up the domain from a
+  platform dropdown instead of asking you to type it, and asks for the contact
+  detail that matches the method you chose. Answering "Other" honestly used to
+  be rejected outright.
+- **Moderators can act without deleting anyone.** A new console bans an
+  account, takes a single record off the boards, or disbands a clan — each
+  reversible, each requiring a written reason, all of it in an append-only
+  ledger. The application queue triages at a glance and opens in full on click.
+
 ## v3.13.3 — 2026-08-22
 
 **Twelve quality-of-life upgrades from the community wave.** The overlay

--- a/docs/STREAMS.md
+++ b/docs/STREAMS.md
@@ -50,17 +50,24 @@ Routes on the Worker:
 ### Day-to-day approval
 
 Open `/admin` and sign in with an allowlisted X account. Pending applications
-are listed newest first, with **Approve** / **Reject** on each. Approving a
-Twitch application publishes its card on the streams page within ~60 s (the
-edge cache window). **Move back to pending** undoes a decision.
+are listed newest first as summary rows — name, channel, platform, viewer
+bucket, age — and expand on click into the full record: what would be
+published (including a preview of the card itself), the private contact block,
+and the applicant's message to the mod team. **Approve** / **Reject** sit on
+each row, and **Move back to pending** undoes a decision. An approval publishes
+the card within ~60 s (the edge cache window).
 
 Rules the pipeline applies:
 
+- **Every platform can be approved.** Twitch channels are embedded and play
+  inline; Kick, YouTube and anything else get a roster card that links out.
+  This used to be Twitch-only — `handleStreamerRoster` filtered on
+  `twitch_login IS NOT NULL`, so an approved Kick creator became a row nobody
+  could see, and the queue admitted it by disabling Approve for them.
 - Twitch logins are normalized (`https://twitch.tv/Name?x=1` → `name`) by the
-  same rule `streams.js` uses; an application whose URL can't be normalized to
-  a valid login is stored but **cannot be approved** — the streams page embeds
-  Twitch, so approving it would set a status that never becomes a card. The
-  Approve button is disabled on those, with a tooltip saying why.
+  same rule `streams.js` uses. A URL that cannot be normalized to a valid
+  login is still approvable — it simply becomes a link-out card rather than a
+  player, and `login` stays null to say so.
 - Duplicate logins are deduped and `STREAMERS` entries win, same as before.
 - One application per channel URL may sit in the queue at a time (a partial
   unique index). A rejected applicant can reapply later.
@@ -74,7 +81,7 @@ enforced in the SQL rather than in a convention:
 
 | Published on approval | Never leaves the mod queue |
 | --- | --- |
-| Creator name, channel URL, Twitch login, the one-line blurb | Discord username, viewer count, contact method, profile link, best time to reach, and the free-text notes |
+| Creator name, channel URL, platform, Twitch login, the one-line blurb | Discord username, viewer count, contact method, contact answer, best time to reach, and the free-text notes |
 
 The one that matters is **blurb vs. notes**. "One line about your stream" says
 it will be shown publicly and is the roster card's text. "Anything else you'd
@@ -97,9 +104,26 @@ show, then set `ROSTER_CSV_URL` back to `''` and unpublish the sheet.
 No Twitch API key: the page checks Twitch's public preview CDN. A live
 channel's `live_user_<login>` thumbnail resolves; an offline one redirects to
 the `404_preview` image. Checked every 60 s. If Twitch ever changes this, the
-page degrades to showing no badges — never wrong ones. The featured player
-auto-promotes the first live streamer unless the viewer clicked a specific one
-(or arrived via `/streams?channel=<login>`).
+page degrades to showing no badges — never wrong ones.
+
+**This is a Twitch-only signal**, so non-Twitch cards show their platform name
+where the badge would be rather than a guessed status, and `refreshLive` does
+not query the CDN for them at all — a Kick login asked of Twitch's CDN answers
+about a Twitch channel that happens to share the name.
+
+### Card order
+
+Live first, then playable-but-offline, then link-out, then by name so two
+loads of the board never disagree. The featured player takes the first live
+channel from that same order unless the viewer clicked one (or arrived via
+`/streams?channel=<login>`) — which means a single live streamer is always the
+one in the player.
+
+There is deliberately **no viewer-count sort**. The preview-CDN signal reports
+whether a channel is up and nothing else, so ranking by viewers would mean
+inventing a number. Real counts need Twitch API credentials
+(`TWITCH_CLIENT_ID` / secret → Helix `GET /streams`); until those exist,
+live-first is the honest ordering.
 
 ## Stream overlay (what streamers use)
 
@@ -128,3 +152,30 @@ Until then, a season can run manually: approved streamers submit their chain
 export at season close, chains are verified offline, winners announced on
 stream. Keep prize copy on the page vague-but-true (it currently says prizes
 are "announced on the streams").
+
+## Moderation console (`/admin-mod`)
+
+Behind the same `ADMIN_X_IDS` gate as the queue. Three reversible switches,
+each requiring a written reason, each recorded in an append-only ledger shown
+on the page:
+
+| Switch | Column | Effect |
+|---|---|---|
+| Ban account | `users.banned_at` | Sign-in refused (checked in `sessionUser`, so it holds on every route); record drops off every board. Bumps `session_epoch`, so live sessions end on the next request. |
+| Disqualify record | `records.dq_at` | The record stops ranking. The account is untouched. |
+| Disband clan | `clans.disbanded_at` | The clan stops appearing; membership rows are kept, so restoring puts the roster back exactly as it was. |
+
+Ban and disqualify are separate deliberately: collapsed into one flag, taking a
+duplicate chain off the board would require banning its owner.
+
+Enforcement is in SQL on the leaderboard and Sprint queries, not in the page —
+there is no board, cache or export that can still be showing a banned account.
+
+**Not available, on purpose:** delete, score editing, chain rewriting, and any
+way to add a moderator. Moderators stay a deploy-time decision in
+`ADMIN_X_IDS` — a console that can promote its own users only has to be
+breached once.
+
+The columns are added by the ALTERs in `server/DEPLOY.md`, which must run
+**before** the Worker is deployed: SQLite fails a query naming a column that
+does not exist, and both the session lookup and the leaderboard name these.

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -130,10 +130,11 @@ echo "profile control OK (slot + script on every page)"
 # page never appeared in results. So the exclusions are enumerated HERE rather
 # than left implicit — adding a page forces a decision about it.
 #
-#   admin            noindex — moderator queue
+#   admin            noindex — streamer queue
+#   admin-mod        noindex — accounts & boards console
 #   clan/duel/profile parameterised; without a query string they are empty states
 #   404              error page
-SITEMAP_SKIP="admin clan duel profile 404"
+SITEMAP_SKIP="admin admin-mod clan duel profile 404"
 SITEMAP_MISSING=""
 for page in site/*.html; do
   slug=$(basename "$page" .html)

--- a/server/DEPLOY.md
+++ b/server/DEPLOY.md
@@ -31,6 +31,20 @@ re-run of the idempotent schema:
 npx wrangler d1 execute papertrench --remote --file=schema.sql
 ```
 
+**Moderation adds one table** (`moderation_log`, created by the schema re-run
+above) **and eight columns**, which the schema cannot add for you.
+
+> **Run this BEFORE deploying the Worker version that contains it.** SQLite
+> fails any query naming a column that does not exist, and both the session
+> lookup and the leaderboard name these — so a Worker deployed ahead of the
+> migration takes sign-in and the board down until the migration lands. One
+> command, then deploy:
+
+```bash
+npx wrangler d1 execute papertrench --remote \
+  --command "ALTER TABLE users ADD COLUMN banned_at INTEGER; ALTER TABLE users ADD COLUMN banned_reason TEXT; ALTER TABLE users ADD COLUMN banned_by INTEGER; ALTER TABLE records ADD COLUMN dq_at INTEGER; ALTER TABLE records ADD COLUMN dq_reason TEXT; ALTER TABLE records ADD COLUMN dq_by INTEGER; ALTER TABLE clans ADD COLUMN disbanded_at INTEGER; ALTER TABLE clans ADD COLUMN disbanded_reason TEXT"
+```
+
 > **Run this BEFORE `wrangler deploy`, not after.** The `[TAG]` chip on the
 > leaderboard and Sprint comes from a `LEFT JOIN clan_members` inside those
 > boards' own queries, and SQLite fails a statement that names a missing table

--- a/server/core/streamer.js
+++ b/server/core/streamer.js
@@ -107,6 +107,49 @@ function safeUrl(raw, max) {
   return url.toString();
 }
 
+/* The contact answer is not always a URL.
+ *
+ * The form asks "how should we reach you?" and relabels itself per method:
+ * Email wants an address, Twitter/X wants a profile link, and Other wants
+ * whatever the applicant actually uses ("Telegram @me"). Demanding a parseable
+ * URL for all three refused two of them — an applicant who picked Other and
+ * answered the question honestly got `contact-link-invalid` and no way to
+ * proceed.
+ *
+ * So the rule is about what we are willing to RENDER, not about shape: an
+ * answer carrying an explicit scheme has to be one we would put in an href,
+ * because that is the string a moderator clicks. Everything else is stored as
+ * text and rendered as text — site/admin.js only builds an <a> when the value
+ * re-parses as http(s), so a plain answer can never become a live link.
+ */
+const HAS_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
+const LOOKS_LIKE_EMAIL = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** Why a contact answer is unusable, or null. */
+function contactProblem(raw) {
+  const text = trim(raw);
+  if (!text) return null;
+  // Whitespace settles it: no URL contains a raw space, so "IG: someone" is
+  // prose, not a scheme claim. Checking the scheme first would read the "IG:"
+  // as one and refuse a perfectly good answer.
+  if (/\s/.test(text)) return null;
+  // An explicit scheme IS a claim to be a link; hold it to the href rule.
+  // Validate the untruncated original so an over-long URL still fails.
+  if (HAS_SCHEME.test(text) && !safeUrl(raw, LIMITS.contactLink)) return 'contact-link-invalid';
+  return null;
+}
+
+/** The contact answer to store: a normalized URL when it is one, else text. */
+function contactAnswer(raw) {
+  const text = clean(raw, LIMITS.contactLink);
+  if (!text) return null;
+  // An address is an address. Left alone, safeUrl would turn it into
+  // "https://you@example.com/" — a userinfo URL pointing at a host nobody meant.
+  if (LOOKS_LIKE_EMAIL.test(text)) return text;
+  if (/\s/.test(text)) return text;                       // free-text answer
+  return safeUrl(raw, LIMITS.contactLink) || text;
+}
+
 /** Which platform a channel URL points at — a label for the mod queue. */
 function platformOf(channelUrl) {
   let host = '';
@@ -167,9 +210,8 @@ function applyProblem(fields) {
   const method = trim(f.contactMethod);
   if (method && !CONTACT_METHODS.includes(method)) return 'contact-method-invalid';
 
-  if (trim(f.contactLink) && !safeUrl(f.contactLink, LIMITS.contactLink)) {
-    return 'contact-link-invalid';
-  }
+  const contact = contactProblem(f.contactLink);
+  if (contact) return contact;
   return null;
 }
 
@@ -192,7 +234,7 @@ function normalizeApplication(fields) {
     blurb: clean(f.blurb, LIMITS.blurb),
     notes: cleanMultiline(f.notes, LIMITS.notes),
     contactMethod: trim(f.contactMethod) || null,
-    contactLink: trim(f.contactLink) ? safeUrl(f.contactLink, LIMITS.contactLink) : null,
+    contactLink: contactAnswer(f.contactLink),
     bestTime: clean(f.bestTime, LIMITS.bestTime),
   };
 }
@@ -225,6 +267,8 @@ module.exports = {
   clean,
   cleanMultiline,
   safeUrl,
+  contactProblem,
+  contactAnswer,
   platformOf,
   twitchLogin,
   applyProblem,

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -248,3 +248,45 @@ CREATE INDEX IF NOT EXISTS idx_streamer_applications_status
 CREATE UNIQUE INDEX IF NOT EXISTS idx_streamer_applications_open_channel
   ON streamer_applications(channel_url)
   WHERE status IN ('pending', 'approved');
+
+-- ---------------------------------------------------------------- moderation
+--
+-- Two reversible switches and a ledger. Deliberately NOT a deletion tool: a
+-- moderator needs to stop a bad record counting, and needs it undoable, but
+-- nothing here removes a user's data or rewrites their chain.
+--
+-- The switches live as COLUMNS on users and records (added by the ALTERs in
+-- DEPLOY.md, since this file is re-run against live databases and ADD COLUMN
+-- is not idempotent):
+--
+--   users.banned_at / banned_reason / banned_by
+--       the ACCOUNT is closed — sign-in refused, record off every board.
+--   records.dq_at / dq_reason / dq_by
+--       the RECORD does not rank, but the account is fine. For a chain that
+--       is wrong rather than a person who is a problem.
+--   clans.disbanded_at / disbanded_reason
+--       the clan stops appearing; the roster stays readable.
+--
+-- Keeping ban and disqualify separate matters: collapsing them would force a
+-- moderator to ban somebody in order to take a bad chain off the board, which
+-- is a much bigger statement than the situation usually deserves.
+--
+-- The ledger is a real table, so it is created here.
+CREATE TABLE IF NOT EXISTS moderation_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  actor_id INTEGER NOT NULL REFERENCES users(id),  -- the moderator
+  action TEXT NOT NULL,             -- user.ban | user.unban | record.disqualify
+                                    -- record.reinstate | clan.disband | clan.restore
+  target_kind TEXT NOT NULL,        -- user | record | clan
+  target_id INTEGER NOT NULL,
+  target_label TEXT,                -- handle or [TAG] at the time, for reading
+  reason TEXT NOT NULL,             -- mandatory at the route; never empty here
+  created_at INTEGER NOT NULL
+);
+
+-- A moderation tool without a ledger is an invitation to argue about what
+-- happened; with one, "who took this off the board and why" is a query.
+CREATE INDEX IF NOT EXISTS idx_moderation_log_recent
+  ON moderation_log(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_moderation_log_target
+  ON moderation_log(target_kind, target_id, created_at DESC);

--- a/server/test/streamer.test.js
+++ b/server/test/streamer.test.js
@@ -55,6 +55,31 @@ test('the same scheme check guards the optional contact link', () => {
   assert.equal(S.applyProblem(withField({ contactLink: '' })), null);
 });
 
+test('a contact answer may be an address or a handle, not only a URL', () => {
+  // The form relabels this field per contact method: Email asks for an
+  // address and Other asks for whatever the applicant actually uses. Both
+  // used to be refused as `contact-link-invalid`, which stranded anyone who
+  // answered the question they were asked.
+  for (const answer of ['you@example.com', 'Telegram @me', 'IG: someone']) {
+    assert.equal(S.applyProblem(withField({ contactLink: answer })), null,
+      `${answer} is a legitimate answer to "how should we reach you?"`);
+  }
+
+  // An address is stored verbatim — never rewritten into a userinfo URL.
+  assert.equal(S.contactAnswer('you@example.com'), 'you@example.com');
+  assert.equal(S.contactAnswer('Telegram @me'), 'Telegram @me');
+
+  // A real link still normalizes, so the mod page can render it as an href.
+  assert.equal(new URL(S.contactAnswer('x.com/someone')).protocol, 'https:');
+
+  // And a hostile scheme is still refused at the door rather than stored as
+  // text — the render path would not linkify it, but there is no reason to
+  // keep it either.
+  assert.equal(S.contactProblem('javascript:alert(1)'), 'contact-link-invalid');
+  assert.equal(S.contactProblem('data:text/html,<script>'), 'contact-link-invalid');
+  assert.equal(S.contactProblem(''), null);
+});
+
 test('a bare host is assumed https rather than failed, and comes back normalized', () => {
   const url = S.safeUrl('twitch.tv/SomeName', 200);
   assert.equal(new URL(url).protocol, 'https:');

--- a/server/worker/auth.js
+++ b/server/worker/auth.js
@@ -112,9 +112,19 @@ async function sessionUser(request, env) {
   const session = await verifyPayload(env.SESSION_SECRET, token);
   if (!session || !session.uid || session.exp < Date.now()) return null;
   const user = await env.DB.prepare(
-    'SELECT id, x_id, handle, display_name, avatar_url, session_epoch FROM users WHERE id = ?')
+    'SELECT id, x_id, handle, display_name, avatar_url, session_epoch, banned_at FROM users WHERE id = ?')
     .bind(session.uid).first();
   if (!user || user.session_epoch !== session.epoch) return null;
+  // A banned account has no session, on any route. Enforcing it here rather
+  // than per-endpoint means a ban cannot be defeated by finding a handler
+  // somebody forgot to guard — including one written after the ban feature.
+  //
+  // `banned_at` is added by the ALTERs in DEPLOY.md and this SELECT names it,
+  // so the migration has to run BEFORE this Worker is deployed. That ordering
+  // is the deliberate trade: a missing column fails loudly at deploy time,
+  // where it is fixed in one command, rather than silently letting every
+  // banned account keep its session.
+  if (user.banned_at) return null;
   return user;
 }
 

--- a/server/worker/index.js
+++ b/server/worker/index.js
@@ -391,6 +391,17 @@ async function handleLeaderboard(env) {
     -- labeled — they simply do not take a position on the board.
     WHERE r.status = 'verified'
       AND json_extract(r.stats_json, '$.rankable')
+      -- Moderation, applied where the ranking happens rather than in the page.
+      -- A banned account and a disqualified record both stop counting here, so
+      -- there is no board, cache or export that can still be showing them.
+      --
+      -- These columns are added by the ALTERs in DEPLOY.md, which must be run
+      -- BEFORE this version of the Worker is deployed: SQLite fails a query
+      -- naming a column that does not exist, so a deploy that runs ahead of
+      -- the migration takes the board down rather than degrading. COALESCE
+      -- here is about the NULL that means "never actioned", nothing else.
+      AND COALESCE(u.banned_at, 0) = 0
+      AND COALESCE(r.dq_at, 0) = 0
     -- The ORDER decides WHO makes the cut, so it must be the ranking order
     -- (DEFECT L-05): the old ORDER BY submitted_at DESC LIMIT 500 selected
     -- the five hundred most RECENT records and only then sorted by score —
@@ -441,7 +452,12 @@ async function handleSprint(env) {
     LEFT JOIN clans cl ON cl.id = cm.clan_id
     -- Same rule as the season board: a week's slice of an unverified record
     -- is still an unverified record.
+    -- ...and a banned account or disqualified record is off this board too,
+    -- or a moderator would have to remember that the Sprint is a second place
+    -- the same name can still be showing.
     WHERE s.week_id = ? AND s.rounds > 0 AND r.status = 'verified'
+      AND COALESCE(u.banned_at, 0) = 0
+      AND COALESCE(r.dq_at, 0) = 0
     -- Deterministic ties, same doctrine as the season board (DEFECT L-05):
     -- the earlier entry keeps the rank, then handle as the fixed final key.
     ORDER BY s.score DESC, s.updated_at ASC, u.handle ASC LIMIT 200`)
@@ -1595,6 +1611,258 @@ async function handleStreamerRoster(env) {
   });
 }
 
+/* ---------------- moderation ----------------
+ *
+ * Everything here is behind the same `moderator()` gate as the streamer queue,
+ * and every route is deliberately small. A moderator can:
+ *
+ *   - look up an account and read its record, clan and moderation history
+ *   - ban / unban an account
+ *   - disqualify / reinstate a RECORD without touching the account
+ *   - disband / restore a clan
+ *
+ * and nothing else. There is no delete, no score edit, no chain rewrite, no
+ * way to promote another moderator — that stays a deploy-time decision in
+ * ADMIN_X_IDS. The powers that exist are the ones that are reversible, and
+ * every one of them writes a moderation_log row with a mandatory reason.
+ *
+ * Reasons are required rather than encouraged: an unexplained ban is
+ * indistinguishable from a mistake three weeks later, including to the
+ * moderator who made it.
+ */
+
+/** Record one moderator action. Reason is pre-validated by the caller. */
+function logModeration(env, actor, action, kind, id, label, reason) {
+  return env.DB.prepare(`
+    INSERT INTO moderation_log
+      (actor_id, action, target_kind, target_id, target_label, reason, created_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)`)
+    .bind(actor.id, action, kind, id, label || null, reason, Date.now())
+    .run();
+}
+
+/** The reason string, or null when it is not usable. */
+function moderationReason(raw) {
+  const text = String(raw == null ? '' : raw).replace(/\s+/g, ' ').trim();
+  return text.length >= 3 ? text.slice(0, 500) : null;
+}
+
+/** Accounts, newest first, optionally filtered by handle or X id. */
+async function handleAdminUsers(request, env) {
+  const mod = await moderator(request, env);
+  if (!mod) return json({ ok: false, reason: 'not-a-moderator' }, 403);
+
+  const term = (new URL(request.url).searchParams.get('q') || '').trim().toLowerCase();
+  const like = '%' + term.replace(/[%_]/g, '') + '%';
+  const rows = await env.DB.prepare(`
+    SELECT u.id, u.handle, u.display_name, u.x_id, u.avatar_url,
+           u.created_at, u.last_login_at, u.banned_at, u.banned_reason,
+           r.status AS record_status, r.chain_len, r.stats_json, r.dq_at, r.dq_reason,
+           cl.tag AS clan_tag
+      FROM users u
+      LEFT JOIN records r ON r.user_id = u.id
+      LEFT JOIN clan_members cm ON cm.user_id = u.id
+      LEFT JOIN clans cl ON cl.id = cm.clan_id
+     WHERE (?1 = '' OR LOWER(u.handle) LIKE ?2 OR u.x_id LIKE ?2)
+     ORDER BY u.last_login_at DESC
+     LIMIT 100`).bind(term, like).all();
+
+  return json({
+    ok: true,
+    users: (rows.results || []).map((r) => {
+      const stats = r.stats_json ? JSON.parse(r.stats_json) : null;
+      return {
+        id: r.id, handle: r.handle, displayName: r.display_name, xId: r.x_id,
+        avatarUrl: r.avatar_url, joinedAt: r.created_at, lastLoginAt: r.last_login_at,
+        banned: Boolean(r.banned_at), bannedReason: r.banned_reason || null,
+        clanTag: r.clan_tag || null,
+        recordStatus: r.record_status || null, chainLen: r.chain_len || 0,
+        rounds: stats ? stats.rounds : 0,
+        score: stats ? stats.score : null,
+        rankable: stats ? Boolean(stats.rankable) : false,
+        disqualified: Boolean(r.dq_at), dqReason: r.dq_reason || null,
+      };
+    }),
+  });
+}
+
+/** One account in full, plus everything a moderator has ever done to it. */
+async function handleAdminUser(request, env) {
+  const mod = await moderator(request, env);
+  if (!mod) return json({ ok: false, reason: 'not-a-moderator' }, 403);
+
+  const handle = (new URL(request.url).searchParams.get('handle') || '').trim();
+  if (!handle) return json({ ok: false, reason: 'handle-required' }, 422);
+
+  const row = await env.DB.prepare(`
+    SELECT u.id, u.handle, u.display_name, u.x_id, u.avatar_url,
+           u.created_at, u.last_login_at, u.banned_at, u.banned_reason,
+           r.status AS record_status, r.chain_len, r.starting_sol, r.stats_json,
+           r.pricing_json, r.submitted_at, r.verified_at, r.dq_at, r.dq_reason,
+           cl.tag AS clan_tag, cl.name AS clan_name, cm.role AS clan_role
+      FROM users u
+      LEFT JOIN records r ON r.user_id = u.id
+      LEFT JOIN clan_members cm ON cm.user_id = u.id
+      LEFT JOIN clans cl ON cl.id = cm.clan_id
+     WHERE u.handle = ? COLLATE NOCASE`).bind(handle).first();
+  if (!row) return json({ ok: false, reason: 'not-found' }, 404);
+
+  const log = await env.DB.prepare(`
+    SELECT m.action, m.reason, m.created_at, m.target_label, a.handle AS actor
+      FROM moderation_log m LEFT JOIN users a ON a.id = m.actor_id
+     WHERE (m.target_kind = 'user' AND m.target_id = ?1)
+        OR (m.target_kind = 'record' AND m.target_id = ?1)
+     ORDER BY m.created_at DESC LIMIT 50`).bind(row.id).all();
+
+  return json({
+    ok: true,
+    user: {
+      id: row.id, handle: row.handle, displayName: row.display_name, xId: row.x_id,
+      avatarUrl: row.avatar_url, joinedAt: row.created_at, lastLoginAt: row.last_login_at,
+      banned: Boolean(row.banned_at), bannedAt: row.banned_at, bannedReason: row.banned_reason,
+      clanTag: row.clan_tag, clanName: row.clan_name, clanRole: row.clan_role,
+      recordStatus: row.record_status, chainLen: row.chain_len,
+      startingSol: row.starting_sol,
+      stats: row.stats_json ? JSON.parse(row.stats_json) : null,
+      pricing: row.pricing_json ? JSON.parse(row.pricing_json) : null,
+      submittedAt: row.submitted_at, verifiedAt: row.verified_at,
+      disqualified: Boolean(row.dq_at), dqAt: row.dq_at, dqReason: row.dq_reason,
+    },
+    log: (log.results || []).map((l) => ({
+      action: l.action, reason: l.reason, at: l.created_at, actor: l.actor || 'a moderator',
+    })),
+  });
+}
+
+/** Close or reopen an account. */
+async function handleAdminBan(request, env) {
+  const mod = await moderator(request, env);
+  if (!mod) return json({ ok: false, reason: 'not-a-moderator' }, 403);
+
+  let body = {};
+  try { body = await request.json(); } catch {}
+  const target = await env.DB.prepare('SELECT id, handle FROM users WHERE id = ?')
+    .bind(Number(body.userId)).first();
+  if (!target) return json({ ok: false, reason: 'not-found' }, 404);
+  // A moderator cannot ban themselves out of the room they are standing in.
+  if (target.id === mod.id) return json({ ok: false, reason: 'cannot-ban-self' }, 422);
+
+  const banning = Boolean(body.banned);
+  const reason = moderationReason(body.reason);
+  if (!reason) return json({ ok: false, reason: 'reason-required' }, 422);
+
+  await env.DB.batch([
+    env.DB.prepare(`
+      UPDATE users SET banned_at = ?, banned_reason = ?, banned_by = ?,
+                       session_epoch = session_epoch + ?
+       WHERE id = ?`)
+      // Bumping session_epoch revokes every live session for this account, so
+      // a ban takes effect on the next request rather than whenever their
+      // current token happens to expire.
+      .bind(banning ? Date.now() : null, banning ? reason : null,
+        banning ? mod.id : null, banning ? 1 : 0, target.id),
+  ]);
+  await logModeration(env, mod, banning ? 'user.ban' : 'user.unban',
+    'user', target.id, target.handle, reason);
+
+  return json({ ok: true });
+}
+
+/** Take a record off the boards, or put it back. The account is untouched. */
+async function handleAdminDisqualify(request, env) {
+  const mod = await moderator(request, env);
+  if (!mod) return json({ ok: false, reason: 'not-a-moderator' }, 403);
+
+  let body = {};
+  try { body = await request.json(); } catch {}
+  const target = await env.DB.prepare(`
+    SELECT u.id, u.handle FROM users u
+      JOIN records r ON r.user_id = u.id
+     WHERE u.id = ?`).bind(Number(body.userId)).first();
+  if (!target) return json({ ok: false, reason: 'no-record' }, 404);
+
+  const dq = Boolean(body.disqualified);
+  const reason = moderationReason(body.reason);
+  if (!reason) return json({ ok: false, reason: 'reason-required' }, 422);
+
+  await env.DB.prepare(`
+    UPDATE records SET dq_at = ?, dq_reason = ?, dq_by = ? WHERE user_id = ?`)
+    .bind(dq ? Date.now() : null, dq ? reason : null, dq ? mod.id : null, target.id)
+    .run();
+  await logModeration(env, mod, dq ? 'record.disqualify' : 'record.reinstate',
+    'record', target.id, target.handle, reason);
+
+  return json({ ok: true });
+}
+
+/** Clans, with size and standing. */
+async function handleAdminClans(request, env) {
+  const mod = await moderator(request, env);
+  if (!mod) return json({ ok: false, reason: 'not-a-moderator' }, 403);
+
+  const rows = await env.DB.prepare(`
+    SELECT c.id, c.tag, c.name, c.motto, c.open, c.created_at,
+           c.disbanded_at, c.disbanded_reason,
+           f.handle AS founder,
+           (SELECT COUNT(*) FROM clan_members m WHERE m.clan_id = c.id) AS members
+      FROM clans c LEFT JOIN users f ON f.id = c.founder_id
+     ORDER BY c.created_at DESC LIMIT 200`).all();
+
+  return json({
+    ok: true,
+    clans: (rows.results || []).map((c) => ({
+      id: c.id, tag: c.tag, name: c.name, motto: c.motto || '',
+      open: Boolean(c.open), createdAt: c.created_at, founder: c.founder || null,
+      members: c.members || 0,
+      disbanded: Boolean(c.disbanded_at), disbandedReason: c.disbanded_reason || null,
+    })),
+  });
+}
+
+/** Disband a clan, or restore one. Membership rows are left intact. */
+async function handleAdminClanDisband(request, env) {
+  const mod = await moderator(request, env);
+  if (!mod) return json({ ok: false, reason: 'not-a-moderator' }, 403);
+
+  let body = {};
+  try { body = await request.json(); } catch {}
+  const clanRow = await env.DB.prepare('SELECT id, tag FROM clans WHERE id = ?')
+    .bind(Number(body.clanId)).first();
+  if (!clanRow) return json({ ok: false, reason: 'not-found' }, 404);
+
+  const off = body.disbanded === undefined ? true : Boolean(body.disbanded);
+  const reason = moderationReason(body.reason);
+  if (!reason) return json({ ok: false, reason: 'reason-required' }, 422);
+
+  await env.DB.prepare(
+    'UPDATE clans SET disbanded_at = ?, disbanded_reason = ? WHERE id = ?')
+    .bind(off ? Date.now() : null, off ? reason : null, clanRow.id).run();
+  await logModeration(env, mod, off ? 'clan.disband' : 'clan.restore',
+    'clan', clanRow.id, '[' + clanRow.tag + ']', reason);
+
+  return json({ ok: true });
+}
+
+/** The whole ledger, newest first. */
+async function handleAdminLog(request, env) {
+  const mod = await moderator(request, env);
+  if (!mod) return json({ ok: false, reason: 'not-a-moderator' }, 403);
+
+  const rows = await env.DB.prepare(`
+    SELECT m.action, m.target_kind, m.target_label, m.reason, m.created_at,
+           a.handle AS actor
+      FROM moderation_log m LEFT JOIN users a ON a.id = m.actor_id
+     ORDER BY m.created_at DESC LIMIT 100`).all();
+
+  return json({
+    ok: true,
+    log: (rows.results || []).map((l) => ({
+      action: l.action, kind: l.target_kind, target: l.target_label,
+      reason: l.reason, at: l.created_at, actor: l.actor || 'a moderator',
+    })),
+  });
+}
+
 /* ---------------- entry ---------------- */
 
 export default {
@@ -1718,6 +1986,21 @@ export default {
       }
       else if (path === '/api/streamer/roster') {
         response = await edgeCached(request, ctx, BOARD_CACHE_SEC, () => handleStreamerRoster(env));
+      }
+      // Moderation. Every one of these re-checks `moderator()` itself — the
+      // routing table is not the gate, the handler is.
+      else if (path === '/api/admin/users') response = await handleAdminUsers(request, env);
+      else if (path === '/api/admin/user') response = await handleAdminUser(request, env);
+      else if (path === '/api/admin/log') response = await handleAdminLog(request, env);
+      else if (path === '/api/admin/clans') response = await handleAdminClans(request, env);
+      else if (path === '/api/admin/user/ban' && request.method === 'POST') {
+        response = await handleAdminBan(request, env);
+      }
+      else if (path === '/api/admin/record/disqualify' && request.method === 'POST') {
+        response = await handleAdminDisqualify(request, env);
+      }
+      else if (path === '/api/admin/clan/disband' && request.method === 'POST') {
+        response = await handleAdminClanDisband(request, env);
       }
       else response = json({ ok: false, reason: 'not-found' }, 404);
     } catch (err) {

--- a/server/worker/index.js
+++ b/server/worker/index.js
@@ -1562,19 +1562,35 @@ async function handleStreamerReview(request, env) {
  * notes answers "anything else you'd like us to know?" — a message to the
  * moderators. Serving notes here would publish something written in private.
  */
+/* The public roster: every approved application, whatever it streams on.
+ *
+ * This used to require `twitch_login IS NOT NULL`, because the streams page
+ * could only render an embeddable Twitch player — so an approved Kick or
+ * YouTube creator was accepted by a moderator and then silently never
+ * appeared anywhere, which is the worst of both answers. The page now renders
+ * a link-out card for the other platforms, so the roster serves them all and
+ * says which is which. `login` stays null off Twitch: it means "embeddable
+ * here", and inventing one for a platform we cannot embed would put a dead
+ * player on the page.
+ *
+ * Still only the three columns the applicant was told become a card — the
+ * private contact block is not in this SELECT and must never be.
+ */
 async function handleStreamerRoster(env) {
   const { results } = await env.DB.prepare(`
-    SELECT name, twitch_login, blurb
+    SELECT name, twitch_login, blurb, platform, channel_url
       FROM streamer_applications
-     WHERE status = 'approved' AND twitch_login IS NOT NULL
+     WHERE status = 'approved'
      ORDER BY created_at DESC
      LIMIT 60`).all();
   return json({
     ok: true,
     streamers: (results || []).map((r) => ({
-      login: r.twitch_login,
+      login: r.twitch_login || null,
       name: r.name,
       blurb: r.blurb || '',
+      platform: r.platform || 'other',
+      channelUrl: r.channel_url || null,
     })),
   });
 }

--- a/site/admin-mod.html
+++ b/site/admin-mod.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PaperTrench — Accounts &amp; boards</title>
+<!-- Not a public page: keep it out of search results and out of previews.
+     This is presentation only — every route it calls is gated server-side. -->
+<meta name="robots" content="noindex, nofollow">
+<meta name="referrer" content="no-referrer">
+<link rel="icon" href="/favicon.ico" sizes="48x48">
+<link rel="icon" type="image/png" href="/assets/icon96.png" sizes="96x96">
+<link rel="icon" type="image/png" href="/assets/icon192.png" sizes="192x192">
+<link rel="apple-touch-icon" href="/assets/icon192.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;700;800&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+<link rel="stylesheet" href="arena.css">
+<style>
+  /* ================================================================== *
+   *  /admin-mod — accounts, records and clans.
+   *
+   *  Scope is deliberately narrow. A moderator here can close an account,
+   *  take a record off the boards, or disband a clan — and can undo all
+   *  three. There is no delete, no score edit, no chain rewrite, and no way
+   *  to add another moderator; that stays a deploy-time decision in
+   *  ADMIN_X_IDS, because a moderation console that can promote its own
+   *  users is a console that only has to be breached once.
+   *
+   *  Every action demands a written reason before its button enables, and
+   *  every action lands in an append-only ledger shown at the bottom of the
+   *  page. Unexplained moderation is indistinguishable from a mistake three
+   *  weeks later, including to the moderator who did it.
+   * ================================================================== */
+  .admin-head { padding: 130px 0 22px; }
+  .admin-head h1 { font-size: clamp(30px, 4vw, 44px); font-weight: 900; letter-spacing: -0.5px; }
+  .admin-head p { font-size: 14px; color: var(--muted); margin-top: 10px; max-width: 680px; line-height: 1.6; }
+
+  .console-nav { display: flex; gap: 6px; margin-top: 20px; flex-wrap: wrap; }
+  .cn { font-size: 13px; font-weight: 700; color: var(--muted); padding: 8px 15px;
+    border-radius: 10px; border: 1px solid var(--line2); background: rgba(255,255,255,0.03);
+    transition: color .15s, background .15s, border-color .15s; }
+  .cn:hover { color: var(--text); background: rgba(255,255,255,0.07); }
+  .cn.on { color: var(--orange2); background: rgba(255,157,69,0.09); border-color: rgba(255,157,69,0.32); }
+
+  .gate { max-width: 560px; margin: 0 auto 90px; text-align: center;
+    background: var(--panel); border: 1px solid var(--line2); border-radius: var(--radius); padding: 40px 32px; }
+  .gate .big { font-size: 42px; margin-bottom: 14px; }
+  .gate h2 { font-size: 20px; font-weight: 800; margin-bottom: 10px; }
+  .gate p { font-size: 13.5px; color: var(--muted); line-height: 1.65; margin-bottom: 18px; }
+  .gate code { font-family: var(--mono); font-size: 12.5px; color: var(--orange2);
+    background: rgba(0,0,0,0.3); border: 1px solid var(--line); border-radius: 6px; padding: 3px 7px; }
+
+  .who { display: flex; align-items: center; gap: 10px; font-size: 13px; color: var(--muted); margin-bottom: 20px; }
+  .who img { width: 26px; height: 26px; border-radius: 50%; }
+  .who b { color: var(--text); font-weight: 750; }
+  .who .spacer { margin-left: auto; }
+
+  .tabs { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 20px; }
+  .tab { font: inherit; font-size: 13px; font-weight: 750; cursor: pointer;
+    color: var(--muted); background: rgba(255,255,255,0.04);
+    border: 1px solid var(--line2); border-radius: 999px; padding: 8px 16px;
+    transition: color .15s, background .15s, border-color .15s; }
+  .tab:hover { color: var(--text); background: rgba(255,255,255,0.08); }
+  .tab.on { color: #2a1a05; background: var(--grad-heat); border-color: transparent; font-weight: 800; }
+
+  .searchbar { display: flex; gap: 9px; margin-bottom: 16px; flex-wrap: wrap; }
+  .searchbar .ar-input { flex: 1; min-width: 220px; }
+
+  .rowset { display: grid; gap: 10px; padding-bottom: 30px; }
+
+  .rec { background: var(--panel); border: 1px solid var(--line); border-radius: 14px; overflow: hidden; }
+  .rec.flagged { border-color: rgba(224,67,58,0.3); }
+
+  .rec-sum { display: flex; align-items: center; gap: 13px; flex-wrap: wrap;
+    padding: 14px 18px; cursor: pointer; list-style: none; transition: background .15s; }
+  .rec-sum::-webkit-details-marker { display: none; }
+  .rec-sum:hover { background: rgba(255,255,255,0.025); }
+  details[open] > .rec-sum { background: rgba(255,255,255,0.03); border-bottom: 1px solid var(--line); }
+  details[open] > .rec-sum .chev { transform: rotate(90deg); }
+  .chev { flex: none; color: var(--dim); display: flex; transition: transform .18s; }
+
+  .rec-id { display: flex; flex-direction: column; min-width: 0; flex: 1; }
+  .rec-handle { font-size: 15px; font-weight: 800; letter-spacing: -0.2px; }
+  .rec-sub { font-family: var(--mono); font-size: 10.5px; color: var(--dim); margin-top: 2px; }
+  .rec-metrics { display: flex; gap: 16px; flex-wrap: wrap; }
+  .met { font-family: var(--mono); font-size: 11px; color: var(--dim); white-space: nowrap; }
+  .met b { display: block; font-size: 13px; color: var(--text); font-weight: 700; }
+
+  .tagline { display: flex; gap: 6px; flex-wrap: wrap; }
+  .st { font-family: var(--mono); font-size: 9.5px; font-weight: 700; letter-spacing: 0.9px;
+    text-transform: uppercase; padding: 3px 8px; border-radius: 999px; white-space: nowrap; }
+  .st.verified { color: var(--green2); background: rgba(52,211,153,0.11); border: 1px solid rgba(52,211,153,0.3); }
+  .st.partial  { color: var(--orange2); background: rgba(255,157,69,0.10); border: 1px solid rgba(255,157,69,0.3); }
+  .st.rejected { color: #ff8a80; background: rgba(224,67,58,0.10); border: 1px solid rgba(224,67,58,0.3); }
+  .st.pending  { color: var(--muted); background: rgba(255,255,255,0.05); border: 1px solid var(--line2); }
+  .st.banned   { color: #fff; background: rgba(224,67,58,0.8); border: 1px solid rgba(224,67,58,0.9); }
+  .st.dq       { color: #ffd9a0; background: rgba(231,123,34,0.22); border: 1px solid rgba(231,123,34,0.45); }
+  .st.clan     { color: var(--blue); background: rgba(106,169,255,0.10); border: 1px solid rgba(106,169,255,0.3); }
+  .st.open     { color: var(--green2); background: rgba(52,211,153,0.09); border: 1px solid rgba(52,211,153,0.26); }
+
+  .rec-body { padding: 18px 18px 6px; }
+  .rows { display: grid; grid-template-columns: 128px minmax(0,1fr); gap: 6px 16px; font-size: 13px; }
+  @media (max-width: 620px) { .rows { grid-template-columns: 1fr; gap: 2px; } .rows dt { margin-top: 9px; } }
+  .rows dt { color: var(--dim); font-size: 11px; font-weight: 750; letter-spacing: 0.5px; text-transform: uppercase; padding-top: 2px; }
+  .rows dd { color: var(--text); word-break: break-word; }
+  .rows dd.empty { color: var(--dim); font-style: italic; }
+
+  .split { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 22px; }
+  @media (max-width: 780px) { .split { grid-template-columns: 1fr; } }
+  .cap { font-family: var(--mono); font-size: 10px; font-weight: 700;
+    letter-spacing: 1.1px; text-transform: uppercase; color: var(--dim); margin-bottom: 9px; }
+
+  /* ---------- the action box ----------
+     A reason is not optional and the UI should not pretend otherwise: the
+     button stays disabled until one is typed. */
+  .act-box { margin-top: 16px; padding: 15px 16px; border-radius: 12px;
+    background: rgba(0,0,0,0.24); border: 1px solid var(--line); }
+  .act-box .cap { margin-bottom: 10px; }
+  .act-row { display: flex; gap: 9px; flex-wrap: wrap; align-items: center; margin-top: 10px; }
+  .act-box .ar-input { font-size: 12.5px; }
+  .ar-btn.bad  { background: rgba(224,67,58,0.11); border-color: rgba(224,67,58,0.32); color: #ff8a80; }
+  .ar-btn.warn { background: rgba(231,123,34,0.13); border-color: rgba(231,123,34,0.36); color: #ffd9a0; }
+  .ar-btn.good { background: rgba(52,211,153,0.12); border-color: rgba(52,211,153,0.33); color: var(--green2); }
+  .ar-btn[disabled] { opacity: .4; cursor: not-allowed; }
+  .act-msg { font-size: 12.5px; font-weight: 650; color: var(--muted); }
+  .act-msg.err { color: #ff8a80; }
+  .act-msg.ok { color: var(--green2); }
+
+  .why { margin-top: 10px; font-size: 12.5px; color: #ffb4ae; line-height: 1.55; }
+  .why b { color: #fff; }
+
+  /* ---------- ledger ---------- */
+  .ledger { margin-top: 10px; padding-bottom: 90px; }
+  .ledger h2 { font-size: 17px; font-weight: 800; margin-bottom: 6px; }
+  .ledger .lede { font-size: 13px; color: var(--muted); margin-bottom: 16px; max-width: 620px; line-height: 1.6; }
+  .log-row { display: flex; gap: 12px; align-items: baseline; flex-wrap: wrap;
+    padding: 11px 14px; border-radius: 10px; background: var(--panel);
+    border: 1px solid var(--line); margin-bottom: 7px; font-size: 13px; }
+  .log-act { font-family: var(--mono); font-size: 10.5px; font-weight: 700;
+    letter-spacing: 0.6px; padding: 3px 8px; border-radius: 999px; white-space: nowrap;
+    color: var(--muted); background: rgba(255,255,255,0.05); border: 1px solid var(--line2); }
+  .log-act.undo { color: var(--green2); background: rgba(52,211,153,0.09); border-color: rgba(52,211,153,0.26); }
+  .log-act.hit  { color: #ff8a80; background: rgba(224,67,58,0.10); border-color: rgba(224,67,58,0.28); }
+  .log-target { font-weight: 750; }
+  .log-reason { color: var(--muted); flex: 1; min-width: 200px; }
+  .log-when { font-family: var(--mono); font-size: 10.5px; color: var(--dim); white-space: nowrap; }
+
+  .state { text-align: center; padding: 54px 20px; color: var(--muted); font-size: 14px; }
+  .state .big { font-size: 34px; margin-bottom: 12px; opacity: 0.8; }
+</style>
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
+
+<nav aria-label="Primary">
+  <div class="nav-inner">
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <div class="nav-links">
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint">Sprint</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/streamer-signup">Streamer signup</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Watch Live</a>
+      <span id="nav-wallet"></span>
+      <span id="nav-profile"></span>
+      <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub ↗</a>
+    </div>
+  </div>
+</nav>
+
+<main id="main">
+
+<header class="admin-head">
+  <div class="wrap">
+    <h1>Accounts &amp; boards</h1>
+    <p>Close an account, take a record off the boards, or disband a clan — each of them reversible, each of them requiring a written reason, and all of them recorded in the ledger at the bottom of this page. Nothing here deletes data or edits a score.</p>
+    <div class="console-nav">
+      <a class="cn" href="/admin">Streamer queue</a>
+      <a class="cn on" href="/admin-mod">Accounts &amp; boards</a>
+    </div>
+  </div>
+</header>
+
+<section style="padding-top:0">
+  <div class="wrap">
+    <div id="loading" class="state"><div class="big">⏳</div>Checking your access…</div>
+
+    <div id="gateSignedOut" class="gate" hidden>
+      <div class="big">🔒</div>
+      <h2>Moderators only</h2>
+      <p>Sign in with the X account on the moderator list to open this console.</p>
+      <a class="btn btn-primary" id="signInBtn" href="#">Sign in with X</a>
+      <p style="margin:16px 0 0;font-size:12.5px">Sign-in returns you to the leaderboard — come back here afterwards.</p>
+    </div>
+
+    <div id="gateNotMod" class="gate" hidden>
+      <div class="big">🚧</div>
+      <h2>Not on the moderator list</h2>
+      <p>You're signed in as <b id="notModHandle"></b>, but that account isn't a PaperTrench moderator.</p>
+      <p>To be added, send an owner your X user id:<br><code id="notModId"></code><br>
+         they add it to <code>ADMIN_X_IDS</code> and redeploy the Worker.</p>
+      <a class="btn btn-ghost" href="/">Back to the site</a>
+    </div>
+
+    <div id="console" hidden>
+      <div class="who">
+        <img id="whoAvatar" src="" alt="" hidden>
+        <span>Signed in as <b id="whoHandle"></b> · moderator</span>
+        <span class="spacer"></span>
+        <button class="ar-btn" type="button" id="refreshBtn">Refresh</button>
+      </div>
+
+      <div class="tabs" id="tabs">
+        <button class="tab on" type="button" data-view="accounts">Accounts</button>
+        <button class="tab" type="button" data-view="clans">Clans</button>
+      </div>
+
+      <div class="searchbar" id="searchbar">
+        <input class="ar-input" type="search" id="q" placeholder="Search by handle or X user id…" autocomplete="off">
+      </div>
+
+      <div class="rowset" id="rows"></div>
+
+      <div class="ledger">
+        <h2>Moderation ledger</h2>
+        <p class="lede">Append-only. Every action on this page writes a row here with the moderator who took it and the reason they gave — so "who took this off the board and why" is a lookup rather than a memory.</p>
+        <div id="log"></div>
+      </div>
+    </div>
+  </div>
+</section>
+</main>
+
+<footer>
+  <div class="wrap">
+    <div class="foot-inner">
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <div class="foot-links">
+        <a href="/">Home</a>
+        <a href="/admin">Streamer queue</a>
+        <a href="/streams">Watch Live</a>
+        <a href="/privacy">Privacy</a>
+      </div>
+    </div>
+    <div class="foot-note">Moderator actions are recorded with your handle. Ban and disqualify are reversible; both still affect a real person's standing — leave a reason your successor can read.</div>
+  </div>
+</footer>
+
+<script src="admin-mod.js"></script>
+<script src="/nav-wallet.js"></script>
+<script src="/nav-profile.js"></script>
+</body>
+</html>

--- a/site/admin-mod.js
+++ b/site/admin-mod.js
@@ -1,0 +1,400 @@
+/* PaperTrench — accounts, records and clans console.
+ *
+ * Like site/admin.js, this page is a VIEW of a server-side decision, never the
+ * decision itself. Every route it calls re-checks the caller's x_id against
+ * ADMIN_X_IDS and returns 403 to everyone else, so hiding the console here is
+ * a courtesy — editing this file, or the DOM, gets an attacker nothing.
+ *
+ * The powers are deliberately few and all reversible: ban/unban an account,
+ * disqualify/reinstate a record, disband/restore a clan. No delete, no score
+ * edit, no chain rewrite, and no way to add a moderator.
+ */
+(() => {
+  'use strict';
+
+  const API = 'https://papertrench-api.onerobby.workers.dev';
+  const TOKEN_KEY = 'pt_session_token';
+
+  const $ = (id) => document.getElementById(id);
+  const esc = (s) => String(s == null ? '' : s).replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ));
+
+  function safeHref(raw) {
+    try {
+      const url = new URL(String(raw));
+      return (url.protocol === 'https:' || url.protocol === 'http:') ? url.toString() : null;
+    } catch { return null; }
+  }
+
+  function sessionToken() {
+    try { return localStorage.getItem(TOKEN_KEY) || null; } catch { return null; }
+  }
+
+  async function api(path, options) {
+    const opts = Object.assign({ credentials: 'include' }, options || {});
+    const token = sessionToken();
+    if (token) opts.headers = Object.assign({}, opts.headers, { Authorization: 'Bearer ' + token });
+    const res = await fetch(API + path, opts);
+    const body = await res.json().catch(() => null);
+    return { status: res.status, body };
+  }
+
+  const authReturn = window.location.hash.match(/^#authed(?:=(.+))?$/);
+  if (authReturn) {
+    if (authReturn[1]) { try { localStorage.setItem(TOKEN_KEY, authReturn[1]); } catch {} }
+    history.replaceState(null, '', window.location.pathname + window.location.search);
+  }
+
+  $('signInBtn').href = API + '/api/auth/x/start';
+
+  function show(paneId) {
+    for (const id of ['loading', 'gateSignedOut', 'gateNotMod', 'console']) {
+      $(id).hidden = (id !== paneId);
+    }
+  }
+
+  const when = (ms) => {
+    if (!ms) return '—';
+    const d = new Date(Number(ms));
+    return Number.isNaN(d.getTime()) ? '—' : d.toLocaleString(undefined, {
+      year: 'numeric', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+    });
+  };
+
+  function ago(ms) {
+    if (!ms) return '';
+    const mins = Math.max(0, Math.round((Date.now() - Number(ms)) / 60000));
+    if (mins < 60) return mins + 'm ago';
+    const h = Math.round(mins / 60);
+    if (h < 48) return h + 'h ago';
+    return Math.round(h / 24) + 'd ago';
+  }
+
+  const num = (v, digits) =>
+    (typeof v === 'number' && Number.isFinite(v)) ? v.toFixed(digits == null ? 2 : digits) : '—';
+
+  function value(text) {
+    const clean = String(text == null ? '' : text).trim();
+    return clean ? `<dd>${esc(clean)}</dd>` : '<dd class="empty">—</dd>';
+  }
+
+  const CHEV =
+    '<span class="chev" aria-hidden="true"><svg width="12" height="12" viewBox="0 0 24 24" ' +
+    'fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" ' +
+    'stroke-linejoin="round"><path d="m9 5 7 7-7 7"/></svg></span>';
+
+  /* ---------------- accounts ---------------- */
+
+  function accountRow(u) {
+    const flags = [];
+    if (u.banned) flags.push('<span class="st banned">banned</span>');
+    if (u.disqualified) flags.push('<span class="st dq">disqualified</span>');
+    if (u.recordStatus) flags.push(`<span class="st ${esc(u.recordStatus)}">${esc(u.recordStatus)}</span>`);
+    if (u.clanTag) flags.push(`<span class="st clan">[${esc(u.clanTag)}]</span>`);
+
+    // Why a record is not on the board, said once, here — a moderator should
+    // not have to reason it out from four separate fields.
+    let why = '';
+    if (u.banned) {
+      why = `<div class="why"><b>Off every board:</b> the account is banned. ${esc(u.bannedReason || '')}</div>`;
+    } else if (u.disqualified) {
+      why = `<div class="why"><b>Off every board:</b> the record is disqualified. ${esc(u.dqReason || '')}</div>`;
+    } else if (u.recordStatus && u.recordStatus !== 'verified') {
+      why = `<div class="why"><b>Not ranked:</b> re-pricing returned <b>${esc(u.recordStatus)}</b>, and only verified records rank. Nothing a moderator did.</div>`;
+    } else if (u.recordStatus === 'verified' && !u.rankable) {
+      why = '<div class="why"><b>Not ranked:</b> fewer than five closed rounds. Nothing a moderator did.</div>';
+    }
+
+    return `
+      <div class="rec ${u.banned || u.disqualified ? 'flagged' : ''}" data-user="${u.id}">
+        <details>
+          <summary class="rec-sum">
+            ${CHEV}
+            <span class="rec-id">
+              <span class="rec-handle">@${esc(u.handle)}</span>
+              <span class="rec-sub">x_id ${esc(u.xId)} · last seen ${esc(ago(u.lastLoginAt))}</span>
+            </span>
+            <span class="tagline">${flags.join('')}</span>
+            <span class="rec-metrics">
+              <span class="met"><b>${esc(u.rounds || 0)}</b>rounds</span>
+              <span class="met"><b>${esc(num(u.score, 1))}</b>score</span>
+              <span class="met"><b>${esc(u.chainLen || 0)}</b>links</span>
+            </span>
+          </summary>
+
+          <div class="rec-body">
+            ${why}
+            <div class="split" style="margin-top:14px">
+              <div>
+                <div class="cap">Account</div>
+                <dl class="rows">
+                  <dt>Handle</dt><dd><a href="/profile?handle=${encodeURIComponent(u.handle)}" target="_blank" rel="noopener">@${esc(u.handle)} ↗</a></dd>
+                  <dt>Display name</dt>${value(u.displayName)}
+                  <dt>X user id</dt><dd><code>${esc(u.xId)}</code></dd>
+                  <dt>Joined</dt><dd>${esc(when(u.joinedAt))}</dd>
+                  <dt>Last login</dt><dd>${esc(when(u.lastLoginAt))}</dd>
+                  <dt>Clan</dt>${u.clanTag ? `<dd>[${esc(u.clanTag)}]</dd>` : '<dd class="empty">none</dd>'}
+                </dl>
+              </div>
+              <div>
+                <div class="cap">Record</div>
+                <dl class="rows">
+                  <dt>Status</dt>${value(u.recordStatus || 'no record')}
+                  <dt>Chain links</dt><dd>${esc(u.chainLen || 0)}</dd>
+                  <dt>Rounds</dt><dd>${esc(u.rounds || 0)}</dd>
+                  <dt>Score</dt><dd>${esc(num(u.score, 2))}</dd>
+                  <dt>Rankable</dt><dd>${u.rankable ? 'yes' : 'no — needs 5 rounds'}</dd>
+                  <dt>Disqualified</dt>${u.disqualified
+                    ? `<dd>yes — ${esc(u.dqReason || '')}</dd>` : '<dd class="empty">no</dd>'}
+                </dl>
+              </div>
+            </div>
+
+            <div class="act-box">
+              <div class="cap">Moderator actions — a reason is required</div>
+              <input class="ar-input" type="text" data-reason placeholder="Why? This is recorded in the ledger and shown to other moderators." maxlength="500">
+              <div class="act-row">
+                ${u.disqualified
+                  ? `<button class="ar-btn good" type="button" data-do="reinstate" disabled>Reinstate record</button>`
+                  : `<button class="ar-btn warn" type="button" data-do="disqualify" disabled>Take record off boards</button>`}
+                ${u.banned
+                  ? `<button class="ar-btn good" type="button" data-do="unban" disabled>Unban account</button>`
+                  : `<button class="ar-btn bad" type="button" data-do="ban" disabled>Ban account</button>`}
+                <span class="act-msg" data-msg></span>
+              </div>
+              <p class="plat-note" style="margin-top:10px;font-size:11.5px;color:var(--dim)">
+                Disqualifying removes the record from the leaderboard and Sprint without touching the account.
+                Banning closes the account and ends its sessions. Both are reversible.
+              </p>
+            </div>
+          </div>
+        </details>
+      </div>`;
+  }
+
+  /* ---------------- clans ---------------- */
+
+  function clanRow(c) {
+    const flags = [];
+    if (c.disbanded) flags.push('<span class="st banned">disbanded</span>');
+    if (c.open) flags.push('<span class="st open">open</span>');
+
+    return `
+      <div class="rec ${c.disbanded ? 'flagged' : ''}" data-clan="${c.id}">
+        <details>
+          <summary class="rec-sum">
+            ${CHEV}
+            <span class="rec-id">
+              <span class="rec-handle">[${esc(c.tag)}] ${esc(c.name)}</span>
+              <span class="rec-sub">founded by @${esc(c.founder || 'unknown')} · ${esc(ago(c.createdAt))}</span>
+            </span>
+            <span class="tagline">${flags.join('')}</span>
+            <span class="rec-metrics"><span class="met"><b>${esc(c.members || 0)}</b>members</span></span>
+          </summary>
+
+          <div class="rec-body">
+            ${c.disbanded
+              ? `<div class="why"><b>Disbanded.</b> ${esc(c.disbandedReason || '')}</div>`
+              : ''}
+            <dl class="rows" style="margin-top:12px">
+              <dt>Tag</dt><dd>[${esc(c.tag)}]</dd>
+              <dt>Name</dt>${value(c.name)}
+              <dt>Motto</dt>${value(c.motto)}
+              <dt>Founder</dt>${value(c.founder ? '@' + c.founder : '')}
+              <dt>Members</dt><dd>${esc(c.members || 0)}</dd>
+              <dt>Join policy</dt><dd>${c.open ? 'open — anyone signed in may join' : 'invite code only'}</dd>
+              <dt>Created</dt><dd>${esc(when(c.createdAt))}</dd>
+            </dl>
+
+            <div class="act-box">
+              <div class="cap">Moderator actions — a reason is required</div>
+              <input class="ar-input" type="text" data-reason placeholder="Why? This is recorded in the ledger." maxlength="500">
+              <div class="act-row">
+                ${c.disbanded
+                  ? '<button class="ar-btn good" type="button" data-do="restore" disabled>Restore clan</button>'
+                  : '<button class="ar-btn bad" type="button" data-do="disband" disabled>Disband clan</button>'}
+                <span class="act-msg" data-msg></span>
+              </div>
+              <p class="plat-note" style="margin-top:10px;font-size:11.5px;color:var(--dim)">
+                Disbanding hides the clan and its board entry. Membership rows are kept, so restoring puts the roster back exactly as it was.
+              </p>
+            </div>
+          </div>
+        </details>
+      </div>`;
+  }
+
+  /* ---------------- ledger ---------------- */
+
+  const UNDO_ACTIONS = ['user.unban', 'record.reinstate', 'clan.restore'];
+
+  function logRow(l) {
+    const kind = UNDO_ACTIONS.includes(l.action) ? 'undo' : 'hit';
+    return `
+      <div class="log-row">
+        <span class="log-act ${kind}">${esc(l.action)}</span>
+        <span class="log-target">${esc(l.target || '')}</span>
+        <span class="log-reason">${esc(l.reason || '')}</span>
+        <span class="log-when">@${esc(l.actor)} · ${esc(ago(l.at))}</span>
+      </div>`;
+  }
+
+  /* ---------------- state ---------------- */
+
+  let view = 'accounts';
+  let term = '';
+
+  async function loadRows() {
+    const box = $('rows');
+    box.innerHTML = '<div class="state"><div class="big">⏳</div>Loading…</div>';
+    $('searchbar').hidden = (view !== 'accounts');
+
+    const path = view === 'accounts'
+      ? '/api/admin/users?q=' + encodeURIComponent(term)
+      : '/api/admin/clans';
+    const { status, body } = await api(path);
+
+    if (status === 403) { await boot(); return; }
+    if (status < 200 || status >= 300 || !body || !body.ok) {
+      // Say the read failed. "No accounts" would be a claim about the data,
+      // made while we cannot see it.
+      box.innerHTML = '<div class="state"><div class="big">⚠️</div>'
+        + 'Couldn’t load that. Refresh to try again.</div>';
+      return;
+    }
+
+    const list = view === 'accounts' ? (body.users || []) : (body.clans || []);
+    if (!list.length) {
+      box.innerHTML = `<div class="state"><div class="big">🗂️</div>${
+        view === 'accounts'
+          ? (term ? 'No account matches that.' : 'No accounts yet.')
+          : 'No clans yet.'}</div>`;
+      return;
+    }
+    box.innerHTML = list.map(view === 'accounts' ? accountRow : clanRow).join('');
+  }
+
+  async function loadLog() {
+    const { status, body } = await api('/api/admin/log');
+    const box = $('log');
+    if (status < 200 || status >= 300 || !body || !body.ok) {
+      box.innerHTML = '<div class="state">Couldn’t load the ledger.</div>';
+      return;
+    }
+    const log = body.log || [];
+    box.innerHTML = log.length
+      ? log.map(logRow).join('')
+      : '<div class="state">Nothing has been actioned yet.</div>';
+  }
+
+  /* ---------------- interaction ---------------- */
+
+  // A reason gates every button in its box. Wiring it on the container rather
+  // than per-button means a re-render cannot leave a live button behind.
+  $('rows').addEventListener('input', (event) => {
+    const input = event.target.closest('[data-reason]');
+    if (!input) return;
+    const box = input.closest('.act-box');
+    const ok = input.value.trim().length >= 3;
+    box.querySelectorAll('button[data-do]').forEach((b) => { b.disabled = !ok; });
+  });
+
+  const CALLS = {
+    ban:         { path: '/api/admin/user/ban', body: (id, r) => ({ userId: id, banned: true, reason: r }) },
+    unban:       { path: '/api/admin/user/ban', body: (id, r) => ({ userId: id, banned: false, reason: r }) },
+    disqualify:  { path: '/api/admin/record/disqualify', body: (id, r) => ({ userId: id, disqualified: true, reason: r }) },
+    reinstate:   { path: '/api/admin/record/disqualify', body: (id, r) => ({ userId: id, disqualified: false, reason: r }) },
+    disband:     { path: '/api/admin/clan/disband', body: (id, r) => ({ clanId: id, disbanded: true, reason: r }) },
+    restore:     { path: '/api/admin/clan/disband', body: (id, r) => ({ clanId: id, disbanded: false, reason: r }) },
+  };
+
+  const REASONS = {
+    'reason-required': 'Write a reason first — it is recorded, and it is what the next moderator reads.',
+    'cannot-ban-self': 'You cannot ban the account you are moderating from.',
+    'not-found': 'That row no longer exists. Refresh.',
+    'no-record': 'That account has never submitted a record, so there is nothing to disqualify.',
+    'not-a-moderator': 'Your moderator access ended. Refresh to sign in again.',
+  };
+
+  $('rows').addEventListener('click', async (event) => {
+    const button = event.target.closest('button[data-do]');
+    if (!button || button.disabled) return;
+
+    const card = button.closest('[data-user], [data-clan]');
+    const box = button.closest('.act-box');
+    const msg = box.querySelector('[data-msg]');
+    const reason = box.querySelector('[data-reason]').value.trim();
+    const id = Number(card.dataset.user || card.dataset.clan);
+    const call = CALLS[button.dataset.do];
+    if (!call) return;
+
+    box.querySelectorAll('button[data-do]').forEach((b) => { b.disabled = true; });
+    msg.textContent = 'Saving…';
+    msg.className = 'act-msg';
+
+    const { status, body } = await api(call.path, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(call.body(id, reason)),
+    });
+
+    if (status >= 200 && status < 300 && body && body.ok) {
+      msg.textContent = 'Done.';
+      msg.className = 'act-msg ok';
+      await Promise.all([loadRows(), loadLog()]);
+      return;
+    }
+
+    box.querySelectorAll('button[data-do]').forEach((b) => { b.disabled = false; });
+    msg.textContent = REASONS[body && body.reason] || 'That didn’t save — try again.';
+    msg.className = 'act-msg err';
+  });
+
+  $('tabs').addEventListener('click', (event) => {
+    const tab = event.target.closest('.tab');
+    if (!tab) return;
+    view = tab.dataset.view;
+    $('tabs').querySelectorAll('.tab').forEach((t) => t.classList.toggle('on', t === tab));
+    loadRows();
+  });
+
+  let searchTimer = 0;
+  $('q').addEventListener('input', (event) => {
+    term = event.target.value.trim();
+    clearTimeout(searchTimer);
+    searchTimer = setTimeout(loadRows, 220);
+  });
+
+  $('refreshBtn').addEventListener('click', () => { loadRows(); loadLog(); });
+
+  /* ---------------- boot ---------------- */
+
+  async function boot() {
+    let session = null;
+    try {
+      const reply = await api('/api/me');
+      session = reply.body;
+    } catch (_) { session = null; }
+
+    if (!session || !session.signedIn) { show('gateSignedOut'); return; }
+
+    if (!session.isMod) {
+      $('notModHandle').textContent = '@' + (session.handle || 'unknown');
+      $('notModId').textContent = session.xId || 'unavailable';
+      show('gateNotMod');
+      return;
+    }
+
+    $('whoHandle').textContent = '@' + (session.handle || 'you');
+    if (session.avatarUrl && safeHref(session.avatarUrl)) {
+      $('whoAvatar').src = session.avatarUrl;
+      $('whoAvatar').hidden = false;
+    }
+    show('console');
+    loadRows();
+    loadLog();
+  }
+
+  boot();
+})();

--- a/site/admin.html
+++ b/site/admin.html
@@ -30,6 +30,19 @@
   .gate code { font-family: var(--mono); font-size: 12.5px; color: var(--orange2);
     background: rgba(0,0,0,0.3); border: 1px solid var(--line); border-radius: 6px; padding: 3px 7px; }
 
+  /* Two consoles, one gate. The link is here rather than in the site nav
+     because /admin-mod is noindex and moderator-only — it has no business in
+     the public navbar. */
+  .console-nav { display: flex; gap: 6px; margin-top: 20px; flex-wrap: wrap; }
+  .cn {
+    font-size: 13px; font-weight: 700; color: var(--muted);
+    padding: 8px 15px; border-radius: 10px;
+    border: 1px solid var(--line2); background: rgba(255,255,255,0.03);
+    transition: color .15s, background .15s, border-color .15s;
+  }
+  .cn:hover { color: var(--text); background: rgba(255,255,255,0.07); }
+  .cn.on { color: var(--orange2); background: rgba(255,157,69,0.09); border-color: rgba(255,157,69,0.32); }
+
   .tabs { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 22px; }
   .tab {
     font: inherit; font-size: 13px; font-weight: 750; cursor: pointer;
@@ -166,6 +179,10 @@
   <div class="wrap">
     <h1>Streamer queue</h1>
     <p>Applications from <a href="/streamer-signup" style="color:var(--orange2)">the signup form</a>. Nothing here is public: an application becomes a card on the streams page only when a moderator approves it, and the contact details never appear anywhere. Twitch channels play inline; Kick and YouTube get a card that links out.</p>
+    <div class="console-nav">
+      <a class="cn on" href="/admin">Streamer queue</a>
+      <a class="cn" href="/admin-mod">Accounts &amp; boards</a>
+    </div>
   </div>
 </header>
 

--- a/site/admin.html
+++ b/site/admin.html
@@ -46,11 +46,58 @@
     background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius);
     padding: 20px 22px;
   }
-  .app-top { display: flex; align-items: flex-start; gap: 12px; flex-wrap: wrap; margin-bottom: 14px; }
-  .app-name { font-size: 16.5px; font-weight: 800; }
-  .app-chan { font-size: 12.5px; margin-top: 2px; }
+  .app { padding: 0; overflow: hidden; }
+
+  /* ---------- summary row ----------
+     Triage is who / where / how big / how old. Everything else is one click
+     away rather than stacked on the page sixty rows deep. */
+  .app-sum {
+    display: flex; align-items: center; gap: 13px; flex-wrap: wrap;
+    padding: 15px 20px; cursor: pointer; list-style: none;
+    transition: background .15s;
+  }
+  .app-sum::-webkit-details-marker { display: none; }
+  .app-sum:hover { background: rgba(255,255,255,0.025); }
+  .app-det[open] .app-sum { background: rgba(255,255,255,0.03); border-bottom: 1px solid var(--line); }
+  .app-det[open] .chev { transform: rotate(90deg); }
+  .chev { flex: none; color: var(--dim); display: flex; transition: transform .18s; }
+  .sum-main { display: flex; flex-direction: column; min-width: 0; flex: 1; }
+  .app-name { font-size: 15.5px; font-weight: 800; letter-spacing: -0.2px; }
+  .app-chan { font-size: 12px; margin-top: 2px; }
   .app-chan a { color: var(--orange2); word-break: break-all; }
-  .app-when { margin-left: auto; font-size: 11.5px; color: var(--dim); white-space: nowrap; }
+  .sum-meta { font-family: var(--mono); font-size: 11px; color: var(--dim); white-space: nowrap; }
+  .app-when { font-family: var(--mono); font-size: 11px; color: var(--dim); white-space: nowrap; }
+
+  .app-full { padding: 18px 20px 4px; }
+  .det-grid { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 22px; }
+  @media (max-width: 780px) { .det-grid { grid-template-columns: 1fr; } }
+
+  .cap { font-family: var(--mono); font-size: 10px; font-weight: 700;
+    letter-spacing: 1.1px; text-transform: uppercase; margin-bottom: 9px; }
+  .cap.pub { color: var(--orange2); }
+  .cap.priv { color: var(--green2); }
+
+  /* The card as the streams page would build it — approving is then a
+     decision about something the moderator has actually looked at. */
+  .mini-card { margin-top: 14px; background: var(--panel2); border: 1px solid var(--line2);
+    border-radius: 10px; overflow: hidden; max-width: 300px; }
+  .mini-thumb { aspect-ratio: 16/9; display: grid; place-items: center;
+    font-family: var(--mono); font-size: 22px; font-weight: 800; color: rgba(255,255,255,0.22); }
+  .mini-thumb.twitch  { background: linear-gradient(145deg, rgba(145,70,255,0.18), transparent); }
+  .mini-thumb.kick    { background: linear-gradient(145deg, rgba(83,252,24,0.16), transparent); }
+  .mini-thumb.youtube { background: linear-gradient(145deg, rgba(255,78,69,0.16), transparent); }
+  .mini-thumb.other   { background: linear-gradient(145deg, rgba(255,255,255,0.07), transparent); }
+  .mini-body { padding: 10px 12px 12px; }
+  .mini-name { font-size: 13px; font-weight: 800; }
+  .mini-handle { font-family: var(--mono); font-size: 10.5px; color: var(--muted); margin-top: 2px; word-break: break-all; }
+  .mini-blurb { margin-top: 6px; font-size: 11.5px; color: var(--muted); line-height: 1.5; }
+  .mini-blurb.empty { color: var(--dim); font-style: italic; }
+  .plat-note { margin-top: 9px; font-size: 11.5px; color: var(--dim); }
+
+  .notes-box { margin-top: 14px; padding: 12px 14px; border-radius: 10px;
+    background: rgba(0,0,0,0.26); border: 1px solid var(--line); }
+  .notes { font-size: 13px; color: var(--text); line-height: 1.6; white-space: pre-wrap; }
+  .notes.empty { color: var(--dim); font-style: italic; }
 
   .plat {
     display: inline-block; font-size: 9.5px; font-weight: 800; letter-spacing: 0.9px;
@@ -75,8 +122,8 @@
   .private-note .cap { font-size: 10px; font-weight: 800; letter-spacing: 1.1px;
     text-transform: uppercase; color: var(--green2); margin-bottom: 7px; }
 
-  .app-acts { display: flex; gap: 9px; flex-wrap: wrap; align-items: center; margin-top: 17px;
-    padding-top: 15px; border-top: 1px solid var(--line); }
+  .app-acts { display: flex; gap: 9px; flex-wrap: wrap; align-items: center;
+    padding: 14px 20px; border-top: 1px solid var(--line); background: rgba(0,0,0,0.18); }
   .ar-btn.good { background: rgba(52,211,153,0.13); border-color: rgba(52,211,153,0.35); color: var(--green2); }
   .ar-btn.bad { background: rgba(224,67,58,0.11); border-color: rgba(224,67,58,0.32); color: #ff8a80; }
   .act-msg { font-size: 12.5px; font-weight: 650; color: var(--muted); }
@@ -117,8 +164,8 @@
 
 <header class="admin-head">
   <div class="wrap">
-    <h1>Moderator queue</h1>
-    <p>Streamer applications from <a href="/streamer-signup" style="color:var(--orange2)">the signup form</a>. Approving a Twitch application puts a card on the streams page within a minute; everything on this page is visible to moderators only.</p>
+    <h1>Streamer queue</h1>
+    <p>Applications from <a href="/streamer-signup" style="color:var(--orange2)">the signup form</a>. Nothing here is public: an application becomes a card on the streams page only when a moderator approves it, and the contact details never appear anywhere. Twitch channels play inline; Kick and YouTube get a card that links out.</p>
   </div>
 </header>
 

--- a/site/admin.js
+++ b/site/admin.js
@@ -91,64 +91,136 @@
     return `<dd><a href="${esc(href)}" target="_blank" rel="noopener noreferrer">${esc(href)}</a></dd>`;
   }
 
+  /** How long ago, in words — "3h ago". Age is the queue's real priority. */
+  function ago(ms) {
+    if (!ms) return '';
+    const mins = Math.max(0, Math.round((Date.now() - Number(ms)) / 60000));
+    if (mins < 60) return mins + 'm ago';
+    const h = Math.round(mins / 60);
+    if (h < 48) return h + 'h ago';
+    return Math.round(h / 24) + 'd ago';
+  }
+
+  const PLATFORM_NOTE = {
+    twitch: 'Plays inline on the streams page.',
+    kick: 'Gets a card that links out to Kick.',
+    youtube: 'Gets a card that links out to YouTube.',
+    other: 'Gets a card that links out to the URL above.',
+  };
+
+  /**
+   * One application, collapsed to a summary row that expands in place.
+   *
+   * The queue used to render every field of every application at once, so
+   * triaging ten meant scrolling past sixty rows of contact details to find
+   * the two that needed a decision. The summary carries what a decision is
+   * usually made on — who, where, how big, how old — and the full record,
+   * including everything private, opens on click.
+   *
+   * <details> rather than a JS toggle: it is keyboard- and screen-reader-
+   * operable for free, and it survives a re-render without state bookkeeping.
+   */
   function cardFor(app) {
     const platform = ['twitch', 'youtube', 'kick'].includes(app.platform) ? app.platform : 'other';
     const chan = safeHref(app.channelUrl);
     const chanHtml = chan
-      ? `<a href="${esc(chan)}" target="_blank" rel="noopener noreferrer">${esc(chan)}</a>`
+      ? `<a href="${esc(chan)}" target="_blank" rel="noopener noreferrer">${esc(chan)} ↗</a>`
       : esc(app.channelUrl || '');
 
     // Every platform is approvable now that the roster serves link-out cards
     // for the ones we cannot embed (handleStreamerRoster). Approving a Kick
-    // application used to set a status that never became anything: the button
-    // was disabled to admit that, which left a moderator with a valid
-    // application and nothing to do about it.
+    // application used to set a status that never became anything.
     const actions = [];
     if (app.status !== 'approved') {
-      actions.push(`<button class="ar-btn good" type="button" data-act="approved" data-id="${app.id}">✓ Approve</button>`);
+      actions.push(`<button class="ar-btn good" type="button" data-act="approved" data-id="${app.id}">Approve</button>`);
     }
     if (app.status !== 'rejected') {
-      actions.push(`<button class="ar-btn bad" type="button" data-act="rejected" data-id="${app.id}">✕ Reject</button>`);
+      actions.push(`<button class="ar-btn bad" type="button" data-act="rejected" data-id="${app.id}">Reject</button>`);
     }
     if (app.status !== 'pending') {
-      actions.push(`<button class="ar-btn" type="button" data-act="pending" data-id="${app.id}">↩ Move back to pending</button>`);
+      actions.push(`<button class="ar-btn" type="button" data-act="pending" data-id="${app.id}">Move back to pending</button>`);
     }
 
     const reviewed = app.reviewedAt
       ? `<span class="act-msg">${esc(app.status)} by @${esc(app.reviewedBy || 'a moderator')} · ${esc(when(app.reviewedAt))}</span>`
       : '';
 
+    // What the public card would actually look like, built from the same three
+    // fields the streams page reads — so "approve" is a decision about a thing
+    // the moderator has seen, not about a row in a form.
+    const cardLabel = app.twitchLogin
+      ? 'twitch.tv/' + app.twitchLogin
+      : String(app.channelUrl || '').replace(/^https?:\/\//i, '').replace(/^www\./i, '').replace(/\/$/, '');
+
     return `
       <article class="app" data-card="${app.id}">
-        <div class="app-top">
-          <div>
-            <div class="app-name">${esc(app.name)} <span class="plat ${platform}">${esc(platform)}</span></div>
-            <div class="app-chan">${chanHtml}</div>
+        <details class="app-det">
+          <summary class="app-sum">
+            <span class="chev" aria-hidden="true">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="m9 5 7 7-7 7"/></svg>
+            </span>
+            <span class="sum-main">
+              <span class="app-name">${esc(app.name)}</span>
+              <span class="app-chan">${chanHtml}</span>
+            </span>
+            <span class="plat ${platform}">${esc(platform)}</span>
+            <span class="sum-meta">${esc(app.viewers || '—')} viewers</span>
+            <span class="app-when" title="${esc(when(app.createdAt))}">${esc(ago(app.createdAt))}</span>
+          </summary>
+
+          <div class="app-full">
+            <div class="det-grid">
+              <div>
+                <div class="cap pub">What gets published</div>
+                <dl class="rows">
+                  <dt>Card name</dt>${value(app.name)}
+                  <dt>Card blurb</dt>${value(app.blurb)}
+                  <dt>Card links to</dt>${chan ? linkValue(chan) : value(app.channelUrl)}
+                </dl>
+                <div class="mini-card">
+                  <div class="mini-thumb ${platform}">${esc(initialsOf(app.name))}</div>
+                  <div class="mini-body">
+                    <div class="mini-name">${esc(app.name)}</div>
+                    <div class="mini-handle">${esc(cardLabel)}</div>
+                    ${app.blurb
+                      ? `<div class="mini-blurb">${esc(app.blurb)}</div>`
+                      : '<div class="mini-blurb empty">no blurb — card shows name and channel only</div>'}
+                  </div>
+                </div>
+                <p class="plat-note">${esc(PLATFORM_NOTE[platform])}</p>
+              </div>
+
+              <div>
+                <div class="cap priv">Private — moderators only</div>
+                <dl class="rows">
+                  <dt>Discord</dt>${value(app.discord)}
+                  <dt>Avg. viewers</dt>${value(app.viewers)}
+                  <dt>Contact via</dt>${value(app.contactMethod)}
+                  <dt>Reach them at</dt>${linkValue(app.contactLink)}
+                  <dt>Best time</dt>${value(app.bestTime)}
+                  <dt>Applied</dt><dd>${esc(when(app.createdAt))}</dd>
+                  <dt>Embeddable</dt>${app.twitchLogin
+                    ? `<dd>yes — <code>${esc(app.twitchLogin)}</code></dd>`
+                    : '<dd class="empty">no — link-out card</dd>'}
+                </dl>
+                <div class="notes-box">
+                  <div class="cap priv">Message to moderators</div>
+                  ${String(app.notes || '').trim()
+                    ? `<p class="notes">${esc(app.notes)}</p>`
+                    : '<p class="notes empty">nothing written</p>'}
+                </div>
+              </div>
+            </div>
           </div>
-          <div class="app-when">${esc(when(app.createdAt))}</div>
-        </div>
-
-        <dl class="rows">
-          <dt>Public blurb</dt>${value(app.blurb)}
-          <dt>Twitch login</dt>${app.twitchLogin
-            ? `<dd>${esc(app.twitchLogin)}</dd>`
-            : '<dd class="empty">not a Twitch channel — cannot be embedded</dd>'}
-          <dt>Avg. viewers</dt>${value(app.viewers)}
-        </dl>
-
-        <div class="private-note">
-          <div class="cap">Private — moderators only</div>
-          <dl class="rows">
-            <dt>Discord</dt>${value(app.discord)}
-            <dt>Contact via</dt>${value(app.contactMethod)}
-            <dt>Profile link</dt>${linkValue(app.contactLink)}
-            <dt>Best time</dt>${value(app.bestTime)}
-            <dt>Notes</dt>${value(app.notes)}
-          </dl>
-        </div>
+        </details>
 
         <div class="app-acts">${actions.join('')}${reviewed}</div>
       </article>`;
+  }
+
+  function initialsOf(name) {
+    return String(name || '').trim().split(/\s+/)
+      .map((w) => w[0] || '').join('').slice(0, 2).toUpperCase() || '?';
   }
 
   /* ---------------- state ---------------- */

--- a/site/admin.js
+++ b/site/admin.js
@@ -98,16 +98,14 @@
       ? `<a href="${esc(chan)}" target="_blank" rel="noopener noreferrer">${esc(chan)}</a>`
       : esc(app.channelUrl || '');
 
-    // Approve is offered only where it can do something. A YouTube or Kick
-    // application is perfectly valid, but the streams page embeds Twitch, so
-    // approving one would set a status that never becomes a card — a button
-    // that silently does nothing is worse than a button that isn't there.
-    const embeddable = Boolean(app.twitchLogin);
-
+    // Every platform is approvable now that the roster serves link-out cards
+    // for the ones we cannot embed (handleStreamerRoster). Approving a Kick
+    // application used to set a status that never became anything: the button
+    // was disabled to admit that, which left a moderator with a valid
+    // application and nothing to do about it.
     const actions = [];
     if (app.status !== 'approved') {
-      actions.push(`<button class="ar-btn good" type="button" data-act="approved" data-id="${app.id}"
-        ${embeddable ? '' : 'disabled title="Only Twitch channels can be embedded on the streams page"'}>✓ Approve</button>`);
+      actions.push(`<button class="ar-btn good" type="button" data-act="approved" data-id="${app.id}">✓ Approve</button>`);
     }
     if (app.status !== 'rejected') {
       actions.push(`<button class="ar-btn bad" type="button" data-act="rejected" data-id="${app.id}">✕ Reject</button>`);

--- a/site/streamer-signup.html
+++ b/site/streamer-signup.html
@@ -36,7 +36,10 @@
    *     it is just a statement about where an answer can end up, not a
    *     warning that it is already on its way there.
    * ================================================================== */
-  :root { --twitch: #9146FF; --twitch2: #bf94ff; --twitch-dim: rgba(145,70,255,0.30); }
+  :root {
+    --twitch: #9146FF; --twitch2: #bf94ff; --twitch-dim: rgba(145,70,255,0.30);
+    --kick: #53fc18; --yt: #ff4e45;
+  }
   .k-twitch { color: var(--twitch2); background: rgba(145,70,255,0.10); border: 1px solid var(--twitch-dim); }
 
   .hero.compact { padding: 132px 0 22px; }
@@ -98,6 +101,23 @@
   .count { margin-left: auto; font-family: var(--mono); font-size: 10.5px; color: var(--dim); }
   .count.near { color: var(--orange2); }
 
+  /* ---------- channel URL, composed from the platform ----------
+   * The domain is not something anyone should have to type, and typing it
+   * is where the typos are. Pick the platform, fill in the handle. A full
+   * pasted URL still works — the JS unwraps it back to the handle. */
+  .url-group { display: flex; align-items: stretch; }
+  .url-prefix {
+    display: flex; align-items: center; flex: none;
+    font-family: var(--mono); font-size: 12.5px; font-weight: 600; color: var(--muted);
+    background: rgba(0,0,0,0.4); border: var(--edge); border-right: 0;
+    border-radius: 10px 0 0 10px; padding: 0 4px 0 12px; white-space: nowrap;
+  }
+  .url-group .ar-input { border-radius: 0 10px 10px 0; }
+  .url-group.bare .url-prefix { display: none; }
+  .url-group.bare .ar-input { border-radius: 10px; }
+  .url-prefix.twitch { color: var(--twitch2); }
+  .url-prefix.kick { color: var(--kick); }
+  .url-prefix.youtube { color: var(--yt); }
 
   /* ---------- the data statement ---------- */
   .data-note {
@@ -144,15 +164,35 @@
   .perk span { color: var(--muted); }
   .side-card.prep .perk .ico { color: var(--orange2); }
 
-  /* ---------- live card preview (green) ---------- */
+  /* ---------- live card preview ----------
+   *
+   * The card wears the colour of the platform it would live on: Twitch
+   * purple, Kick green, YouTube red — the same cue the streams page uses for
+   * its badges. A preview in a colour the real card never takes is a mock-up;
+   * matching it means what they are looking at is what gets built.
+   *
+   * Driven by two custom properties so the platform class sets the colour in
+   * one place and everything tinted follows. */
   .prev-card {
+    --prev: var(--twitch2);
+    --prev-soft: rgba(145,70,255,0.17);
     background: var(--panel2); border: 1px solid var(--line2);
     border-radius: 12px; overflow: hidden;
+    transition: border-color .25s;
   }
+  .prev-card.kick    { --prev: var(--kick); --prev-soft: rgba(83,252,24,0.15); }
+  .prev-card.youtube { --prev: var(--yt);   --prev-soft: rgba(255,78,69,0.15); }
+  .prev-card.other   { --prev: var(--muted); --prev-soft: rgba(255,255,255,0.07); }
+
+  /* No transition on either tinted property. A `transition` on a value that
+     comes from a custom property pins it to the START value when the property
+     changes — the handle stayed Twitch purple on a Kick card, reporting the
+     old colour indefinitely rather than for 250ms. (The gradient would not
+     have interpolated anyway; gradients are not interpolable.) */
   .prev-thumb {
     position: relative; aspect-ratio: 16 / 9;
     display: grid; place-items: center;
-    background: linear-gradient(145deg, rgba(52,211,153,0.17), rgba(52,211,153,0.02));
+    background: linear-gradient(145deg, var(--prev-soft), rgba(0,0,0,0));
     font-family: var(--mono); font-size: 26px; font-weight: 800;
     color: rgba(255,255,255,0.22); letter-spacing: 2px;
   }
@@ -164,7 +204,7 @@
   }
   .prev-body { padding: 12px 14px 14px; }
   .prev-name { font-size: 14px; font-weight: 800; letter-spacing: -0.2px; word-break: break-word; }
-  .prev-handle { font-family: var(--mono); font-size: 11px; color: var(--green2); margin-top: 3px; word-break: break-all; }
+  .prev-handle { font-family: var(--mono); font-size: 11px; color: var(--prev); margin-top: 3px; word-break: break-all; }
   .prev-blurb { margin-top: 8px; font-size: 12.5px; color: var(--muted); line-height: 1.5; word-break: break-word; }
   .prev-blurb.empty { color: var(--dim); font-style: italic; }
   .prev-foot { margin-top: 12px; font-size: 11.5px; color: var(--dim); line-height: 1.5; }
@@ -201,7 +241,7 @@
   <div class="wrap">
     <span class="sec-kicker k-twitch reveal">Streamer application</span>
     <h1 class="reveal d1">Get featured <span class="grad-twitch">in the trench.</span></h1>
-    <p class="hero-sub reveal d2">Any creator running the PaperTrench Challenge can apply. Approved streamers get a card on the <a href="/streams">streams page</a>, the Streamer role in Discord, and an automatic alert when they go live.</p>
+    <p class="hero-sub reveal d2">Any creator running the PaperTrench Challenge can apply — Twitch, Kick or YouTube. Approved streamers get a card on the <a href="/streams">streams page</a>, the Streamer role in Discord, and an automatic alert when they go live.</p>
   </div>
 </header>
 
@@ -231,11 +271,25 @@
               <input class="ar-input" type="text" name="name" id="f-name" maxlength="40" autocomplete="off" required>
             </label>
 
-            <label class="ar-field">
-              <span class="lbl">Main channel URL <span class="req">*</span></span>
-              <input class="ar-input" type="text" name="channelUrl" id="f-channel" maxlength="200" inputmode="url" placeholder="twitch.tv/yourname" autocomplete="off" required>
-              <span class="hint">Twitch, YouTube, Kick — whichever is your main. Twitch channels also play inline on the streams page.</span>
-            </label>
+            <div class="ar-field">
+              <label class="lbl" for="f-platform">Where do you stream? <span class="req">*</span></label>
+              <select class="ar-input" id="f-platform" name="platform">
+                <option value="twitch" selected>Twitch</option>
+                <option value="kick">Kick</option>
+                <option value="youtube">YouTube</option>
+                <option value="other">Somewhere else</option>
+              </select>
+              <span class="hint" id="platformHint">Twitch channels can be played inline on the streams page — the other platforms get a card that links out.</span>
+            </div>
+
+            <div class="ar-field">
+              <label class="lbl" for="f-channel">Channel <span class="req">*</span></label>
+              <div class="url-group" id="urlGroup">
+                <span class="url-prefix twitch" id="urlPrefix">twitch.tv/</span>
+                <input class="ar-input" type="text" name="channelUrl" id="f-channel" maxlength="200" inputmode="url" placeholder="yourname" autocomplete="off" required>
+              </div>
+              <span class="hint" id="channelHint">Just the part after the slash. Pasting the full link works too.</span>
+            </div>
 
             <label class="ar-field">
               <span class="lbl">One line about your stream <span class="count" id="blurbCount">0 / 160</span></span>
@@ -277,7 +331,7 @@
 
             <label class="ar-field">
               <span class="lbl">Preferred contact method</span>
-              <select class="ar-input" name="contactMethod">
+              <select class="ar-input" name="contactMethod" id="f-method">
                 <option value="" selected>No preference</option>
                 <option>Discord DM</option>
                 <option>Email</option>
@@ -286,10 +340,13 @@
               </select>
             </label>
 
-            <label class="ar-field">
-              <span class="lbl">Profile link</span>
-              <input class="ar-input" type="text" name="contactLink" id="f-contactlink" maxlength="200" inputmode="url" autocomplete="off" placeholder="https://…">
-              <span class="hint">If you picked Discord, Twitter/X or Other above, drop the profile link here.</span>
+            <!-- Relabels itself to match the method above; hidden entirely when
+                 the chosen method needs nothing extra (Discord DM is already
+                 answered by the Discord field). -->
+            <label class="ar-field" id="contactLinkField" hidden>
+              <span class="lbl" id="contactLinkLabel">Profile link</span>
+              <input class="ar-input" type="text" name="contactLink" id="f-contactlink" maxlength="200" autocomplete="off" placeholder="https://…">
+              <span class="hint" id="contactLinkHint">Where should we reach you?</span>
             </label>
 
             <label class="ar-field">
@@ -323,7 +380,7 @@
       <!-- The card as it would be built, shown before anyone else can see it. -->
       <div class="side-card">
         <h3>Your card, if approved</h3>
-        <div class="prev-card" aria-live="polite">
+        <div class="prev-card twitch" id="prevCard" aria-live="polite">
           <div class="prev-thumb" id="prevInitials">?<span class="chip">OFFLINE</span></div>
           <div class="prev-body">
             <div class="prev-name" id="prevName">Your channel name</div>

--- a/site/streamer-signup.html
+++ b/site/streamer-signup.html
@@ -4,9 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PaperTrench — Streamer application</title>
-<meta name="description" content="Apply to become a featured PaperTrench streamer — get the Streamer role in Discord, an announcement to the community, automated live alerts, and a card on the streams page.">
+<meta name="description" content="Apply to become a featured PaperTrench streamer — a card on the streams page, the Streamer role in Discord, and automated live alerts. Applications are read privately by a moderator; nothing goes public on its own.">
 <meta property="og:title" content="PaperTrench — Streamer application">
-<meta property="og:description" content="Apply to join the PaperTrench Challenge roster. Featured on the streams page, Streamer role in Discord, and automated live alerts.">
+<meta property="og:description" content="Apply to join the PaperTrench Challenge roster. Every application is read privately by a moderator first, and you can see your card before anyone else does.">
 <meta property="og:image" content="https://papertrench.com/assets/video-poster.jpg">
 <link rel="icon" href="/favicon.ico" sizes="48x48">
 <link rel="icon" type="image/png" href="/assets/icon96.png" sizes="96x96">
@@ -18,63 +18,156 @@
 <link rel="stylesheet" href="style.css">
 <link rel="stylesheet" href="arena.css">
 <style>
-  :root { --twitch: #9146FF; --twitch2: #bf94ff; }
-  .k-twitch { color: var(--twitch2); background: rgba(145,70,255,0.10); border: 1px solid rgba(145,70,255,0.32); }
-  .hero.compact { padding: 140px 0 24px; }
-  .hero.compact h1 { font-size: clamp(34px, 5vw, 58px); }
+  /* ================================================================== *
+   *  /streamer-signup — the application form.
+   *
+   *  Two things this page must get right, in this order:
+   *
+   *  1. NOTHING HERE IS PUBLISHED BY SENDING IT. Every application lands
+   *     in a private moderator queue and stays there until a moderator on
+   *     the ADMIN_X_IDS allowlist approves it. An earlier draft labelled
+   *     the first section "PUBLISHED", which reads as "this is going live
+   *     the moment you hit send" — the opposite of what happens, and a
+   *     good reason not to fill the form in. The wording now describes the
+   *     real sequence: reviewed privately, then published if approved.
+   *
+   *  2. The applicant should still know which answers COULD become public
+   *     and which never can. That distinction is real and worth keeping —
+   *     it is just a statement about where an answer can end up, not a
+   *     warning that it is already on its way there.
+   * ================================================================== */
+  :root { --twitch: #9146FF; --twitch2: #bf94ff; --twitch-dim: rgba(145,70,255,0.30); }
+  .k-twitch { color: var(--twitch2); background: rgba(145,70,255,0.10); border: 1px solid var(--twitch-dim); }
+
+  .hero.compact { padding: 132px 0 22px; }
+  .hero.compact h1 { font-size: clamp(33px, 4.6vw, 54px); line-height: 1.06; letter-spacing: -1.4px; }
   .grad-twitch {
     background: linear-gradient(100deg, var(--twitch2) 10%, var(--twitch) 70%);
     -webkit-background-clip: text; background-clip: text; color: transparent;
   }
+  .hero-sub a { color: var(--twitch2); border-bottom: 1px solid rgba(191,148,255,0.3); }
+  .hero-sub a:hover { border-bottom-color: var(--twitch2); }
 
-  .apply-wrap { display: grid; grid-template-columns: minmax(0,1fr) 320px; gap: 28px; align-items: start; padding-bottom: 90px; }
-  @media (max-width: 900px) { .apply-wrap { grid-template-columns: 1fr; } }
+  .apply-wrap { display: grid; grid-template-columns: minmax(0,1fr) 330px; gap: 26px; align-items: start; padding-bottom: 88px; }
+  @media (max-width: 940px) { .apply-wrap { grid-template-columns: 1fr; } }
 
   .apply-card {
     background: var(--panel); border: 1px solid var(--line2);
-    border-radius: var(--radius); padding: 26px 28px 28px;
+    border-radius: var(--radius); padding: 0; overflow: hidden;
   }
-  .apply-card h2 { font-size: 19px; font-weight: 800; margin-bottom: 6px; }
-  .apply-card .lede { font-size: 13.5px; color: var(--muted); line-height: 1.6; margin-bottom: 22px; }
+
+  /* ---------- the review promise, stated first ---------- */
+  .review-note {
+    display: flex; gap: 13px; align-items: flex-start;
+    padding: 17px 28px; border-bottom: 1px solid var(--line);
+    background: rgba(52,211,153,0.05);
+  }
+  .review-note .mark { flex: none; color: var(--green2); margin-top: 2px; }
+  .review-note p { font-size: 13px; color: var(--muted); line-height: 1.65; }
+  .review-note b { color: var(--text); font-weight: 700; }
+
+  /* ---------- form sections ---------- */
+  .fs { padding: 24px 28px 4px; }
+  .fs + .fs { border-top: 1px solid var(--line); }
+  .fs-head { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; margin-bottom: 4px; }
+  .fs-head h2 { font-size: 17px; font-weight: 800; letter-spacing: -0.3px; }
+  .fs-rule { font-size: 13px; color: var(--muted); line-height: 1.6; margin-bottom: 20px; max-width: 56ch; }
+  .fs-rule b { color: var(--text); font-weight: 700; }
 
   .req { color: var(--orange2); font-weight: 800; }
-  .ar-field { margin-bottom: 17px; }
-  textarea.ar-input { min-height: 96px; resize: vertical; line-height: 1.55; }
+  .ar-field { margin-bottom: 18px; }
+  .ar-field .lbl { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; }
+  textarea.ar-input { min-height: 92px; resize: vertical; line-height: 1.55; }
   select.ar-input { appearance: none; cursor: pointer;
     background-image: linear-gradient(45deg, transparent 50%, var(--muted) 50%), linear-gradient(135deg, var(--muted) 50%, transparent 50%);
     background-position: calc(100% - 17px) 51%, calc(100% - 12px) 51%;
     background-size: 5px 5px, 5px 5px; background-repeat: no-repeat; padding-right: 34px; }
   select.ar-input option { background: var(--panel2); color: var(--text); }
+  .ar-input:focus { border-color: var(--green); box-shadow: 0 0 0 3px rgba(52,211,153,0.13); }
 
-  /* A field whose answer becomes public says so where the answer is typed —
-     not in a policy page nobody opens. */
+  /* Where an answer CAN end up — not a warning that it is on its way. */
   .vis {
-    display: inline-flex; align-items: center; gap: 5px; margin-left: 8px;
-    font-size: 9.5px; font-weight: 800; letter-spacing: 0.8px; text-transform: uppercase;
-    padding: 2px 7px; border-radius: 999px; vertical-align: middle;
+    display: inline-flex; align-items: center; gap: 4px;
+    font-family: var(--mono);
+    font-size: 9px; font-weight: 700; letter-spacing: 0.7px; text-transform: uppercase;
+    padding: 2px 7px; border-radius: 999px;
   }
-  .vis.public { color: var(--twitch2); background: rgba(145,70,255,0.12); border: 1px solid rgba(145,70,255,0.3); }
-  .vis.private { color: var(--green2); background: rgba(52,211,153,0.10); border: 1px solid rgba(52,211,153,0.28); }
+  .vis.card { color: var(--green2); background: rgba(52,211,153,0.10); border: 1px solid rgba(52,211,153,0.28); }
+  .vis.mods { color: var(--muted); background: rgba(255,255,255,0.045); border: 1px solid var(--line2); }
 
-  .apply-actions { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; margin-top: 22px; }
+  .count { margin-left: auto; font-family: var(--mono); font-size: 10.5px; color: var(--dim); }
+  .count.near { color: var(--orange2); }
+
+
+  /* ---------- the data statement ---------- */
+  .data-note {
+    margin: 0 0 22px; padding: 16px 18px;
+    display: flex; gap: 13px; align-items: flex-start;
+    background: rgba(255,255,255,0.025);
+    border: 1px solid var(--line2);
+    border-left: 2px solid var(--dim); border-radius: 12px;
+  }
+  .data-note .mark { flex: none; color: var(--muted); margin-top: 2px; }
+  .data-note p { font-size: 12.5px; color: var(--muted); line-height: 1.65; }
+  .data-note b { color: var(--text); font-weight: 700; }
+  .data-note a { color: var(--green2); border-bottom: 1px solid rgba(125,243,196,0.28); }
+
+  /* ---------- actions ---------- */
+  .apply-actions {
+    display: flex; align-items: center; gap: 15px; flex-wrap: wrap;
+    padding: 20px 28px 26px; border-top: 1px solid var(--line);
+    background: rgba(0,0,0,0.16);
+  }
   .form-msg { font-size: 13px; font-weight: 650; line-height: 1.55; }
   .form-msg.err { color: #ff8a80; }
   .form-msg.ok { color: var(--green2); }
+  .ar-btn.primary[disabled] { opacity: .55; cursor: progress; }
 
-  .done { text-align: center; padding: 26px 10px 10px; }
-  .done .big { font-size: 44px; margin-bottom: 12px; }
-  .done h2 { font-size: 21px; margin-bottom: 8px; }
-  .done p { font-size: 14px; color: var(--muted); line-height: 1.65; max-width: 420px; margin: 0 auto 20px; }
+  .done { text-align: center; padding: 44px 26px 40px; }
+  .done .mark { margin: 0 auto 16px; color: var(--green2); }
+  .done h2 { font-size: 21px; margin-bottom: 8px; letter-spacing: -0.3px; }
+  .done p { font-size: 14px; color: var(--muted); line-height: 1.65; max-width: 430px; margin: 0 auto 22px; }
 
-  .side { display: grid; gap: 16px; position: sticky; top: 96px; }
-  @media (max-width: 900px) { .side { position: static; } }
-  .side-card { background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius); padding: 20px 22px; }
-  .side-card h3 { font-size: 12px; font-weight: 800; letter-spacing: 1.3px; text-transform: uppercase; color: var(--dim); margin-bottom: 13px; }
-  .perk { display: flex; gap: 11px; align-items: flex-start; margin-bottom: 13px; font-size: 13.5px; line-height: 1.5; }
+  /* ---------- sidebar ---------- */
+  .side { display: grid; gap: 15px; position: sticky; top: 92px; }
+  @media (max-width: 940px) { .side { position: static; } }
+  .side-card { background: var(--panel); border: 1px solid var(--line); border-radius: 14px; padding: 19px 21px; }
+  .side-card h3 {
+    font-family: var(--mono);
+    font-size: 10.5px; font-weight: 700; letter-spacing: 1.3px; text-transform: uppercase;
+    color: var(--dim); margin-bottom: 14px;
+  }
+  .perk { display: flex; gap: 11px; align-items: flex-start; margin-bottom: 12px; font-size: 13px; line-height: 1.55; }
   .perk:last-child { margin-bottom: 0; }
-  .perk .ico { font-size: 16px; flex: none; line-height: 1.35; }
-  .perk b { font-weight: 750; }
+  .perk .ico { flex: none; margin-top: 2px; color: var(--green2); }
+  .perk b { font-weight: 700; }
   .perk span { color: var(--muted); }
+  .side-card.prep .perk .ico { color: var(--orange2); }
+
+  /* ---------- live card preview (green) ---------- */
+  .prev-card {
+    background: var(--panel2); border: 1px solid var(--line2);
+    border-radius: 12px; overflow: hidden;
+  }
+  .prev-thumb {
+    position: relative; aspect-ratio: 16 / 9;
+    display: grid; place-items: center;
+    background: linear-gradient(145deg, rgba(52,211,153,0.17), rgba(52,211,153,0.02));
+    font-family: var(--mono); font-size: 26px; font-weight: 800;
+    color: rgba(255,255,255,0.22); letter-spacing: 2px;
+  }
+  .prev-thumb .chip {
+    position: absolute; top: 8px; left: 8px;
+    font-family: var(--mono); font-size: 9px; font-weight: 700; letter-spacing: 1.1px;
+    padding: 3px 8px; border-radius: 999px;
+    background: rgba(0,0,0,0.7); color: var(--dim); border: 1px solid var(--line2);
+  }
+  .prev-body { padding: 12px 14px 14px; }
+  .prev-name { font-size: 14px; font-weight: 800; letter-spacing: -0.2px; word-break: break-word; }
+  .prev-handle { font-family: var(--mono); font-size: 11px; color: var(--green2); margin-top: 3px; word-break: break-all; }
+  .prev-blurb { margin-top: 8px; font-size: 12.5px; color: var(--muted); line-height: 1.5; word-break: break-word; }
+  .prev-blurb.empty { color: var(--dim); font-style: italic; }
+  .prev-foot { margin-top: 12px; font-size: 11.5px; color: var(--dim); line-height: 1.5; }
 </style>
 </head>
 <body>
@@ -108,7 +201,7 @@
   <div class="wrap">
     <span class="sec-kicker k-twitch reveal">Streamer application</span>
     <h1 class="reveal d1">Get featured <span class="grad-twitch">in the trench.</span></h1>
-    <p class="hero-sub reveal d2">Any creator running the PaperTrench Challenge can apply. Approved streamers get a card on the <a href="/streams" style="color:var(--twitch2)">streams page</a>, the Streamer role in Discord, and automated live alerts.</p>
+    <p class="hero-sub reveal d2">Any creator running the PaperTrench Challenge can apply. Approved streamers get a card on the <a href="/streams">streams page</a>, the Streamer role in Discord, and an automatic alert when they go live.</p>
   </div>
 </header>
 
@@ -117,107 +210,143 @@
     <div class="apply-card reveal">
       <!-- The form and the thank-you state swap in place; JS toggles them. -->
       <div id="formPane">
-        <h2>Tell us about your channel</h2>
-        <p class="lede">Fields marked <span class="req">*</span> are required. We review applications by hand — expect a Discord DM once a moderator has looked at yours.</p>
+
+        <div class="review-note">
+          <svg class="mark" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3 4.5 6.2v5.1c0 4.6 3.1 8.9 7.5 10.2 4.4-1.3 7.5-5.6 7.5-10.2V6.2z"/><path d="m9.2 12 2 2 3.6-3.8"/></svg>
+          <p><b>Sending this does not put anything on the site.</b> Your application goes into a private queue that only verified PaperTrench moderators can open. A human reads it, and only if they approve does a card appear on the streams page. If they don't, nothing is published at all.</p>
+        </div>
 
         <form id="applyForm" novalidate>
-          <label class="ar-field">
-            <span class="lbl">Creator / Channel Name <span class="req">*</span><span class="vis public">Public</span></span>
-            <input class="ar-input" type="text" name="name" maxlength="40" autocomplete="off" required>
-          </label>
 
-          <label class="ar-field">
-            <span class="lbl">Main Channel URL <span class="req">*</span><span class="vis public">Public</span></span>
-            <input class="ar-input" type="text" name="channelUrl" maxlength="200" inputmode="url" placeholder="twitch.tv/yourname" autocomplete="off" required>
-            <span class="hint">Twitch, YouTube, Kick, etc. Twitch channels can be embedded and played directly on the streams page.</span>
-          </label>
+          <!-- ============ CHANNEL ============ -->
+          <div class="fs">
+            <div class="fs-head">
+              <h2>Your channel</h2>
+              <span class="vis card">Goes on your card</span>
+            </div>
+            <p class="fs-rule">If a moderator approves you, these three answers are what your roster card is built from. There's a live preview of it in the sidebar so you can see the card before anyone else does.</p>
 
-          <label class="ar-field">
-            <span class="lbl">Discord Username <span class="req">*</span><span class="vis private">Private</span></span>
-            <input class="ar-input" type="text" name="discord" maxlength="40" autocomplete="off" required>
-            <span class="hint">So we can assign your Streamer role and post your live alerts.</span>
-          </label>
+            <label class="ar-field">
+              <span class="lbl">Creator / channel name <span class="req">*</span></span>
+              <input class="ar-input" type="text" name="name" id="f-name" maxlength="40" autocomplete="off" required>
+            </label>
 
-          <label class="ar-field">
-            <span class="lbl">Average Live Viewers <span class="req">*</span><span class="vis private">Private</span></span>
-            <select class="ar-input" name="viewers" required>
-              <option value="" selected disabled>Choose one…</option>
-              <option>1–10</option>
-              <option>10–50</option>
-              <option>50–100</option>
-              <option>100+</option>
-            </select>
-          </label>
+            <label class="ar-field">
+              <span class="lbl">Main channel URL <span class="req">*</span></span>
+              <input class="ar-input" type="text" name="channelUrl" id="f-channel" maxlength="200" inputmode="url" placeholder="twitch.tv/yourname" autocomplete="off" required>
+              <span class="hint">Twitch, YouTube, Kick — whichever is your main. Twitch channels also play inline on the streams page.</span>
+            </label>
 
-          <label class="ar-field">
-            <span class="lbl">One line about your stream<span class="vis public">Public</span></span>
-            <input class="ar-input" type="text" name="blurb" maxlength="160" autocomplete="off" placeholder="Weekend challenge runs — fresh eyes on the trenches.">
-            <span class="hint">This is the blurb printed on your roster card if you're approved. Leave it blank and your card just shows your name.</span>
-          </label>
+            <label class="ar-field">
+              <span class="lbl">One line about your stream <span class="count" id="blurbCount">0 / 160</span></span>
+              <input class="ar-input" type="text" name="blurb" id="f-blurb" maxlength="160" autocomplete="off" placeholder="Weekend challenge runs — fresh eyes on the trenches.">
+              <span class="hint">Optional. Leave it blank and the card just shows your name and channel.</span>
+            </label>
+          </div>
 
-          <label class="ar-field">
-            <span class="lbl">Anything else you'd like us to know?<span class="vis private">Private</span></span>
-            <textarea class="ar-input" name="notes" maxlength="1000" rows="4"></textarea>
-            <span class="hint">Only the moderator team reads this — it is never shown on the site.</span>
-          </label>
+          <!-- ============ CONTACT ============ -->
+          <div class="fs">
+            <div class="fs-head">
+              <h2>How we reach you</h2>
+              <span class="vis mods">Moderators only</span>
+            </div>
+            <p class="fs-rule">Moderators need a way to reach you about your application. These answers live in a separate set of columns from the card ones, and the query that builds the public roster does not read them — so there is no path by which they end up on the site.</p>
 
-          <label class="ar-field">
-            <span class="lbl">Preferred Contact Method<span class="vis private">Private</span></span>
-            <select class="ar-input" name="contactMethod">
-              <option value="" selected>No preference</option>
-              <option>Discord DM</option>
-              <option>Email</option>
-              <option>Twitter/X</option>
-              <option>Other</option>
-            </select>
-          </label>
+            <div class="data-note">
+              <svg class="mark" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4.5" y="10.5" width="15" height="9.5" rx="2"/><path d="M8 10.5V7.8a4 4 0 0 1 8 0v2.7"/></svg>
+              <p><b>What is stored.</b> The answers on this page, plus a one-way hash of your IP address for abuse triage — never the address itself. Nothing is sold, shared with third parties, or used for marketing. Ask any moderator to delete your application and it is removed, approved or not. Details in the <a href="/privacy">privacy policy</a>.</p>
+            </div>
 
-          <label class="ar-field">
-            <span class="lbl">Profile link<span class="vis private">Private</span></span>
-            <input class="ar-input" type="text" name="contactLink" maxlength="200" inputmode="url" autocomplete="off" placeholder="https://…">
-            <span class="hint">If you picked Discord, Twitter/X, or Other above, drop the profile link here.</span>
-          </label>
+            <label class="ar-field">
+              <span class="lbl">Discord username <span class="req">*</span></span>
+              <input class="ar-input" type="text" name="discord" maxlength="40" autocomplete="off" required>
+              <span class="hint">So a moderator can DM you, assign the Streamer role, and wire up your live alerts.</span>
+            </label>
 
-          <label class="ar-field">
-            <span class="lbl">Best Day/Time to Reach You<span class="vis private">Private</span></span>
-            <input class="ar-input" type="text" name="bestTime" maxlength="100" autocomplete="off" placeholder="Weeknights after 8pm ET">
-          </label>
+            <label class="ar-field">
+              <span class="lbl">Average live viewers <span class="req">*</span></span>
+              <select class="ar-input" name="viewers" required>
+                <option value="" selected disabled>Choose one…</option>
+                <option>1–10</option>
+                <option>10–50</option>
+                <option>50–100</option>
+                <option>100+</option>
+              </select>
+              <span class="hint">Used to plan alerts and scheduling — it is not a bar you have to clear. Small channels are approved all the time.</span>
+            </label>
+
+            <label class="ar-field">
+              <span class="lbl">Preferred contact method</span>
+              <select class="ar-input" name="contactMethod">
+                <option value="" selected>No preference</option>
+                <option>Discord DM</option>
+                <option>Email</option>
+                <option>Twitter/X</option>
+                <option>Other</option>
+              </select>
+            </label>
+
+            <label class="ar-field">
+              <span class="lbl">Profile link</span>
+              <input class="ar-input" type="text" name="contactLink" id="f-contactlink" maxlength="200" inputmode="url" autocomplete="off" placeholder="https://…">
+              <span class="hint">If you picked Discord, Twitter/X or Other above, drop the profile link here.</span>
+            </label>
+
+            <label class="ar-field">
+              <span class="lbl">Best day / time to reach you</span>
+              <input class="ar-input" type="text" name="bestTime" maxlength="100" autocomplete="off" placeholder="Weeknights after 8pm ET">
+            </label>
+
+            <label class="ar-field">
+              <span class="lbl">Anything else we should know?</span>
+              <textarea class="ar-input" name="notes" maxlength="1000" rows="4" placeholder="Schedule, other platforms, questions about the challenge…"></textarea>
+              <span class="hint">A message to the moderator team — this is not a bio, and it is never shown on the site.</span>
+            </label>
+          </div>
 
           <div class="apply-actions">
             <button class="ar-btn primary" type="submit" id="submitBtn">Send application</button>
             <span class="form-msg" id="formMsg" role="status" aria-live="polite"></span>
           </div>
         </form>
-
-        <p class="ar-note" style="margin-top:20px">
-          What we store: the answers above, and a one-way hash of your IP for
-          abuse triage. Your Discord handle and contact details are visible only
-          to PaperTrench moderators — never published, never sold. Ask a
-          moderator to delete your application and it's gone.
-        </p>
       </div>
 
       <div class="done" id="donePane" hidden>
-        <div class="big">🎥</div>
+        <svg class="mark" width="42" height="42" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9.2"/><path d="m8 12.3 2.8 2.8L16.3 9.6"/></svg>
         <h2>Application received</h2>
-        <p>A moderator will look it over and reach out on Discord. If you're approved, your card goes up on the streams page automatically.</p>
+        <p>It is sitting in the moderator queue now — not on the site. A moderator will read it and reach out on Discord. If they approve you, your card goes up on the streams page automatically.</p>
         <a class="btn btn-primary" href="/streams">Back to the streams page</a>
       </div>
     </div>
 
     <aside class="side reveal d1">
+      <!-- The card as it would be built, shown before anyone else can see it. -->
+      <div class="side-card">
+        <h3>Your card, if approved</h3>
+        <div class="prev-card" aria-live="polite">
+          <div class="prev-thumb" id="prevInitials">?<span class="chip">OFFLINE</span></div>
+          <div class="prev-body">
+            <div class="prev-name" id="prevName">Your channel name</div>
+            <div class="prev-handle" id="prevHandle">twitch.tv/you</div>
+            <div class="prev-blurb empty" id="prevBlurb">Your one-liner appears here.</div>
+          </div>
+        </div>
+        <p class="prev-foot">This is the whole of what a card can show. Nothing from the contact section can appear on it.</p>
+      </div>
+
       <div class="side-card">
         <h3>What approved streamers get</h3>
-        <div class="perk"><span class="ico">🌟</span><span><b>Streamer role</b> in the PaperTrench Discord.</span></div>
-        <div class="perk"><span class="ico">📢</span><span><b>Featured announcement</b> introducing you to the community.</span></div>
-        <div class="perk"><span class="ico">🔴</span><span><b>Automated live notifications</b> when you go live.</span></div>
-        <div class="perk"><span class="ico">🎬</span><span><b>A card on the streams page</b> — Twitch channels play inline.</span></div>
+        <div class="perk"><svg class="ico" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m12 3.5 2.6 5.4 5.9.8-4.3 4.1 1.1 5.9-5.3-2.9-5.3 2.9 1.1-5.9L3.5 9.7l5.9-.8z"/></svg><span><b>Streamer role</b> in the PaperTrench Discord.</span></div>
+        <div class="perk"><svg class="ico" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 10.5v3a1.5 1.5 0 0 0 1.5 1.5H7l5 4V6.5l-5 4H4.5A1.5 1.5 0 0 0 3 12z"/><path d="M17 9.2a4 4 0 0 1 0 5.6"/></svg><span><b>An announcement</b> introducing you to the community.</span></div>
+        <div class="perk"><svg class="ico" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M18 8.5a6 6 0 1 0-12 0c0 5.3-2.2 6.8-2.2 6.8h16.4S18 13.8 18 8.5"/><path d="M10.4 19.2a2 2 0 0 0 3.2 0"/></svg><span><b>Automatic live alerts</b> when you go live.</span></div>
+        <div class="perk"><svg class="ico" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2.5" y="6" width="12" height="12" rx="2"/><path d="m14.5 10.5 7-3.5v10l-7-3.5z"/></svg><span><b>A card on the streams page</b> — Twitch channels play inline.</span></div>
       </div>
-      <div class="side-card">
+
+      <div class="side-card prep">
         <h3>Before you apply</h3>
-        <div class="perk"><span class="ico">⬇</span><span>Install the extension from the <a href="/#install" style="color:var(--orange2)">install guide</a> — free, open source, no signup.</span></div>
-        <div class="perk"><span class="ico">🟩</span><span>Open <code>🎥 Stream overlay</code> from the popup and add it to OBS with a chroma key.</span></div>
-        <div class="perk"><span class="ico">⛓️</span><span>Your record is a <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener" style="color:var(--orange2)">hash-chained</a> paper wallet — same rules as everyone.</span></div>
+        <div class="perk"><svg class="ico" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3.5v12"/><path d="m7.5 11 4.5 4.5 4.5-4.5"/><path d="M4.5 19.5h15"/></svg><span>Install the extension from the <a href="/#install" style="color:var(--orange2)">install guide</a> — free, open source, no signup.</span></div>
+        <div class="perk"><svg class="ico" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4.5" width="18" height="13" rx="2"/><path d="M8 21h8"/><path d="M12 17.5V21"/></svg><span>Open <code>Stream overlay</code> from the popup and add it to OBS with a chroma key.</span></div>
+        <div class="perk"><svg class="ico" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10.5 13.5a4 4 0 0 0 5.7 0l2.6-2.6a4 4 0 0 0-5.7-5.7l-1.3 1.3"/><path d="M13.5 10.5a4 4 0 0 0-5.7 0l-2.6 2.6a4 4 0 1 0 5.7 5.7l1.3-1.3"/></svg><span>Your record is a <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener" style="color:var(--orange2)">hash-chained</a> paper wallet — same rules as everyone.</span></div>
       </div>
     </aside>
   </div>

--- a/site/streamer-signup.js
+++ b/site/streamer-signup.js
@@ -27,6 +27,69 @@
   }, { threshold: 0.12 });
   document.querySelectorAll('.reveal').forEach((el) => io.observe(el));
 
+  /* ---------- live preview of the published card ----------
+   *
+   * The form asks for personal details on the promise that only three of the
+   * answers are ever published. A promise is worth less than the artefact, so
+   * the sidebar renders the actual card from the actual public fields as they
+   * are typed. Anything absent from this preview does not go on the site.
+   *
+   * Every write below is textContent, never innerHTML: this is untrusted input
+   * being echoed back into the page, and the preview must not become the one
+   * place on the site where it executes.
+   */
+  const preview = {
+    initials: $('prevInitials'),
+    name: $('prevName'),
+    handle: $('prevHandle'),
+    blurb: $('prevBlurb'),
+  };
+  const blurbCount = $('blurbCount');
+
+  /** Same normalisation streams.js applies before it renders a roster card. */
+  function previewHandle(raw) {
+    const s = String(raw || '').trim().toLowerCase().replace(/^@/, '');
+    if (!s) return 'twitch.tv/you';
+    const m = s.match(/twitch\.tv\/([a-z0-9_]+)/);
+    if (m) return 'twitch.tv/' + m[1];
+    // A full URL to somewhere else is shown as typed — the card links out to
+    // whatever platform they gave, so inventing a twitch.tv/ prefix would
+    // preview a card that will never exist.
+    if (/^https?:\/\//.test(s) || s.includes('.')) return s.replace(/^https?:\/\//, '');
+    return /^[a-z0-9_]{3,25}$/.test(s) ? 'twitch.tv/' + s : s;
+  }
+
+  function initialsOf(name) {
+    return String(name).trim().split(/\s+/).map((w) => w[0] || '').join('').slice(0, 2).toUpperCase();
+  }
+
+  function renderPreview() {
+    if (!preview.name) return; // preview markup absent — form still works
+    const name = String(form.elements.name.value || '').trim();
+    const blurb = String(form.elements.blurb.value || '').trim();
+
+    preview.name.textContent = name || 'Your channel name';
+    preview.handle.textContent = previewHandle(form.elements.channelUrl.value);
+
+    // The initials tile keeps its OFFLINE chip child, so replace only the text
+    // node rather than clearing the element.
+    preview.initials.firstChild.nodeValue = initialsOf(name) || '?';
+
+    preview.blurb.textContent = blurb || 'Your one-liner appears here.';
+    preview.blurb.classList.toggle('empty', !blurb);
+
+    if (blurbCount) {
+      blurbCount.textContent = blurb.length + ' / 160';
+      blurbCount.classList.toggle('near', blurb.length > 140);
+    }
+  }
+
+  ['name', 'channelUrl', 'blurb'].forEach((field) => {
+    const el = form.elements[field];
+    if (el) el.addEventListener('input', renderPreview);
+  });
+  renderPreview();
+
   /**
    * Server reason code -> what the applicant should read.
    *

--- a/site/streamer-signup.js
+++ b/site/streamer-signup.js
@@ -39,6 +39,7 @@
    * place on the site where it executes.
    */
   const preview = {
+    card: $('prevCard'),
     initials: $('prevInitials'),
     name: $('prevName'),
     handle: $('prevHandle'),
@@ -46,27 +47,184 @@
   };
   const blurbCount = $('blurbCount');
 
+  /* ---------- platform → channel URL ----------
+   *
+   * The domain is the part nobody should have to type and the part typos
+   * land in, so the platform picker supplies it and the input takes only the
+   * handle. The server still derives the real platform from the finished URL
+   * (streamer.js platformOf) — this selector is an input aid, never the
+   * authority, so a mismatched pair cannot mislabel anything downstream.
+   */
+  const PLATFORMS = {
+    twitch: {
+      prefix: 'twitch.tv/', placeholder: 'yourname',
+      hint: 'Just the part after the slash. Pasting the full link works too.',
+      note: 'Twitch channels can be played inline on the streams page — the other platforms get a card that links out.',
+    },
+    kick: {
+      prefix: 'kick.com/', placeholder: 'yourname',
+      hint: 'Just the part after the slash. Pasting the full link works too.',
+      note: 'Kick channels get a roster card that links straight to your channel.',
+    },
+    youtube: {
+      prefix: 'youtube.com/', placeholder: '@yourhandle',
+      hint: 'Your @handle, or the full link to your channel page.',
+      note: 'YouTube channels get a roster card that links straight to your channel.',
+    },
+    other: {
+      prefix: '', placeholder: 'https://your-channel-link',
+      hint: 'Paste the full link to your channel, including https://.',
+      note: 'Anywhere else works too — the card links out to whatever you paste.',
+    },
+  };
+
+  const platformSel = $('f-platform');
+  const channelInput = $('f-channel');
+  const urlGroup = $('urlGroup');
+  const urlPrefix = $('urlPrefix');
+
+  const platformKey = () =>
+    (platformSel && PLATFORMS[platformSel.value]) ? platformSel.value : 'twitch';
+
+  /** Strip a pasted full URL back to the handle for the selected platform. */
+  function unwrapForPlatform(raw, key) {
+    let s = String(raw || '').trim().replace(/^@(?=[^/]*$)/, (m) => (key === 'youtube' ? '@' : ''));
+    if (key === 'other') return s;
+    s = s.replace(/^https?:\/\//i, '').replace(/^www\./i, '');
+    const host = { twitch: 'twitch.tv/', kick: 'kick.com/', youtube: 'youtube.com/' }[key];
+    if (host && s.toLowerCase().startsWith(host)) s = s.slice(host.length);
+    // youtu.be and /c//channel/ forms are left intact rather than guessed at.
+    return s.replace(/^\/+/, '');
+  }
+
+  /** The full URL the server is sent, composed from platform + handle. */
+  function composedUrl() {
+    const key = platformKey();
+    const raw = String(channelInput ? channelInput.value : '').trim();
+    if (!raw) return '';
+    if (key === 'other') return raw;
+    // Somebody pasted a link for a DIFFERENT platform than the one selected:
+    // send what they actually typed. The server reads the URL, not the picker,
+    // so honouring the paste is what keeps the two in agreement.
+    if (/^https?:\/\//i.test(raw) || /^[a-z0-9-]+\.[a-z]{2,}\//i.test(raw)) return raw;
+    return PLATFORMS[key].prefix + raw.replace(/^\/+/, '');
+  }
+
+  function applyPlatform() {
+    const key = platformKey();
+    const spec = PLATFORMS[key];
+    if (!urlGroup || !urlPrefix || !channelInput) return;
+
+    urlPrefix.textContent = spec.prefix;
+    urlPrefix.className = 'url-prefix ' + key;
+    urlGroup.classList.toggle('bare', !spec.prefix);
+    channelInput.placeholder = spec.placeholder;
+    channelInput.inputMode = key === 'other' ? 'url' : 'text';
+    const hint = $('channelHint');
+    if (hint) hint.textContent = spec.hint;
+    const note = $('platformHint');
+    if (note) note.textContent = spec.note;
+
+    // Re-unwrap what is already typed so switching platforms does not leave a
+    // handle sitting behind the wrong domain.
+    channelInput.value = unwrapForPlatform(channelInput.value, key);
+    renderPreview();
+  }
+
+  if (platformSel) platformSel.addEventListener('change', applyPlatform);
+
+  // Unwrap a pasted URL on the way out of the field, not while they type —
+  // rewriting the value mid-keystroke fights the cursor. Only a paste that
+  // matches the SELECTED platform collapses; a link to somewhere else is left
+  // whole, because composedUrl() forwards it verbatim.
+  if (channelInput) {
+    channelInput.addEventListener('blur', () => {
+      const key = platformKey();
+      if (key === 'other') return;
+      const host = { twitch: 'twitch.tv/', kick: 'kick.com/', youtube: 'youtube.com/' }[key];
+      const bare = channelInput.value.trim().replace(/^https?:\/\//i, '').replace(/^www\./i, '');
+      if (!host || !bare.toLowerCase().startsWith(host)) return;
+      channelInput.value = unwrapForPlatform(channelInput.value, key);
+      renderPreview();
+    });
+  }
+
+  /* ---------- contact method → what we still need ----------
+   * "Other" is the case that used to strand people: they picked it and the
+   * next field still said "Profile link", which is not what Other means. */
+  const CONTACT_ASK = {
+    '': null, // no preference — nothing more is needed
+    'Discord DM': null, // already answered by the Discord field above
+    'Email': {
+      label: 'Your email address',
+      placeholder: 'you@example.com',
+      hint: 'Where a moderator should email you about this application.',
+    },
+    'Twitter/X': {
+      label: 'Your X profile link',
+      placeholder: 'https://x.com/yourhandle',
+      hint: 'The account a moderator should DM.',
+    },
+    'Other': {
+      label: 'How should we reach you?',
+      placeholder: 'Telegram @you, Instagram link, anything…',
+      hint: 'Name the platform and the handle or link — a moderator has no other way to guess it.',
+    },
+  };
+
+  const methodSel = $('f-method');
+  const linkField = $('contactLinkField');
+
+  function applyContactMethod() {
+    if (!methodSel || !linkField) return;
+    const ask = CONTACT_ASK[methodSel.value] || null;
+    linkField.hidden = !ask;
+    if (!ask) return;
+    $('contactLinkLabel').textContent = ask.label;
+    $('contactLinkHint').textContent = ask.hint;
+    $('f-contactlink').placeholder = ask.placeholder;
+    // Email and free-text answers are not URLs, and the server only URL-checks
+    // contactLink when it looks like one — so the input type stays text.
+    $('f-contactlink').inputMode = methodSel.value === 'Email' ? 'email' : 'text';
+  }
+
+  if (methodSel) methodSel.addEventListener('change', applyContactMethod);
+
   /** Same normalisation streams.js applies before it renders a roster card. */
   function previewHandle(raw) {
-    const s = String(raw || '').trim().toLowerCase().replace(/^@/, '');
-    if (!s) return 'twitch.tv/you';
-    const m = s.match(/twitch\.tv\/([a-z0-9_]+)/);
-    if (m) return 'twitch.tv/' + m[1];
-    // A full URL to somewhere else is shown as typed — the card links out to
-    // whatever platform they gave, so inventing a twitch.tv/ prefix would
-    // preview a card that will never exist.
-    if (/^https?:\/\//.test(s) || s.includes('.')) return s.replace(/^https?:\/\//, '');
-    return /^[a-z0-9_]{3,25}$/.test(s) ? 'twitch.tv/' + s : s;
+    const url = composedUrl();
+    if (!url) return PLATFORMS[platformKey()].prefix + 'you' || 'your-channel-link';
+    return url.replace(/^https?:\/\//i, '').replace(/^www\./i, '');
   }
 
   function initialsOf(name) {
     return String(name).trim().split(/\s+/).map((w) => w[0] || '').join('').slice(0, 2).toUpperCase();
   }
 
+  /**
+   * Which platform the card should be COLOURED as.
+   *
+   * Not simply the dropdown: composedUrl() forwards a pasted link for another
+   * platform verbatim, and the server derives the real platform from that URL.
+   * So the preview reads the finished URL the same way, and a Kick link pasted
+   * while "Twitch" is selected previews green — which is the card that would
+   * actually be built.
+   */
+  function previewPlatform() {
+    const url = composedUrl().toLowerCase().replace(/^https?:\/\//, '').replace(/^www\./, '');
+    if (url.startsWith('twitch.tv/')) return 'twitch';
+    if (url.startsWith('kick.com/')) return 'kick';
+    if (url.startsWith('youtube.com/') || url.startsWith('youtu.be/')) return 'youtube';
+    if (url) return 'other';
+    return platformKey();   // nothing typed yet — follow the picker
+  }
+
   function renderPreview() {
     if (!preview.name) return; // preview markup absent — form still works
     const name = String(form.elements.name.value || '').trim();
     const blurb = String(form.elements.blurb.value || '').trim();
+
+    if (preview.card) preview.card.className = 'prev-card ' + previewPlatform();
 
     preview.name.textContent = name || 'Your channel name';
     preview.handle.textContent = previewHandle(form.elements.channelUrl.value);
@@ -88,6 +246,8 @@
     const el = form.elements[field];
     if (el) el.addEventListener('input', renderPreview);
   });
+  applyPlatform();
+  applyContactMethod();
   renderPreview();
 
   /**
@@ -141,6 +301,13 @@
     if (button.disabled) return;
 
     const data = Object.fromEntries(new FormData(form).entries());
+
+    // The input holds a handle; the server wants a URL. Compose it here so the
+    // stored channel_url is whole, and drop the picker itself — it is an input
+    // aid, and letting it ride along would invite a future reader to trust it
+    // over the URL that streamer.js actually derives the platform from.
+    data.channelUrl = composedUrl();
+    delete data.platform;
 
     // A cheap local pass on the three required text fields, so the obvious
     // omission does not cost a round trip. The server owns the real verdict.

--- a/site/streams.html
+++ b/site/streams.html
@@ -4,9 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PaperTrench — Live on Twitch · The PaperTrench Challenge</title>
-<meta name="description" content="Watch streamers grind the PaperTrench Challenge live on Twitch — real charts, fake money, verified leaderboard records, and giveaways for the best runs.">
+<meta name="description" content="Watch streamers run the PaperTrench Challenge live on Twitch — real charts, paper money, and records that are re-hashed and re-priced against public market history before they count.">
 <meta property="og:title" content="PaperTrench Challenge — Live on Twitch">
-<meta property="og:description" content="Streamers battle for the top of a leaderboard that can't be faked. Real prices, paper money, giveaways for the best verified records. Watch live.">
+<meta property="og:description" content="Streamers run a paper wallet on live markets. Every fill is hash-chained, replayed, and re-priced against public market history. Watch live.">
 <meta property="og:image" content="https://papertrench.com/assets/video-poster.jpg">
 <link rel="icon" href="/favicon.ico" sizes="48x48">
 <link rel="icon" type="image/png" href="/assets/icon96.png" sizes="96x96">
@@ -17,57 +17,83 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;700;800&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="style.css">
 <style>
-  /* ---------- streams page ---------- */
-  :root { --twitch: #9146FF; --twitch2: #bf94ff; }
+  /* ================================================================== *
+   *  /streams — the watch page.
+   *
+   *  Design brief: cleaner, and trustworthy on the page's own terms. The
+   *  old version led with "verified leaderboard records" and "giveaways"
+   *  as flat claims. Both are things a visitor cannot check from here, and
+   *  an unbacked claim is the opposite of trust — so the claims are now
+   *  stated as the MECHANISM that produces them, with a link to the code
+   *  that runs it, and the honest limits are printed next to the badge
+   *  rather than left in a doc nobody opens.
+   *
+   *  Visual pass: one gradient per page (the hero), emoji replaced with
+   *  drawn marks, and a monospace/protocol register for anything that
+   *  describes verification — it should read like a receipt, not an ad.
+   * ================================================================== */
+  :root { --twitch: #9146FF; --twitch2: #bf94ff; --twitch-dim: rgba(145,70,255,0.30); }
 
-  .k-twitch { color: var(--twitch2); background: rgba(145,70,255,0.10); border: 1px solid rgba(145,70,255,0.32); }
+  .k-twitch { color: var(--twitch2); background: rgba(145,70,255,0.10); border: 1px solid var(--twitch-dim); }
 
-  .hero.compact { padding: 140px 0 30px; }
-  .hero.compact h1 { font-size: clamp(38px, 5.6vw, 68px); }
+  /* ---------- hero ---------- */
+  .hero.compact { padding: 132px 0 26px; }
+  .hero.compact h1 { font-size: clamp(36px, 5.2vw, 62px); line-height: 1.05; letter-spacing: -1.5px; }
   .grad-twitch {
     background: linear-gradient(100deg, var(--twitch2) 10%, var(--twitch) 70%);
     -webkit-background-clip: text; background-clip: text; color: transparent;
   }
+
+  /* The status pill is a live readout, so it renders as one: monospace, and
+     it changes colour only when something is actually live. */
   .live-count {
-    display: inline-flex; align-items: center; gap: 8px;
-    font-size: 12.5px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase;
-    color: #ff8a80; background: rgba(224,67,58,0.09);
-    border: 1px solid rgba(224,67,58,0.35); border-radius: 999px; padding: 7px 16px;
+    display: inline-flex; align-items: center; gap: 9px;
+    font-family: var(--mono);
+    font-size: 11.5px; font-weight: 700; letter-spacing: 1.1px; text-transform: uppercase;
+    color: var(--muted); background: rgba(255,255,255,0.035);
+    border: 1px solid var(--line2); border-radius: 999px; padding: 7px 15px 7px 13px;
+    transition: color .3s, border-color .3s, background .3s;
   }
-  .live-count .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--red); box-shadow: 0 0 10px var(--red); animation: pulse 1.6s infinite; }
+  .live-count .dot {
+    width: 7px; height: 7px; border-radius: 50%;
+    background: var(--dim); transition: background .3s, box-shadow .3s;
+  }
+  .live-count.on { color: #ff9a90; background: rgba(224,67,58,0.09); border-color: rgba(224,67,58,0.34); }
+  .live-count.on .dot { background: var(--red); box-shadow: 0 0 10px var(--red); animation: pulse 1.6s infinite; }
+
+  .hero-sub a { color: var(--twitch2); border-bottom: 1px solid rgba(191,148,255,0.3); }
+  .hero-sub a:hover { border-bottom-color: var(--twitch2); }
 
   /* ---------- featured player ---------- */
-  .watch-sec { padding: 30px 0 70px; }
-  .player-grid { display: grid; grid-template-columns: 1fr 340px; gap: 16px; align-items: stretch; }
+  .watch-sec { padding: 26px 0 64px; }
+  .player-grid { display: grid; grid-template-columns: minmax(0,1fr) 336px; gap: 14px; align-items: stretch; }
   .player-shell {
-    position: relative; overflow: hidden;
+    position: relative; overflow: hidden; display: flex; flex-direction: column;
     background: var(--panel); border: 1px solid var(--line2); border-radius: var(--radius);
     box-shadow: 0 30px 80px rgba(0,0,0,0.55);
   }
   .player-shell .frame-wrap { position: relative; aspect-ratio: 16 / 9; background: #000; }
   .player-shell iframe { position: absolute; inset: 0; width: 100%; height: 100%; border: 0; }
+
   .player-bar {
     display: flex; align-items: center; gap: 12px;
-    padding: 12px 16px; border-top: 1px solid var(--line);
-    font-size: 13.5px;
+    padding: 13px 16px; border-top: 1px solid var(--line);
+    background: rgba(0,0,0,0.22);
   }
-  .player-bar .who { font-weight: 800; }
-  .player-bar .handle { color: var(--muted); font-weight: 600; font-size: 12.5px; }
+  .player-bar .who { font-weight: 800; font-size: 14.5px; letter-spacing: -0.2px; }
+  .player-bar .handle { font-family: var(--mono); color: var(--dim); font-weight: 500; font-size: 11.5px; }
   .player-bar .spacer { margin-left: auto; }
-  .player-bar a.twitch-out {
-    font-size: 12.5px; font-weight: 700; color: var(--twitch2);
-    border: 1px solid rgba(145,70,255,0.35); background: rgba(145,70,255,0.08);
-    padding: 6px 13px; border-radius: 999px; transition: background .2s;
+  .pill-btn {
+    font: inherit; font-size: 12px; font-weight: 700; cursor: pointer; white-space: nowrap;
+    border-radius: 999px; padding: 7px 14px;
+    transition: color .2s, background .2s, border-color .2s;
   }
-  .player-bar a.twitch-out:hover { background: rgba(145,70,255,0.18); }
-  .chat-toggle {
-    font: inherit; font-size: 12.5px; font-weight: 700; cursor: pointer;
-    color: var(--muted); background: rgba(255,255,255,0.04);
-    border: 1px solid var(--line2); border-radius: 999px; padding: 6px 13px;
-    transition: color .2s, background .2s;
-  }
-  .chat-toggle:hover { color: var(--text); background: rgba(255,255,255,0.09); }
-  @media (max-width: 980px) { .chat-toggle { display: none; } }
+  .pill-btn.ghost { color: var(--muted); background: rgba(255,255,255,0.04); border: 1px solid var(--line2); }
+  .pill-btn.ghost:hover { color: var(--text); background: rgba(255,255,255,0.09); }
+  .pill-btn.twitch { color: var(--twitch2); background: rgba(145,70,255,0.09); border: 1px solid var(--twitch-dim); }
+  .pill-btn.twitch:hover { background: rgba(145,70,255,0.2); border-color: rgba(145,70,255,0.55); }
+  @media (max-width: 980px) { #chatToggle { display: none; } }
+
   .player-grid.no-chat { grid-template-columns: 1fr; }
   .player-grid.no-chat .chat-shell { display: none !important; }
   .chat-shell {
@@ -75,67 +101,135 @@
     background: var(--panel); border: 1px solid var(--line2); border-radius: var(--radius);
   }
   .chat-shell iframe { flex: 1; width: 100%; border: 0; min-height: 400px; }
-  .chat-label { padding: 10px 14px; border-bottom: 1px solid var(--line); font-size: 11px; font-weight: 800; letter-spacing: 1.2px; color: var(--dim); }
+  .chat-label {
+    padding: 12px 15px; border-bottom: 1px solid var(--line);
+    font-family: var(--mono); font-size: 10.5px; font-weight: 700;
+    letter-spacing: 1.4px; color: var(--dim);
+  }
   @media (max-width: 980px) { .player-grid { grid-template-columns: 1fr; } .chat-shell { display: none; } }
 
   .player-empty {
     aspect-ratio: 16 / 9; display: grid; place-items: center; text-align: center;
     background:
-      radial-gradient(500px 260px at 50% 0%, rgba(145,70,255,0.14), transparent 70%),
+      radial-gradient(560px 280px at 50% 0%, rgba(145,70,255,0.13), transparent 72%),
       var(--panel2);
   }
-  .player-empty .inner { max-width: 460px; padding: 24px; }
-  .player-empty .big { font-size: 42px; margin-bottom: 14px; }
-  .player-empty h3 { font-size: 20px; font-weight: 800; margin-bottom: 8px; }
-  .player-empty p { font-size: 14px; color: var(--muted); }
+  .player-empty .inner { max-width: 440px; padding: 26px; }
+  .player-empty .mark { margin: 0 auto 16px; color: var(--twitch2); opacity: .85; }
+  .player-empty h3 { font-size: 19px; font-weight: 800; margin-bottom: 8px; letter-spacing: -0.3px; }
+  .player-empty p { font-size: 13.5px; color: var(--muted); line-height: 1.6; }
+  .player-empty a { color: var(--twitch2); }
 
-  /* ---------- streamer cards ---------- */
-  .streamers-sec { padding: 20px 0 90px; }
-  .streamer-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; margin-top: 40px; }
+  /* ---------- roster ---------- */
+  .streamers-sec { padding: 8px 0 76px; }
+  .streamer-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; margin-top: 34px; }
   @media (max-width: 980px) { .streamer-grid { grid-template-columns: repeat(2, 1fr); } }
   @media (max-width: 640px) { .streamer-grid { grid-template-columns: 1fr; } }
+
   .s-card {
-    text-align: left; cursor: pointer; overflow: hidden; padding: 0;
-    background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius);
-    font: inherit; color: inherit;
-    transition: transform .25s, border-color .25s, box-shadow .25s;
+    position: relative; text-align: left; cursor: pointer; overflow: hidden; padding: 0;
+    background: var(--panel); border: 1px solid var(--line); border-radius: 14px;
+    font: inherit; color: inherit; display: block; width: 100%;
+    transition: transform .22s cubic-bezier(.2,.8,.2,1), border-color .22s, box-shadow .22s;
   }
-  .s-card:hover { transform: translateY(-5px); border-color: rgba(145,70,255,0.45); box-shadow: 0 24px 60px rgba(0,0,0,0.5); }
+  .s-card:hover { transform: translateY(-4px); border-color: rgba(145,70,255,0.42); box-shadow: 0 22px 54px rgba(0,0,0,0.5); }
+  .s-card:hover .s-play { opacity: 1; transform: scale(1); }
+
   .s-thumb { position: relative; aspect-ratio: 16 / 9; background: var(--panel2); overflow: hidden; }
   .s-thumb img { width: 100%; height: 100%; object-fit: cover; display: block; }
   .s-thumb .ph {
     position: absolute; inset: 0; display: grid; place-items: center;
-    font-size: 34px; font-weight: 900; color: rgba(255,255,255,0.16); letter-spacing: 2px;
-    background: linear-gradient(145deg, rgba(145,70,255,0.16), rgba(145,70,255,0.03));
+    font-family: var(--mono);
+    font-size: 30px; font-weight: 800; color: rgba(255,255,255,0.18); letter-spacing: 2px;
+    background: linear-gradient(145deg, rgba(145,70,255,0.15), rgba(145,70,255,0.02));
+  }
+  /* A play affordance on hover — the card is a button, so it should look
+     like one the moment a pointer is on it. */
+  .s-play {
+    position: absolute; inset: 0; margin: auto; width: 52px; height: 52px;
+    display: grid; place-items: center; pointer-events: none;
+    border-radius: 50%; background: rgba(10,6,20,0.72); border: 1px solid rgba(191,148,255,0.5);
+    color: #fff; opacity: 0; transform: scale(.86);
+    transition: opacity .22s, transform .22s;
+    backdrop-filter: blur(3px);
   }
   .s-live {
-    position: absolute; top: 10px; left: 10px;
+    position: absolute; top: 9px; left: 9px;
     display: inline-flex; align-items: center; gap: 6px;
-    font-size: 10px; font-weight: 800; letter-spacing: 1.2px;
-    padding: 4px 10px; border-radius: 999px;
+    font-family: var(--mono);
+    font-size: 9.5px; font-weight: 700; letter-spacing: 1.1px;
+    padding: 4px 9px; border-radius: 999px;
   }
-  .s-live.on { background: rgba(224,67,58,0.92); color: #fff; }
+  .s-live.on { background: rgba(224,67,58,0.94); color: #fff; }
   .s-live.on .dot { width: 6px; height: 6px; border-radius: 50%; background: #fff; animation: pulse 1.6s infinite; }
-  .s-live.off { background: rgba(0,0,0,0.65); color: var(--muted); border: 1px solid var(--line2); }
-  .s-body { padding: 15px 17px 17px; }
-  .s-name { display: flex; align-items: center; gap: 8px; font-size: 15.5px; font-weight: 800; }
-  .s-handle { font-size: 12.5px; color: var(--twitch2); font-weight: 700; margin-top: 1px; }
-  .s-blurb { margin-top: 8px; font-size: 13.5px; color: var(--muted); line-height: 1.5; }
+  .s-live.off { background: rgba(0,0,0,0.7); color: var(--dim); border: 1px solid var(--line2); }
+
+  .s-body { padding: 14px 16px 16px; }
+  .s-name { font-size: 15px; font-weight: 800; letter-spacing: -0.2px; }
+  .s-handle { font-family: var(--mono); font-size: 11.5px; color: var(--twitch2); font-weight: 500; margin-top: 3px; }
+  .s-blurb { margin-top: 9px; font-size: 13px; color: var(--muted); line-height: 1.55; }
+
+  /* The open slot is an invitation, not a fake streamer — it never borrows
+     the live/offline vocabulary of a real card. */
+  .s-card.open { border-style: dashed; border-color: rgba(145,70,255,0.3); background: rgba(145,70,255,0.02); }
+  .s-card.open:hover { border-color: rgba(145,70,255,0.55); }
+  .s-card.open .s-thumb { background: transparent; }
+  .s-card.open .ph { background: linear-gradient(145deg, rgba(145,70,255,0.09), transparent); color: rgba(191,148,255,0.3); }
 
   .signup-strip {
-    margin-top: 46px; padding: 22px 26px;
+    margin-top: 40px; padding: 22px 26px;
     display: flex; align-items: center; gap: 18px; flex-wrap: wrap;
-    background: linear-gradient(120deg, rgba(145,70,255,0.10), rgba(255,157,69,0.07));
-    border: 1px solid rgba(145,70,255,0.3); border-radius: var(--radius);
+    background: linear-gradient(120deg, rgba(145,70,255,0.10), rgba(255,157,69,0.06));
+    border: 1px solid var(--twitch-dim); border-radius: var(--radius);
   }
   .signup-strip .txt { flex: 1; min-width: 260px; }
-  .signup-strip h3 { font-size: 18px; font-weight: 800; margin-bottom: 4px; }
-  .signup-strip p { font-size: 13.5px; color: var(--muted); }
+  .signup-strip h3 { font-size: 17.5px; font-weight: 800; margin-bottom: 5px; letter-spacing: -0.3px; }
+  .signup-strip p { font-size: 13.5px; color: var(--muted); line-height: 1.55; }
   .btn-twitch {
     background: linear-gradient(135deg, var(--twitch2), var(--twitch));
-    color: #140030; box-shadow: 0 10px 30px -8px rgba(145,70,255,0.55);
+    color: #150031; box-shadow: 0 10px 30px -8px rgba(145,70,255,0.55);
   }
   .btn-twitch:hover { transform: translateY(-2px); box-shadow: 0 14px 36px -8px rgba(145,70,255,0.7); }
+
+  /* ---------- how a record is checked ---------- */
+  .proof-sec { padding: 20px 0 30px; background: linear-gradient(180deg, transparent, rgba(145,70,255,0.035), transparent); }
+  .proof-head { max-width: 640px; }
+
+  .proof-chain { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin-top: 38px; }
+  @media (max-width: 900px) { .proof-chain { grid-template-columns: 1fr; } }
+  .proof-step {
+    position: relative; padding: 22px 22px 24px;
+    background: var(--panel); border: 1px solid var(--line); border-radius: 14px;
+  }
+  .proof-step .idx {
+    font-family: var(--mono); font-size: 11px; font-weight: 700; letter-spacing: 1.4px;
+    color: var(--dim); margin-bottom: 14px;
+  }
+  .proof-step h3 { font-size: 16px; font-weight: 800; margin-bottom: 8px; letter-spacing: -0.2px; }
+  .proof-step p { font-size: 13.5px; color: var(--muted); line-height: 1.6; }
+  .proof-step code {
+    font-family: var(--mono); font-size: 11.5px; color: var(--twitch2);
+    background: rgba(145,70,255,0.08); padding: 2px 6px; border-radius: 5px;
+  }
+
+  /* The limits of the badge, printed beside the badge. A verification page
+     that only lists what it proves is advertising. */
+  .proof-limits {
+    margin-top: 18px; padding: 18px 22px;
+    display: flex; gap: 14px; align-items: flex-start;
+    background: rgba(255,157,69,0.045); border: 1px solid rgba(255,157,69,0.2);
+    border-left: 2px solid var(--orange); border-radius: 12px;
+  }
+  .proof-limits .mark { flex: none; color: var(--orange2); margin-top: 1px; }
+  .proof-limits p { font-size: 13px; color: var(--muted); line-height: 1.65; }
+  .proof-limits b { color: var(--text); font-weight: 700; }
+  .proof-limits a { color: var(--orange2); border-bottom: 1px solid rgba(255,192,129,0.28); }
+
+  /* ---------- stream it yourself ---------- */
+  .obs-sec { padding: 56px 0 20px; }
+
+  /* ---------- final ---------- */
+  .final-cta { padding: 96px 0 110px; }
 </style>
 </head>
 <body>
@@ -168,9 +262,8 @@
 <!-- ============ HERO ============ -->
 <header class="hero compact">
   <div class="wrap">
-    <span class="live-count reveal"><span class="dot"></span><span id="liveCountLabel">The PaperTrench Challenge</span></span>
+    <span class="live-count reveal" id="liveCount"><span class="dot"></span><span id="liveCountLabel">The PaperTrench Challenge</span></span>
     <h1 class="reveal d1">Watch the trenches.<br><span class="grad-twitch">Live on Twitch.</span></h1>
-    <p class="hero-sub reveal d2">Streamers are grinding the PaperTrench leaderboard live — real charts, real launches, <strong>fake money</strong> — and the best verified records win <strong>giveaways</strong>. Watch how they read the trenches, then <a href="/#install" style="color:var(--orange2)">run your own paper wallet</a> and try to beat them.</p>
   </div>
 </header>
 
@@ -186,8 +279,8 @@
           <span class="who" id="playerWho"></span>
           <span class="handle" id="playerHandle"></span>
           <span class="spacer"></span>
-          <button class="chat-toggle" id="chatToggle" type="button">Hide chat</button>
-          <a class="twitch-out" id="playerOut" href="#" target="_blank" rel="noopener">Watch on Twitch ↗</a>
+          <button class="pill-btn ghost" id="chatToggle" type="button">Hide chat</button>
+          <a class="pill-btn twitch" id="playerOut" href="#" target="_blank" rel="noopener">Watch on Twitch ↗</a>
         </div>
       </div>
       <div class="chat-shell" id="chatShell" style="display:none">
@@ -198,51 +291,81 @@
   </div>
 </section>
 
-<!-- ============ STREAMER GRID ============ -->
-<section class="streamers-sec" id="streamers" style="padding-top:0">
+<!-- ============ ROSTER ============ -->
+<section class="streamers-sec" id="streamers">
   <div class="wrap">
     <span class="sec-kicker k-twitch reveal">Challenge roster</span>
-    <h2 class="reveal d1">The streamers <span class="grad-twitch">in the trench</span></h2>
-    <p class="sec-sub reveal d2">Every one of them trades a paper wallet with a hash-chained, verifiable record — the same leaderboard protocol as everyone else. Click a card to watch.</p>
+    <h2 class="reveal d1">The streamers in the trench</h2>
+    <p class="sec-sub reveal d2">Every one of them trades a paper wallet under the same protocol as everyone else — no house accounts, no seeded balances. Pick a card to watch them here.</p>
     <div class="streamer-grid" id="streamerGrid"></div>
+
     <div class="signup-strip reveal" id="signupStrip">
       <div class="txt">
-        <h3>Streaming the challenge? Get featured here.</h3>
-        <p>Any Twitch streamer running PaperTrench can join the roster — we link your stream on this page and you compete for the giveaway with a record nobody can fake.</p>
+        <h3>Streaming the challenge? Get on the roster.</h3>
+        <p>Any Twitch streamer running PaperTrench can apply. Approved channels get a card on this page, the Streamer role in Discord, and an automatic alert when they go live.</p>
       </div>
-      <a class="btn btn-twitch" id="signupBtn" href="/streamer-signup">Sign up as a streamer</a>
+      <a class="btn btn-twitch" id="signupBtn" href="/streamer-signup">Apply as a streamer</a>
     </div>
   </div>
 </section>
 
-<!-- ============ HOW THE CHALLENGE WORKS ============ -->
-<section id="challenge" style="padding-top:40px;background:linear-gradient(180deg, transparent, rgba(145,70,255,0.04), transparent)">
+<!-- ============ HOW A RECORD IS CHECKED ============ -->
+<section class="proof-sec" id="challenge">
   <div class="wrap">
-    <div style="text-align:center;max-width:680px;margin:0 auto">
-      <span class="sec-kicker k-green reveal">The rules</span>
-      <h2 class="reveal d1">A competition that <span style="background:linear-gradient(100deg,var(--green2),var(--green));-webkit-background-clip:text;background-clip:text;color:transparent">can't be gamed</span></h2>
+    <div class="proof-head">
+      <span class="sec-kicker k-green reveal">How a record is checked</span>
+      <h2 class="reveal d1">Standings come from the fills, not the screenshots</h2>
+      <p class="sec-sub reveal d2">Nobody on this page reports their own numbers. A record is rebuilt from the raw fills by a server that runs three checks in order — and the code that runs them is public.</p>
     </div>
-    <div class="grid3">
-      <div class="gcard reveal"><div class="gi">⛓️</div><h3>Verified, not vibes</h3><p>Every fill is committed to a SHA-256 hash chain the moment it happens. Standings come from the raw fills — no screenshots, no self-reported numbers, no edited history.</p></div>
-      <div class="gcard reveal d1"><div class="gi">🪙</div><h3>Paper only. Everyone equal.</h3><p>Every competitor starts from the same paper balance, and nobody risks a cent. It's pure skill expression: entries, exits, sizing, discipline — on live markets.</p></div>
-      <div class="gcard reveal d2"><div class="gi">🎁</div><h3>Top the board, win the giveaway</h3><p>Best verified records on the leaderboard win. Prize details and season dates are announced on the streams — follow the roster above so you don't miss a drop.</p></div>
+
+    <div class="proof-chain">
+      <div class="proof-step reveal">
+        <div class="idx">STEP 01 · LOCAL</div>
+        <h3>Each fill signs the one before it</h3>
+        <p>The moment a trade executes, the extension commits its mint, size, price, timestamp and chain into a <code>SHA-256</code> link over the previous one. Editing any fill after the fact breaks every link that followed it.</p>
+      </div>
+      <div class="proof-step reveal d1">
+        <div class="idx">STEP 02 · SERVER</div>
+        <h3>The whole chain is re-hashed and replayed</h3>
+        <p>On submission the server recomputes every link, refuses a history that shrank or was swapped for a luckier one, and replays the book itself. Your claimed P&amp;L is never what ranks — the replay's is.</p>
+      </div>
+      <div class="proof-step reveal d2">
+        <div class="idx">STEP 03 · MARKET</div>
+        <h3>Every fill is re-priced against real candles</h3>
+        <p>A valid hash only proves a history is internally consistent. So each fill's price is checked against the minute it claims to have traded in, using public market data. A price that never existed fails the record.</p>
+      </div>
+    </div>
+
+    <div class="proof-limits reveal">
+      <svg class="mark" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 8h.01M11 12h1v4h1"/></svg>
+      <p>
+        <b>What the checks do not cover.</b> Re-pricing needs public candle data
+        for the minute a fill claims, and the newest launches often have none —
+        those fills come back <i>unpriced</i> rather than passing, and a record
+        carrying too many of them is labelled instead of ranked. Live/offline
+        badges on this page are inferred from Twitch's public preview images,
+        not an official Twitch API, so treat them as a hint rather than a
+        guarantee. The full protocol, including what it deliberately refuses to
+        claim, is in
+        <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener">LEADERBOARD.md</a>.
+      </p>
     </div>
   </div>
 </section>
 
 <!-- ============ STREAM IT YOURSELF ============ -->
-<section id="stream-yourself">
+<section class="obs-sec" id="stream-yourself">
   <div class="wrap">
-    <div style="text-align:center;max-width:720px;margin:0 auto">
+    <div style="text-align:center;max-width:700px;margin:0 auto">
       <span class="sec-kicker k-orange reveal">For streamers</span>
-      <h2 class="reveal d1">Put your paper P&amp;L <span class="grad-orange" style="background:linear-gradient(100deg,var(--orange2),var(--orange-deep));-webkit-background-clip:text;background-clip:text;color:transparent">on stream</span></h2>
-      <p class="sec-sub reveal d2" style="margin:0 auto">PaperTrench ships a built-in <b>stream overlay</b> — a chroma-key window with your live equity, session P&amp;L, win rate, and open positions. It updates the instant you trade, and it's permanently marked <b>PAPER</b> so your chat always knows it's simulated.</p>
+      <h2 class="reveal d1">Put your paper P&amp;L on stream</h2>
+      <p class="sec-sub reveal d2" style="margin:0 auto">PaperTrench ships a built-in <b>stream overlay</b> — a chroma-key window with live equity, session P&amp;L, win rate and open positions. It updates the instant you trade, and it is permanently marked <b>PAPER</b> so your chat is never in doubt about what they are watching.</p>
     </div>
     <div class="install-steps">
       <div class="step reveal"><div class="n">01</div><h4>Install PaperTrench</h4><p>Grab the extension from the <a href="/#install" style="color:var(--orange2)">install guide</a> — free, open source, no signup.</p></div>
-      <div class="step reveal d1"><div class="n">02</div><h4>Open the overlay</h4><p>Click the PaperTrench icon → <code>🎥 Stream overlay</code>. A capture-ready window opens on a green screen.</p></div>
+      <div class="step reveal d1"><div class="n">02</div><h4>Open the overlay</h4><p>Click the PaperTrench icon, then <code>Stream overlay</code>. A capture-ready window opens on a green screen.</p></div>
       <div class="step reveal d2"><div class="n">03</div><h4>Add it to OBS</h4><p>Sources → <code>Window Capture</code> → pick the overlay → add a <code>Chroma Key</code> filter. Defaults just work.</p></div>
-      <div class="step reveal d3"><div class="n">04</div><h4>Go live &amp; sign up</h4><p>Trade with the overlay on screen and <a href="#streamers" style="color:var(--orange2)">join the roster</a> to get featured on this page.</p></div>
+      <div class="step reveal d3"><div class="n">04</div><h4>Go live &amp; apply</h4><p>Trade with the overlay on screen, then <a href="/streamer-signup" style="color:var(--orange2)">apply for the roster</a> to get featured here.</p></div>
     </div>
   </div>
 </section>
@@ -252,8 +375,8 @@
   <div class="wrap">
     <span class="hero-badge reveal"><span class="dot"></span>Paper money. Real competition.</span>
     <h2 class="reveal d1" style="margin-top:24px">Think you can out-trade them?<br><span class="grad-twitch">Prove it on the board.</span></h2>
-    <div class="hero-ctas reveal d3" style="margin-top:36px;justify-content:center">
-      <a class="btn btn-primary" href="/#install">⬇ Get PaperTrench</a>
+    <div class="hero-ctas reveal d3" style="margin-top:34px;justify-content:center">
+      <a class="btn btn-primary" href="/#install">Get PaperTrench</a>
       <a class="btn btn-ghost" href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener">How verification works</a>
     </div>
   </div>

--- a/site/streams.html
+++ b/site/streams.html
@@ -184,9 +184,12 @@
   .s-name { font-size: 15px; font-weight: 800; letter-spacing: -0.2px; }
   .s-handle {
     display: inline-block; font-family: var(--mono); font-size: 11.5px;
-    color: var(--twitch2); font-weight: 500; margin-top: 3px; word-break: break-all;
+    color: var(--twitch2); font-weight: 500; margin-top: 3px;
+    border-bottom: 1px solid transparent; word-break: break-all;
   }
+  a.s-handle:hover { border-bottom-color: currentColor; }
   .s-card.link .s-handle { color: var(--muted); }
+  .s-card[data-login] .s-handle { color: var(--twitch2); }
   .s-blurb { margin-top: 9px; font-size: 13px; color: var(--muted); line-height: 1.55; }
 
   /* The open slot is an invitation, not a fake streamer — it never borrows

--- a/site/streams.html
+++ b/site/streams.html
@@ -32,7 +32,10 @@
    *  drawn marks, and a monospace/protocol register for anything that
    *  describes verification — it should read like a receipt, not an ad.
    * ================================================================== */
-  :root { --twitch: #9146FF; --twitch2: #bf94ff; --twitch-dim: rgba(145,70,255,0.30); }
+  :root {
+    --twitch: #9146FF; --twitch2: #bf94ff; --twitch-dim: rgba(145,70,255,0.30);
+    --kick: #53fc18; --yt: #ff4e45;
+  }
 
   .k-twitch { color: var(--twitch2); background: rgba(145,70,255,0.10); border: 1px solid var(--twitch-dim); }
 
@@ -164,9 +167,26 @@
   .s-live.on .dot { width: 6px; height: 6px; border-radius: 50%; background: #fff; animation: pulse 1.6s infinite; }
   .s-live.off { background: rgba(0,0,0,0.7); color: var(--dim); border: 1px solid var(--line2); }
 
+  /* Off Twitch there is no live signal to report, so the slot names the
+     platform in that platform's colour instead of guessing a status. */
+  .s-live.plat { background: rgba(0,0,0,0.72); }
+  .s-live.plat.twitch  { color: var(--twitch2); border: 1px solid var(--twitch-dim); }
+  .s-live.plat.kick    { color: var(--kick);    border: 1px solid rgba(83,252,24,0.34); }
+  .s-live.plat.youtube { color: var(--yt);      border: 1px solid rgba(255,78,69,0.34); }
+  .s-live.plat.other   { color: var(--muted);   border: 1px solid var(--line2); }
+
+  /* A link-out card says so: arrow instead of a play triangle, and it never
+     borrows the player card's hover promise. */
+  .s-card.link:hover { border-color: rgba(255,255,255,0.22); }
+  .s-play.out { background: rgba(6,10,16,0.74); border-color: rgba(255,255,255,0.34); }
+
   .s-body { padding: 14px 16px 16px; }
   .s-name { font-size: 15px; font-weight: 800; letter-spacing: -0.2px; }
-  .s-handle { font-family: var(--mono); font-size: 11.5px; color: var(--twitch2); font-weight: 500; margin-top: 3px; }
+  .s-handle {
+    display: inline-block; font-family: var(--mono); font-size: 11.5px;
+    color: var(--twitch2); font-weight: 500; margin-top: 3px; word-break: break-all;
+  }
+  .s-card.link .s-handle { color: var(--muted); }
   .s-blurb { margin-top: 9px; font-size: 13px; color: var(--muted); line-height: 1.55; }
 
   /* The open slot is an invitation, not a fake streamer — it never borrows

--- a/site/streams.js
+++ b/site/streams.js
@@ -16,6 +16,9 @@
 
   // Hand-maintained roster. Entries here always show, and they win over a
   // sheet row with the same login — useful for pinning or fixing a blurb.
+  // `login` is the Twitch login and means "embeddable inline". Kick and
+  // YouTube entries carry `platform` + `channelUrl` instead and render as
+  // link-out cards — there is no login to invent for a player we cannot mount.
   const STREAMERS = [
     {
       login: 'onlyterp',                 // twitch.tv/<login> — lowercase
@@ -91,6 +94,68 @@
     '<path d="M8 5.6v12.8a.7.7 0 0 0 1.07.6l10-6.4a.7.7 0 0 0 0-1.2l-10-6.4A.7.7 0 0 0 8 5.6z"/>' +
     '</svg></span>';
 
+  const MARK_OUT =
+    '<span class="s-play out" aria-hidden="true">' +
+    '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+    'stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+    '<path d="M14 4.5h5.5V10M19.5 4.5 11 13"/>' +
+    '<path d="M17.5 14v4.6a1.6 1.6 0 0 1-1.6 1.6H5.9a1.6 1.6 0 0 1-1.6-1.6V8.1A1.6 1.6 0 0 1 5.9 6.5h4.6"/>' +
+    '</svg></span>';
+
+  /* ---------- platforms ----------
+   *
+   * Only Twitch can be embedded, so only Twitch cards act as a player button.
+   * The rest are links, and are drawn as links — a card that looks identical
+   * to a playable one but silently opens a new tab teaches the visitor that
+   * the whole grid is unpredictable. Live/offline is a Twitch-only signal too
+   * (it comes from Twitch's preview CDN), so the other platforms show their
+   * platform name where the badge would be rather than a guessed status.
+   */
+  const PLATFORMS = {
+    twitch: {
+      label: 'Twitch', host: 'twitch.tv/', embeddable: true,
+      url: (s) => 'https://twitch.tv/' + encodeURIComponent(s.login),
+    },
+    kick: {
+      label: 'Kick', host: 'kick.com/', embeddable: false,
+      url: (s) => s.channelUrl,
+    },
+    youtube: {
+      label: 'YouTube', host: 'youtube.com/', embeddable: false,
+      url: (s) => s.channelUrl,
+    },
+    other: {
+      label: 'Stream', host: '', embeddable: false,
+      url: (s) => s.channelUrl,
+    },
+  };
+
+  const platformOf = (s) => PLATFORMS[s && s.platform] || PLATFORMS.twitch;
+
+  /** The href a card points at, or null when there is nothing safe to link. */
+  function channelHref(s) {
+    const spec = platformOf(s);
+    if (spec.embeddable) return s.login ? spec.url(s) : null;
+    const raw = spec.url(s);
+    if (!raw) return null;
+    // The roster is server-normalized, but this is the point where a string
+    // becomes an href a visitor clicks. Re-check the scheme rather than
+    // trusting the trip it took to get here.
+    try {
+      const url = new URL(String(raw));
+      return (url.protocol === 'https:' || url.protocol === 'http:') ? url.toString() : null;
+    } catch { return null; }
+  }
+
+  /** What to print under the name: "twitch.tv/name", or the bare host+path. */
+  function channelLabel(s) {
+    const spec = platformOf(s);
+    if (spec.embeddable && s.login) return spec.host + s.login;
+    const href = channelHref(s);
+    if (!href) return spec.label;
+    return href.replace(/^https?:\/\//i, '').replace(/^www\./i, '').replace(/\/$/, '');
+  }
+
   /* ---------- scroll reveal (same behaviour as main.js) ---------- */
   const io = new IntersectionObserver((entries) => {
     for (const e of entries) {
@@ -102,6 +167,9 @@
   /* ---------- state ---------- */
   const live = new Map();       // login -> true | false | null (unknown)
   let roster = [...STREAMERS];  // manual entries + approved sheet rows
+
+  /** Identity for dedupe: a Twitch login, else the channel it points at. */
+  const keyOf = (s) => (s.login ? 'twitch:' + s.login : 'url:' + String(s.channelUrl || '').toLowerCase());
   let featured = null;          // login currently in the big player
   let userPinned = false;       // stop auto-promotion once the viewer chose
 
@@ -180,18 +248,28 @@
       const body = await res.json();
       if (!body || !body.ok || !Array.isArray(body.streamers)) return;
 
-      const seen = new Set(roster.map((s) => s.login));
+      const seen = new Set(roster.map((s) => keyOf(s)));
       for (const row of body.streamers) {
+        if (!row) continue;
         // The server normalizes these, but the page owns what it renders:
         // re-run the same login rule rather than trusting the shape.
-        const login = normalizeLogin(row && row.login);
-        if (!login || seen.has(login)) continue;
-        seen.add(login);
-        roster.push({
-          login,
-          name: String((row && row.name) || '').trim() || login,
-          blurb: String((row && row.blurb) || '').trim(),
-        });
+        const login = normalizeLogin(row.login);
+        const platform = PLATFORMS[row.platform] ? row.platform : (login ? 'twitch' : 'other');
+        const entry = {
+          login: login || null,
+          platform,
+          channelUrl: String(row.channelUrl || '').trim() || null,
+          name: String(row.name || '').trim() || login || '',
+          blurb: String(row.blurb || '').trim(),
+        };
+        // An entry we can neither embed nor link is not a card, it is a
+        // name with nowhere to go — drop it rather than render a dead tile.
+        if (!entry.login && !channelHref(entry)) continue;
+        if (!entry.name) continue;
+        const key = keyOf(entry);
+        if (seen.has(key)) continue;
+        seen.add(key);
+        roster.push(entry);
       }
     } catch (err) {
       console.warn('PaperTrench: roster API unavailable —', err.message);
@@ -338,42 +416,70 @@
     const grid = $('streamerGrid');
 
     const cards = roster.map((s) => {
-      const status = live.get(s.login);
+      const spec = platformOf(s);
+      const href = channelHref(s);
+      const status = spec.embeddable ? live.get(s.login) : undefined;
       const isUp = status === true;
-      const badge = status === true
+
+      // Live/offline is a Twitch-only fact. Off Twitch the slot names the
+      // platform instead of guessing a status we cannot observe.
+      const badge = isUp
         ? '<span class="s-live on"><span class="dot"></span>LIVE</span>'
         : status === false
           ? '<span class="s-live off">OFFLINE</span>'
-          : '';
+          : `<span class="s-live plat ${esc(s.platform || 'twitch')}">${esc(spec.label)}</span>`;
+
       const thumb = isUp
         ? `<img src="${thumbUrl(s.login)}" alt="Live preview of ${esc(s.name)}" loading="lazy">`
         : `<div class="ph">${esc(initials(s.name))}</div>`;
-      return `
-        <button class="s-card" data-login="${esc(s.login)}" type="button" title="Watch ${esc(s.name)}">
-          <div class="s-thumb">${thumb}${badge}${MARK_PLAY}</div>
+
+      const body = (handleLine) => `
           <div class="s-body">
             <div class="s-name">${esc(s.name)}</div>
-            <div class="s-handle">twitch.tv/${esc(s.login)}</div>
+            ${handleLine}
             ${s.blurb ? `<div class="s-blurb">${esc(s.blurb)}</div>` : ''}
-          </div>
-        </button>`;
+          </div>`;
+
+      // Embeddable → a card that mounts the player.
+      if (spec.embeddable && s.login) {
+        return `
+        <div class="s-card" data-login="${esc(s.login)}" role="button" tabindex="0"
+             title="Watch ${esc(s.name)} here">
+          <div class="s-thumb">${thumb}${badge}${MARK_PLAY}</div>
+          ${body(`<span class="s-handle">${esc(channelLabel(s))}</span>`)}
+        </div>`;
+      }
+
+      // Link-out → the whole card is the anchor.
+      return `
+        <a class="s-card link" href="${esc(href)}" target="_blank" rel="noopener"
+           title="Open ${esc(s.name)} on ${esc(spec.label)}">
+          <div class="s-thumb">${thumb}${badge}${MARK_OUT}</div>
+          ${body(`<span class="s-handle">${esc(channelLabel(s))}</span>`)}
+        </a>`;
     });
 
     while (cards.length < OPEN_SLOTS) cards.push(openSlot());
     grid.innerHTML = cards.join('');
 
     grid.querySelectorAll('.s-card[data-login]').forEach((card) => {
-      card.addEventListener('click', () =>
-        setFeatured(card.dataset.login, { pinned: true, scroll: true }));
+      const open = () => setFeatured(card.dataset.login, { pinned: true, scroll: true });
+      card.addEventListener('click', open);
+      card.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open(); }
+      });
     });
   }
 
   /* ---------- live badge refresh loop ---------- */
   async function refreshLive() {
     if (!roster.length) return;
-    await Promise.all(roster.map(async (s) => live.set(s.login, await isLive(s.login))));
+    // Only Twitch has a live signal; asking the preview CDN about a Kick
+    // login would answer about a Twitch channel of the same name.
+    const checkable = roster.filter((s) => platformOf(s).embeddable && s.login);
+    await Promise.all(checkable.map(async (s) => live.set(s.login, await isLive(s.login))));
 
-    const liveCount = roster.filter((s) => live.get(s.login) === true).length;
+    const liveCount = checkable.filter((s) => live.get(s.login) === true).length;
     $('liveCountLabel').textContent = liveCount > 0
       ? `${liveCount} streamer${liveCount === 1 ? '' : 's'} live right now`
       : 'The PaperTrench Challenge';
@@ -397,8 +503,11 @@
       if (requested && roster.some((s) => s.login === requested)) {
         userPinned = true;
         featured = requested;
-      } else if (!featured && roster.length) {
-        featured = roster[0].login;
+      } else if (!featured) {
+        // Only an embeddable entry can go in the player; a Kick card at the
+        // top of the order must not blank the player out.
+        const first = roster.find((s) => platformOf(s).embeddable && s.login);
+        if (first) featured = first.login;
       }
     };
 

--- a/site/streams.js
+++ b/site/streams.js
@@ -412,10 +412,33 @@
         </a>`;
   }
 
+  /* The order the grid is read in.
+   *
+   * Live first, so a visitor who came to watch something lands on something
+   * watchable; embeddable before link-out inside each band, because a card
+   * that plays here is a better first click than one that leaves the site;
+   * then name, so two loads of a quiet board never disagree about order.
+   *
+   * There is deliberately no viewer-count sort: the live signal comes from
+   * Twitch's public preview CDN, which reports whether a channel is up and
+   * nothing else. Ranking by a number we do not have would mean inventing
+   * one, and a made-up "top stream" is exactly the kind of claim this site
+   * refuses everywhere else.
+   */
+  function orderedRoster() {
+    const rank = (s) => {
+      if (live.get(s.login) === true) return 0;     // live now
+      if (platformOf(s).embeddable) return 1;       // playable, currently off
+      return 2;                                     // link-out
+    };
+    return [...roster].sort((a, b) =>
+      rank(a) - rank(b) || String(a.name).localeCompare(String(b.name)));
+  }
+
   function renderGrid() {
     const grid = $('streamerGrid');
 
-    const cards = roster.map((s) => {
+    const cards = orderedRoster().map((s) => {
       const spec = platformOf(s);
       const href = channelHref(s);
       const status = spec.embeddable ? live.get(s.login) : undefined;
@@ -440,27 +463,41 @@
             ${s.blurb ? `<div class="s-blurb">${esc(s.blurb)}</div>` : ''}
           </div>`;
 
-      // Embeddable → a card that mounts the player.
+      // Embeddable → a card that mounts the player, with the channel line as
+      // its own link so reaching someone's actual channel does not mean
+      // promoting them into the player first (two clicks and a scroll for
+      // what is just a URL). stopPropagation keeps it from doing both.
       if (spec.embeddable && s.login) {
+        const handleLine = href
+          ? `<a class="s-handle" href="${esc(href)}" target="_blank" rel="noopener"
+               data-out title="Open ${esc(channelLabel(s))}">${esc(channelLabel(s))} ↗</a>`
+          : `<span class="s-handle">${esc(channelLabel(s))}</span>`;
         return `
         <div class="s-card" data-login="${esc(s.login)}" role="button" tabindex="0"
              title="Watch ${esc(s.name)} here">
           <div class="s-thumb">${thumb}${badge}${MARK_PLAY}</div>
-          ${body(`<span class="s-handle">${esc(channelLabel(s))}</span>`)}
+          ${body(handleLine)}
         </div>`;
       }
 
-      // Link-out → the whole card is the anchor.
+      // Link-out → the WHOLE card is the anchor, so the channel line must be
+      // a span. An <a> inside an <a> is not nestable markup: the parser closes
+      // the outer one early and splits a single card into two broken tiles.
       return `
         <a class="s-card link" href="${esc(href)}" target="_blank" rel="noopener"
            title="Open ${esc(s.name)} on ${esc(spec.label)}">
           <div class="s-thumb">${thumb}${badge}${MARK_OUT}</div>
-          ${body(`<span class="s-handle">${esc(channelLabel(s))}</span>`)}
+          ${body(`<span class="s-handle">${esc(channelLabel(s))} ↗</span>`)}
         </a>`;
     });
 
     while (cards.length < OPEN_SLOTS) cards.push(openSlot());
     grid.innerHTML = cards.join('');
+
+    // The channel link must not also trigger the card behind it.
+    grid.querySelectorAll('a[data-out]').forEach((a) => {
+      a.addEventListener('click', (e) => e.stopPropagation());
+    });
 
     grid.querySelectorAll('.s-card[data-login]').forEach((card) => {
       const open = () => setFeatured(card.dataset.login, { pinned: true, scroll: true });
@@ -488,8 +525,11 @@
     $('liveCount').classList.toggle('on', liveCount > 0);
 
     // Put a live channel in the player unless the viewer picked one themself.
+    // orderedRoster() already sorts live to the front, so its first entry IS
+    // the one to feature — and when exactly one channel is live, that is the
+    // channel, which is the behaviour a single streamer should get for free.
     if (!userPinned) {
-      const firstLive = roster.find((s) => live.get(s.login) === true);
+      const firstLive = orderedRoster().find((s) => live.get(s.login) === true);
       if (firstLive && live.get(featured) !== true) setFeatured(firstLive.login);
     }
     renderGrid();
@@ -506,7 +546,7 @@
       } else if (!featured) {
         // Only an embeddable entry can go in the player; a Kick card at the
         // top of the order must not blank the player out.
-        const first = roster.find((s) => platformOf(s).embeddable && s.login);
+        const first = orderedRoster().find((s) => platformOf(s).embeddable && s.login);
         if (first) featured = first.login;
       }
     };

--- a/site/streams.js
+++ b/site/streams.js
@@ -69,6 +69,28 @@
     { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
   ));
 
+  /* ---------- drawn marks ----------
+   * Emoji render as a different typeface per platform and carry an OS-level
+   * colour we cannot theme, which is exactly wrong for a page whose job is to
+   * look considered. These inherit currentColor and scale with the layout. */
+  const MARK_CAMERA =
+    '<svg class="mark" width="38" height="38" viewBox="0 0 24 24" fill="none" ' +
+    'stroke="currentColor" stroke-width="1.6" stroke-linecap="round" ' +
+    'stroke-linejoin="round" aria-hidden="true">' +
+    '<rect x="2" y="6" width="13" height="12" rx="2.5"/>' +
+    '<path d="M15 10.5 22 7v10l-7-3.5z"/></svg>';
+  const MARK_EXTERNAL =
+    '<svg class="mark" width="34" height="34" viewBox="0 0 24 24" fill="none" ' +
+    'stroke="currentColor" stroke-width="1.6" stroke-linecap="round" ' +
+    'stroke-linejoin="round" aria-hidden="true">' +
+    '<path d="M14 4h6v6M20 4l-9 9"/>' +
+    '<path d="M18 14v5a1.8 1.8 0 0 1-1.8 1.8H5.2A1.8 1.8 0 0 1 3.4 19V7.8A1.8 1.8 0 0 1 5.2 6H10"/></svg>';
+  const MARK_PLAY =
+    '<span class="s-play" aria-hidden="true">' +
+    '<svg width="17" height="17" viewBox="0 0 24 24" fill="currentColor">' +
+    '<path d="M8 5.6v12.8a.7.7 0 0 0 1.07.6l10-6.4a.7.7 0 0 0 0-1.2l-10-6.4A.7.7 0 0 0 8 5.6z"/>' +
+    '</svg></span>';
+
   /* ---------- scroll reveal (same behaviour as main.js) ---------- */
   const io = new IntersectionObserver((entries) => {
     for (const e of entries) {
@@ -245,10 +267,11 @@
       frame.innerHTML = `
         <div class="player-empty">
           <div class="inner">
-            <div class="big">🎥</div>
+            ${MARK_CAMERA}
             <h3>The roster is forming</h3>
-            <p>Streamer signups for the PaperTrench Challenge are open. The first
-            live runs land right here — and if you stream, that could be you.</p>
+            <p>Streamer applications for the PaperTrench Challenge are open. The
+            first live runs land right here — and if you stream, that could be
+            you. <a href="/streamer-signup">Apply for the roster</a>.</p>
           </div>
         </div>`;
       return;
@@ -267,10 +290,10 @@
       frame.innerHTML = `
         <div class="player-empty">
           <div class="inner">
-            <div class="big">↗</div>
+            ${MARK_EXTERNAL}
             <h3>Embeds need a web origin</h3>
             <p>Open this page from papertrench.com (or localhost) to watch inline,
-            or head straight to <a style="color:var(--twitch2)" href="https://twitch.tv/${login}" target="_blank" rel="noopener">twitch.tv/${login}</a>.</p>
+            or head straight to <a href="https://twitch.tv/${login}" target="_blank" rel="noopener">twitch.tv/${login}</a>.</p>
           </div>
         </div>`;
       return;
@@ -301,13 +324,12 @@
   const OPEN_SLOTS = 3;
   function openSlot() {
     return `
-        <a class="s-card" href="${esc(SIGNUP_URL)}"
-           style="display:block;border-style:dashed;border-color:rgba(145,70,255,0.35)">
-          <div class="s-thumb"><div class="ph">?</div></div>
+        <a class="s-card open" href="${esc(SIGNUP_URL)}">
+          <div class="s-thumb"><div class="ph">+</div></div>
           <div class="s-body">
             <div class="s-name">Your stream here</div>
             <div class="s-handle">twitch.tv/you</div>
-            <div class="s-blurb">Open slot on the challenge roster — sign up below and it's yours.</div>
+            <div class="s-blurb">An open slot on the challenge roster. Applications are reviewed by hand.</div>
           </div>
         </a>`;
   }
@@ -328,7 +350,7 @@
         : `<div class="ph">${esc(initials(s.name))}</div>`;
       return `
         <button class="s-card" data-login="${esc(s.login)}" type="button" title="Watch ${esc(s.name)}">
-          <div class="s-thumb">${thumb}${badge}</div>
+          <div class="s-thumb">${thumb}${badge}${MARK_PLAY}</div>
           <div class="s-body">
             <div class="s-name">${esc(s.name)}</div>
             <div class="s-handle">twitch.tv/${esc(s.login)}</div>
@@ -355,6 +377,9 @@
     $('liveCountLabel').textContent = liveCount > 0
       ? `${liveCount} streamer${liveCount === 1 ? '' : 's'} live right now`
       : 'The PaperTrench Challenge';
+    // The pill only goes red when something is genuinely live — a permanently
+    // red "LIVE" dot on an empty roster is the cheapest kind of lie.
+    $('liveCount').classList.toggle('on', liveCount > 0);
 
     // Put a live channel in the player unless the viewer picked one themself.
     if (!userPinned) {


### PR DESCRIPTION
**Stack 10 of 10** — includes #1–#9. Merge last.

`docs/STREAMS.md` still described a Twitch-only pipeline and an **Approve** button that is disabled for everything else. That stopped being true across this stack.

### Updated
- Every platform is approvable, and what each one renders as.
- The queue's summary-and-expand shape.
- The card ordering rule, and **why there is no viewer-count sort** — including what it would take to add one, so the next person does not rediscover the constraint from scratch.
- The published/private table, which listed `profile link`: that field takes an address or a handle now, not only a URL.

### Added
A section for the moderation console — the three switches, the columns behind them, why ban and disqualify are deliberately separate, where enforcement lives, and the list of things the console deliberately cannot do. The migration-before-deploy ordering is repeated here, because the person reading the runbook is not necessarily the person who read `DEPLOY.md`.

### CHANGELOG
Opens a new `## Unreleased` section (this base has none) with user-facing wording for the four themes in the stack.