### PR TITLE
F-60 + F-61: chip collision probe read-through; stand-in bag heal at graduation (v3.13.6/v3.13.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 Stream-style log of what shipped, newest first. User-facing wording; the gory
 details live in the commit messages.
 
+## v3.13.6 — 2026-08-24
+
+**Bags bought from a Pulse final-stretch row no longer vanish when the coin
+bonds.** jb's 8/17 report: buy via final stretch, hold until the coin
+graduates, reopen it from the bonding section — the position card renders
+empty.
+
+- **What broke:** on an unresolved final-stretch row the fill committed
+  under the row's CLICK address — on Pulse that is the pair/curve
+  stand-in, not the mint. Right while the page lived, dead after
+  graduation: the bonded reopen resolves the real mint, a key the wallet
+  never held. Closing the page between buy and graduation also skipped the
+  graduation stash entirely — a list page has no loaded token to stash.
+
+- **The fix:** the commit core now probes the click address on-chain (one
+  bounded read) whenever the fill's identity is missing or an echo, and
+  books under the discovered real mint. Wallets already carrying stranded
+  bags heal on reopen: every pool the mint lists — including its graduated
+  bonding-era curve — now carries its orphaned position onto the real key.
+  An unrelated coin can never inherit the bag; a silent probe keeps the
+  honest legacy keying and the fill still books. (F-61)
+
 ## v3.13.4 — 2026-08-24
 
 **Armed buys fire the moment the first quote lands — even when the launch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 Stream-style log of what shipped, newest first. User-facing wording; the gory
 details live in the commit messages.
 
+## v3.13.7 — 2026-08-24
+
+**Bags bought from a Pulse final-stretch row no longer vanish when the coin
+bonds.** jb's 8/17 report: buy via final stretch, hold until the coin
+graduates, reopen it from the bonding section — the position card renders
+empty.
+
+- **What broke:** on an unresolved final-stretch row the fill committed
+  under the row's CLICK address — on Pulse that is the pair/curve
+  stand-in, not the mint. Right while the page lived, dead after
+  graduation: the bonded reopen resolves the real mint, a key the wallet
+  never held. Closing the page between buy and graduation also skipped the
+  graduation stash entirely — a list page has no loaded token to stash.
+
+- **The fix:** the commit core now probes the click address on-chain (one
+  bounded read) whenever the fill's identity is missing or an echo, and
+  books under the discovered real mint. Wallets already carrying stranded
+  bags heal on reopen: every pool the mint lists — including its graduated
+  bonding-era curve — now carries its orphaned position onto the real key.
+  An unrelated coin can never inherit the bag; a silent probe keeps the
+  honest legacy keying and the fill still books. (F-61)
+
 ## v3.13.4 — 2026-08-24
 
 **Armed buys fire the moment the first quote lands — even when the launch

--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -473,6 +473,34 @@ per-site defaults (`listQuickBuyPlacement`) and an explicit user setting
 once the chip itself is painted → F-60. Locked by
 extension/test/rowchipcollision.test.js (probe decisions, gutter fallback,
 placementPref plumbing, both anchor modes consult the probe).
+**F-61 · S1 · a Pulse final-stretch buy committed under the pair stand-in vanished at the graduation boundary — the bonded reopen resolved a key the wallet never held**
+`content.js` fillRowBuy/detectLoop/requote/healStandInPositions ·
+`quote.js` tokenFromPayload · Axiom Pulse "Final Stretch" list rows (jb
+2026-08-17: "buy via final stretch, hold until bond, open from the bonding
+section: the buy does not show") · **fixed v3.13.7** — two holes, one
+identity family (F-51's stand-in stranding at a different lifecycle point):
+
+(1) *Commit-time.* The row-buy cascade ends in the row-feed fallback
+(`mint: address` — an ECHO, not a discovered identity). On a Pulse
+final-stretch row the click address is the PAIR/curve stand-in, so the fill
+keyed the stand-in: right while the page lived, dead the moment the coin
+graduated to a new AMM pool. `fillRowBuy` now probes the click address with
+ONE bounded `onchainPrewatch` when the candidate's mint is missing or the
+echo (`data.mint === address`); a discovered real mint re-keys the candidate
+BEFORE the engine buy. A silent probe keeps the honest legacy keying — the
+fill still books, never refuses.
+
+(2) *Recovery.* Wallets already carrying stand-in-keyed bags (the reported
+case: page closed between buy and graduation, so P0-3's in-context
+swapStash never ran — no loaded token, nothing stashed) heal at reopen:
+`tokenFromPayload` now carries `poolAddresses` (every pool Dexscreener
+lists for the base mint — graduated bonding-era pairs stay listed forever),
+and detectLoop/requote call `healStandInPositions`, which rekeys any OPEN
+position still keyed by one of those pools onto the real mint (via
+`E.rekeyMint`, both-keys merge-safe). An unrelated coin never matches —
+only pools provably listed under THIS base mint can donate their bag.
+Locked by extension/test/strandedbag.test.js (full-life report scenario,
+negative isolation, legacy silent-probe path) — red on pre-fix code.
 
 **F-41 · S1 · One buy drew TWO bubbles, and the average line never appeared — a dead self-write guard duplicated every fill, and a stale-ledger veto quietly relocated the line off-screen**
 `content.js` watchStorage/doBuy/doSellInner · `price-bridge.js`

--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -430,6 +430,35 @@ extension/test/rowfillaccuracy.test.js (identity lookups, cap rescale on
 both override sites, first-buy witness wiring, refusal voice, ancient-print
 exemption).
 
+**F-61 · S1 · a Pulse final-stretch buy committed under the pair stand-in vanished at the graduation boundary — the bonded reopen resolved a key the wallet never held**
+`content.js` fillRowBuy/detectLoop/requote/healStandInPositions ·
+`quote.js` tokenFromPayload · Axiom Pulse "Final Stretch" list rows (jb
+2026-08-17: "buy via final stretch, hold until bond, open from the bonding
+section: the buy does not show") · **fixed v3.13.6** — two holes, one
+identity family (F-51's stand-in stranding at a different lifecycle point):
+
+(1) *Commit-time.* The row-buy cascade ends in the row-feed fallback
+(`mint: address` — an ECHO, not a discovered identity). On a Pulse
+final-stretch row the click address is the PAIR/curve stand-in, so the fill
+keyed the stand-in: right while the page lived, dead the moment the coin
+graduated to a new AMM pool. `fillRowBuy` now probes the click address with
+ONE bounded `onchainPrewatch` when the candidate's mint is missing or the
+echo (`data.mint === address`); a discovered real mint re-keys the candidate
+BEFORE the engine buy. A silent probe keeps the honest legacy keying — the
+fill still books, never refuses.
+
+(2) *Recovery.* Wallets already carrying stand-in-keyed bags (the reported
+case: page closed between buy and graduation, so P0-3's in-context
+swapStash never ran — no loaded token, nothing stashed) heal at reopen:
+`tokenFromPayload` now carries `poolAddresses` (every pool Dexscreener
+lists for the base mint — graduated bonding-era pairs stay listed forever),
+and detectLoop/requote call `healStandInPositions`, which rekeys any OPEN
+position still keyed by one of those pools onto the real mint (via
+`E.rekeyMint`, both-keys merge-safe). An unrelated coin never matches —
+only pools provably listed under THIS base mint can donate their bag.
+Locked by extension/test/strandedbag.test.js (full-life report scenario,
+negative isolation, legacy silent-probe path) — red on pre-fix code.
+
 **F-41 · S1 · One buy drew TWO bubbles, and the average line never appeared — a dead self-write guard duplicated every fill, and a stale-ledger veto quietly relocated the line off-screen**
 `content.js` watchStorage/doBuy/doSellInner · `price-bridge.js`
 vettedMcapClose/paper-lines · fomo.family, maintainer field test ·

--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -430,6 +430,50 @@ extension/test/rowfillaccuracy.test.js (identity lookups, cap rescale on
 both override sites, first-buy witness wiring, refusal voice, ancient-print
 exemption).
 
+**F-60 · S3 · The quick-buy chip could pin itself on top of the MC — once painted, its own body shadowed the collision probe and the overlap became undetectable**
+`price-bridge.js` rowAnchorHitsContent/scanScreenerRows · all screener-row
+sites, worst on ultra/compact terminal formats · found by audit of the F-53
+fix while verifying jb's 2026-08-18 report ("quick buy button is on top of
+the mc on terminal if ur format is ultra") · **fixed v3.13.6** (the probe
+reads the elementsFromPoint STACK and looks through its own chip)
+F-53 (v3.6.0) taught the sweep to probe the float anchor before painting:
+elementFromPoint at the chip-body midpoint, drop to the bottom-right gutter
+when the hit is row content. But `.pt-rowbuy` chips are CLICKABLE
+(pointer-events:auto, only the LAYER is pointer-events:none), so the moment
+a chip is painted at the float anchor its own body tops that hit-test:
+`hit === entry.el` → "clean", forever. Anything that moved the MC under an
+ALREADY-painted chip — a live normal→ultra format switch (no reload, React
+recycles the row nodes in place), a late-mounting MC cell losing the mount
+race, a row recycle re-rendering denser content — re-created jb's exact
+symptom, and the F-53 probe was structurally blind to it: in pill mode the
+probe point is the dead centre of the painted chip. The probe now reads the
+hit-test stack (document.elementsFromPoint) and skips every chip-owned
+entry (its own body, its descendants, sibling chips marked
+data-pt-row-chip); the first REAL element beneath decides, same
+inside-the-row / pill-overlap rules as before. READ-phase only, no style
+writes; engines without elementsFromPoint keep the legacy top-hit read
+(documented degradation, never wedges the sweep). Locked by
+extension/test/rowchipcollision.test.js: painted-chip-over-MC must read
+collision, chip-over-gutter must stay clean, legacy single-hit fallback,
+and a source contract pinning the stack read + no style writes.
+
+**F-53 · S3 · The quick-buy chip painted on top of the row's MC in ultra terminal format** *(retroactive entry — shipped in v3.6.0 without a ledger record; registered while auditing F-60)*
+`price-bridge.js` positionRowChip/scanScreenerRows · all screener-row sites
+(ultra/compact formats, Padre's pill row) · field report 2026-08-18
+(Discord #bug-reports, jb: "quick buy button is on top of the mc on
+terminal if ur format is ultra") · **fixed v3.6.0** (anchor probe + gutter
+fallback + placement setting)
+Dense formats leave no gutter at the row's top-right, so the float-anchored
+chip landed on the MC column. The sweep now probes the anchor before
+painting (elementFromPoint at the chip-body midpoint — the chip extends
+LEFT of its anchor, so the anchor point alone cleared while the body still
+covered content) and drops to the bottom-right gutter on a content hit;
+per-site defaults (`listQuickBuyPlacement`) and an explicit user setting
+(Quick-buy chip placement → Bottom-right / Auto) pin it. Probe blind spot
+once the chip itself is painted → F-60. Locked by
+extension/test/rowchipcollision.test.js (probe decisions, gutter fallback,
+placementPref plumbing, both anchor modes consult the probe).
+
 **F-41 · S1 · One buy drew TWO bubbles, and the average line never appeared — a dead self-write guard duplicated every fill, and a stale-ledger veto quietly relocated the line off-screen**
 `content.js` watchStorage/doBuy/doSellInner · `price-bridge.js`
 vettedMcapClose/paper-lines · fomo.family, maintainer field test ·

--- a/extension/content.js
+++ b/extension/content.js
@@ -1058,6 +1058,19 @@
           if (stash.fromMint !== data.mint) rekeyLiveState(stash.fromMint, data.mint);
         }
       }
+      // F-61 backstop: heal stand-in-keyed bags at the graduation boundary.
+      // A Pulse row buy that never resolved (row-feed fallback) commits under
+      // the click address — the PAIR stand-in on Axiom. When the coin bonds,
+      // the migration pool gets a NEW pair address; reopening the coin (from
+      // the bonded listing or any pool URL) resolves the REAL mint, a key this
+      // wallet never held: the card renders empty (jb, 8/17). Unlike the
+      // in-context stash bridge above, nothing links the two sessions. The
+      // resolver's own payload carries the proof for free: Dexscreener lists
+      // EVERY pool for the base mint — including the graduated bonding-era
+      // pair — so a position whose key appears among the pool list is the
+      // same coin under its old stand-in. Deterministic identity proof, one
+      // rekey, no network added.
+      healStandInPositions(data);
       // Rug verdicts read Solana holder state — a foreign chain has no
       // verdict, and the guard stays silent rather than pretending.
       if (!data.chain || data.chain === 'solana') refreshRugVerdict(data.mint);
@@ -1145,6 +1158,24 @@
    * the storage write rides the serialized CAS commit, re-applying itself on
    * contention like every other mutation (F-46).
    */
+  /**
+   * F-61: heal bags stranded under a stand-in key at the graduation boundary.
+   * `tokenRecord` is a resolver record carrying `poolAddresses` — every pool
+   * listed for the base mint. Any OPEN position keyed by one of those pool
+   * addresses (but not the mint itself) is the same coin bought under its
+   * bonding-era pair stand-in; rekey it onto the real mint so the card, the
+   * bar chip, and the batch quote poller all see one bag under one key.
+   * Idempotent; a no-op when no position matches.
+   */
+  function healStandInPositions(tokenRecord) {
+    if (!tokenRecord || !tokenRecord.mint || !Array.isArray(tokenRecord.poolAddresses)) return;
+    if (!state.positions) return;
+    const stranded = Object.keys(state.positions).filter(
+      (k) => k !== tokenRecord.mint && tokenRecord.poolAddresses.indexOf(k) !== -1
+    );
+    for (const standIn of stranded) rekeyLiveState(standIn, tokenRecord.mint);
+  }
+
   function rekeyLiveState(oldMint, newMint) {
     if (!oldMint || !newMint || oldMint === newMint) return;
     const cached = livePositionPrices[oldMint];
@@ -1375,6 +1406,14 @@
       if (!token || token.mint !== forMint) return;
       if (!fresh || !(fresh.priceNative > 0)) return;
       if (fresh.mint && fresh.mint !== token.mint) return;
+      // F-61: a refresh re-quotes /tokens/<mint> — EVERY pool for this base
+      // mint, including graduated bonding-era pairs. An initial resolve via
+      // /pairs/<addr> carried only that one pool; adopt the full list so the
+      // graduation backstop can see a stand-in-held bag.
+      if (Array.isArray(fresh.poolAddresses)) {
+        token.poolAddresses = fresh.poolAddresses;
+        healStandInPositions(token);
+      }
 
       // The resolver quote becomes the new anchor immediately. Live ticks
       // validate against this, so the anchor never lags behind real moves.
@@ -6591,6 +6630,25 @@
     // since moved past (entry MC 6k on a coin printing 20k). The row's own
     // print is the anchor instead (see rowPrintVouchesFirstBuy).
     if (!(await rowPrintVouchesFirstBuy(address, data, posAnchor))) return null;
+    // F-61: a row-fed candidate carries NO mint — the row feed keys its
+    // ticks by whatever the board prints (on Axiom Pulse that is the PAIR
+    // stand-in; F-59 saw the same keying). Committing under that key strands
+    // the bag at the graduation boundary: the coin bonds, the page reopens
+    // under the migration pool, and the resolver hands back the REAL mint —
+    // a key the wallet never held (jb, 8/17: "buy via final stretch, hold
+    // until bond, open from the bonding section: the buy does not show").
+    // The chain classifies the click address the same way prewatch does —
+    // one bounded read, never blocking the fill: a miss keeps the row's own
+    // address as the key, exactly the honest legacy behavior.
+    if (address && (!data.mint || data.mint === address)) {
+      try {
+        const found = await R.onchainPrewatch({ mint: address, pool: address }).catch(() => null);
+        if (found && found.mint && found.mint !== data.mint) {
+          data.mint = found.mint;
+          if (!data.pairAddress && found.pool) data.pairAddress = found.pool;
+        }
+      } catch (_) { /* identity stays the row's own key */ }
+    }
     // Guardrails apply to chip buys exactly like panel buys.
     const guard = E.guardCheck(state, settings, { solAmount: amount });
     if (!guard.ok) { toast(guard.message); return null; }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PaperTrench",
-  "version": "3.13.5",
+  "version": "3.13.7",
   "description": "Paper-trade Solana memecoins with live P&L, native chart fills, session replay, AI coaching, and a verifiable track record.",
   "permissions": [
     "storage",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PaperTrench",
-  "version": "3.13.5",
+  "version": "3.13.6",
   "description": "Paper-trade Solana memecoins with live P&L, native chart fills, session replay, AI coaching, and a verifiable track record.",
   "permissions": [
     "storage",

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "papertrench",
-  "version": "3.13.5",
+  "version": "3.13.6",
   "private": true,
   "description": "Paper-trade Solana memecoins on Axiom, Padre, Photon, GMGN, BullX and more.",
   "scripts": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "papertrench",
-  "version": "3.13.5",
+  "version": "3.13.7",
   "private": true,
   "description": "Paper-trade Solana memecoins on Axiom, Padre, Photon, GMGN, BullX and more.",
   "scripts": {

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3204,6 +3204,16 @@
    * itself — i.e. real content (text, stat, avatar) the chip would cover.
    * A hit outside the row entirely (page background, whitespace) is fine:
    * the anchor is in the gutter already.
+   *
+   * F-60: the chip is CLICKABLE (pointer-events:auto on .pt-rowbuy), so
+   * once it is painted at the anchor its own body tops the hit-test and
+   * elementFromPoint returns the chip — reading "clean" forever while it
+   * covers the MC a live format switch (or a late mount, or a row
+   * recycle) just moved under it. The probe therefore reads the STACK
+   * (elementsFromPoint) and skips chip-owned entries: the first element
+   * in the stack that is neither the chip, inside the chip, nor this
+   * layer's other chips, is the ground truth the chip is covering.
+   * Engines without elementsFromPoint keep the legacy top-hit read.
    */
   function rowAnchorHitsContent(anchor, rect, row, entry, pillRect) {
     const chipWidth = (entry && entry.el && entry.el.getBoundingClientRect)
@@ -3211,18 +3221,37 @@
       : 0;
     const bodyX = Math.max(1, Math.round(anchor.x - (chipWidth > 0 ? chipWidth / 2 : 14)));
     const bodyY = Math.min(Math.max(Math.round(anchor.y), 1), (window.innerHeight || 1) - 1);
-    let hit = null;
-    try { hit = document.elementFromPoint(bodyX, bodyY); } catch (_) { return false; }
-    if (!hit || hit === entry.el || entry.el.contains(hit)) return false;
-    if (hit === row) return false;
-    // Content INSIDE the row (or the pill the anchor belongs to): covered.
+    let hits = null;
     try {
-      if (row.contains(hit)) return true;
-    } catch (_) {}
-    if (pillRect && hit.getBoundingClientRect) {
-      const hr = hit.getBoundingClientRect();
-      if (hr.width > 0 && hr.right > pillRect.left && hr.left < pillRect.right
-          && hr.bottom > pillRect.top && hr.top < pillRect.bottom) return true;
+      if (typeof document.elementsFromPoint === 'function') {
+        hits = document.elementsFromPoint(bodyX, bodyY);
+      } else {
+        const one = document.elementFromPoint(bodyX, bodyY);
+        hits = one ? [one] : [];
+      }
+    } catch (_) { return false; }
+    if (!hits || !hits.length) return false;
+    for (let i = 0; i < hits.length; i += 1) {
+      const hit = hits[i];
+      if (!hit) continue;
+      // Skip everything the chip itself owns: its own body and anything
+      // inside it. The stack is painted front-to-back, so these lead.
+      if (hit === entry.el) continue;
+      try { if (entry.el && entry.el.contains(hit)) continue; } catch (_) {}
+      // Skip other chips from this same layer: a neighbouring row's chip
+      // can legitimately sit beneath this one on overlap-heavy layouts.
+      if (hit.dataset && hit.dataset.ptRowChip === '1') continue;
+      if (hit === row) return false;
+      // Content INSIDE the row (or the pill the anchor belongs to): covered.
+      try {
+        if (row.contains(hit)) return true;
+      } catch (_) {}
+      if (pillRect && hit.getBoundingClientRect) {
+        const hr = hit.getBoundingClientRect();
+        if (hr.width > 0 && hr.right > pillRect.left && hr.left < pillRect.right
+            && hr.bottom > pillRect.top && hr.top < pillRect.bottom) return true;
+      }
+      return false;
     }
     return false;
   }
@@ -3633,6 +3662,9 @@
 
       const button = document.createElement('button');
       button.className = 'pt-rowbuy';
+      // F-60: mark the chip so collision probes can recognise (and look
+      // through) their own paint in the elementsFromPoint stack.
+      try { button.dataset.ptRowChip = '1'; } catch (_) {}
       button.type = 'button';
       button.textContent = `P ${amount}`;
       button.title = `PaperTrench: paper-buy ${amount} SOL of this token right now`;

--- a/extension/quote.js
+++ b/extension/quote.js
@@ -216,7 +216,25 @@
     if (!payload || typeof payload !== 'object') return null;
     const chainId = chainIdFor(opts && opts.chain);
     const pair = payload.pair || pickBestPair(payload.pairs, fallbackAddress, chainId);
-    return normalizePair(pair, fallbackAddress, opts);
+    const token = normalizePair(pair, fallbackAddress, opts);
+    // F-61: surface EVERY pool the source lists for this base mint. A Pulse
+    // row buy can commit under a bonding-era PAIR stand-in (the row-feed
+    // fallback echoes the click address as the key); after graduation the
+    // coin resolves under its REAL mint and the bag strands. The pool list
+    // is the deterministic identity proof — graduated bonding pairs stay
+    // listed under the same base mint (verified on-chain 2026-08-20, P0-3) —
+    // so the chart page can rekey any position whose key is one of these
+    // pools. Additive: consumers that ignore it are unaffected.
+    if (token && Array.isArray(payload.pairs)) {
+      const seen = {};
+      const pools = [];
+      for (var i = 0; i < payload.pairs.length; i++) {
+        var p = payload.pairs[i] && payload.pairs[i].pairAddress;
+        if (p && !seen[p]) { seen[p] = 1; pools.push(p); }
+      }
+      if (pools.length) token.poolAddresses = pools;
+    }
+    return token;
   }
 
   /* ------------------------------------------------------------------ *

--- a/extension/test/_debug_race.js
+++ b/extension/test/_debug_race.js
@@ -1,0 +1,40 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const src = fs.readFileSync(path.join(__dirname, 'orderrace.test.js'), 'utf8');
+const harness = src.slice(0, src.indexOf('/* ---------------- the race'));
+const mod = { exports: {} };
+const fn = new Function('require', 'module', 'exports', '__harness', '__dirname',
+  harness + '\n__harness.runOrderRace = runOrderRace;');
+const h = {};
+fn(require, mod, mod.exports, h, __dirname);
+
+(async () => {
+  const ov = h.runOrderRace({});
+  await ov.settle();
+  const E = require(path.join(__dirname, '..', 'engine.js'));
+  const MINT = '3PTQpne3b7kjJEvDYDMBHSuRjTDUh6HSin2xMyW3pump';
+  const base = E.resetState(E.defaultSettings());
+  E.buy(base, E.defaultSettings(), { ts: 4000000, mint: MINT, site: 'padre', solAmount: 1, priceNative: 1e-9, priceUsd: 2e-7 });
+  E.addOrder(base, MINT, { kind: 'tp', triggerPrice: 2e-9, sizePt: 50 }, 1e-9, 4100000);
+  ov.seed(base);
+  console.log('seeded. orders in seed:', JSON.stringify(Object.keys(base.orders || {})));
+  ov.emitTick({ candidates: [{ value:  2.2e-9, unit: 'native' }] });
+  await ov.settle();
+  await ov.advance(2000);
+  const st = ov.workerState();
+  console.log('journal sells:', (st.journal || []).filter(t => t.side === 'sell').length);
+  console.log('positions:', Object.keys(st.positions || {}));
+  console.log('commits:', JSON.stringify(ov.commitLog()).slice(0, 400));
+  try {
+    console.log('token symbol:', vm.runInContext('typeof token !== "undefined" && token ? token.symbol : "none"', ov.sandbox));
+    console.log('orders in live state:', vm.runInContext('typeof state !== "undefined" && state ? JSON.stringify(Object.keys(state.orders || {})) : "no state"', ov.sandbox));
+    console.log('lastTickPrice:', vm.runInContext('typeof lastChartPrice !== "undefined" ? String(lastChartPrice) : "n/a"', ov.sandbox));
+  } catch (e) { console.log('probe err:', e.message); }
+  try {
+    console.log('resolver type:', vm.runInContext('typeof PaperTrenchResolver', ov.sandbox));
+    const r = await vm.runInContext('PaperTrenchResolver ? PaperTrenchResolver.resolve("3PTQpne3b7kjJEvDYDMBHSuRjTDUh6HSin2xMyW3pump") : null', ov.sandbox);
+    console.log('resolve result:', JSON.stringify(r).slice(0, 300));
+  } catch (e) { console.log('probe err:', e.message); }
+  process.exit(0);
+})();

--- a/extension/test/orderrace.test.js
+++ b/extension/test/orderrace.test.js
@@ -1,0 +1,313 @@
+/* Chart-order CAS race — jb's 2026-08-18 report (#bug-reports, 11:10 UTC):
+ * "took clips from a trade and fully exited but on my paper equity it shows
+ * +9.109 sol when its supposed to be +0.091".
+ *
+ * Mechanism under test: two chart tabs on the same token, one armed TP
+ * level. Both tabs' tick loops see the trigger; both call fireChartOrder.
+ * The CAS loser's remutate re-checks only the POSITION — not whether the
+ * winning context already spent the order — so it re-applies E.sell on the
+ * adopted base. The clip is booked twice: cash credited twice, the round's
+ * returnedSol double-counts, paper equity inflates by a whole extra set of
+ * clip proceeds (jb: +0.091 true + ~9.0 duplicated clips = +9.109).
+ *
+ * Asymmetric precedent: firePendingBuy's remutate re-checks the armed buy
+ * still exists ("if (!armed) return") before re-applying. The order fire
+ * must do the same. This test pins that contract.
+ *
+ * F-59 - shipped in v3.13.4
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+global.window = global.window || {};
+const Q = require('../quote.js');
+const E = require('../engine.js');
+
+const NEW_MINT = '3PTQpne3b7kjJEvDYDMBHSuRjTDUh6HSin2xMyW3pump';
+const SOL_USD = 200;
+
+function jupiterPayload() {
+  return [
+    {
+      id: NEW_MINT,
+      name: 'Bark',
+      symbol: 'BARK',
+      usdPrice: 0.0000021,
+      mcap: 2100.12,
+      liquidity: 2204.47,
+      firstPool: { id: 'PooLAddress1111111111111111111111111111111', createdAt: '2026-08-01T04:00:00Z' },
+    },
+    {
+      id: Q.WSOL_MINT,
+      name: 'Wrapped SOL',
+      symbol: 'SOL',
+      usdPrice: SOL_USD,
+      firstPool: { id: 'sol', createdAt: '2020-01-01T00:00:00Z' },
+    },
+  ];
+}
+
+/* ---------------- harness (faithful clone of freshlaunch.test.js) ---------------- */
+
+function runOrderRace(opts) {
+  const options = opts || {};
+  const timers = [];
+  let now = 5_000_000;
+  const nodesById = {};
+  const messages = [];
+  const winListeners = {};
+
+  function makeNode(tag) {
+    const node = {
+      tag, style: { setProperty() {}, removeProperty() {} }, dataset: {},
+      children: [], childNodes: [], _fields: {},
+      classList: {
+        _s: new Set(),
+        add(...c) { c.forEach((x) => this._s.add(x)); },
+        remove(...c) { c.forEach((x) => this._s.delete(x)); },
+        toggle(c, on) { if (on === undefined) { this._s.has(c) ? this._s.delete(c) : this._s.add(c); } else if (on) this._s.add(c); else this._s.delete(c); },
+        contains(c) { return this._s.has(c); },
+      },
+      set textContent(v) { this._t = v; },
+      get textContent() { return this._t || ''; },
+      set innerHTML(v) {
+        this._h = v;
+        const re = /data-f="([a-z]+)"/g; let m;
+        while ((m = re.exec(v))) { const c = makeNode('span'); c.dataset.f = m[1]; this._fields[m[1]] = c; }
+      },
+      get innerHTML() { return this._h || ''; },
+      appendChild(c) { const i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); if (c._parent && c._parent !== this) c._parent.removeChild(c); c._parent = this; this.children.push(c); this.childNodes = this.children; return c; },
+      removeChild(c) { const i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); if (c._parent === this) c._parent = null; },
+      remove() { if (this._parent) this._parent.removeChild(this); },
+      setAttribute() {}, getAttribute() { return null; },
+      addEventListener(type, fn) {
+        if (!this._listeners) this._listeners = {};
+        (this._listeners[type] = this._listeners[type] || []).push(fn);
+      },
+      click() { ((this._listeners && this._listeners.click) || []).forEach((fn) => fn()); },
+      querySelectorAll() { return []; },
+      value: '',
+      querySelector(sel) {
+        const m = /data-f="([a-z]+)"/.exec(sel);
+        if (m && this._fields[m[1]]) return this._fields[m[1]];
+        return makeNode('span');
+      },
+      getBoundingClientRect() { return { top: 0 }; },
+      attachShadow() { return shadowRoot; },
+      focus() {}, closest() { return null; },
+      get offsetWidth() { return 1; },
+    };
+    return node;
+  }
+
+  const shadowRoot = {
+    set innerHTML(v) { this._h = v; }, get innerHTML() { return this._h || ''; },
+    getElementById(id) { if (!nodesById[id]) nodesById[id] = makeNode('div'); return nodesById[id]; },
+    querySelector() { return makeNode('div'); }, querySelectorAll() { return []; }, appendChild() {},
+  };
+
+  const doc = {
+    readyState: 'complete', hidden: false, title: 'new coin',
+    body: Object.assign(makeNode('body'), { innerText: '' }),
+    documentElement: makeNode('html'), head: makeNode('head'),
+    createElement: (t) => makeNode(t),
+    getElementById: () => null, querySelector: () => null, querySelectorAll: () => [],
+    addEventListener: () => {}, createTreeWalker: () => ({ nextNode: () => null }),
+  };
+
+  const url = `https://trade.padre.gg/trade/solana/${NEW_MINT}`;
+  const parsed = new URL(url);
+  const win = {
+    addEventListener: (type, fn) => {
+      if (type === 'message') (winListeners.message = winListeners.message || []).push(fn);
+    },
+    removeEventListener: () => {},
+    postMessage: (msg) => { if (msg && msg.source === 'papertrench-content') messages.push(msg.type); },
+    location: { href: url, hostname: parsed.hostname, pathname: parsed.pathname, search: parsed.search },
+    getComputedStyle: () => ({ right: '18px', top: '84px' }),
+    confirm: () => true,
+  };
+  win.window = win;
+
+  // The single source of truth for wallet state, held by the fake worker.
+  let workerState = null;
+  let commitLog = [];
+  let staleReplies = options.staleReplies || [];
+
+  const storage = { pt_settings: E.defaultSettings() };
+
+  const sandbox = {
+    window: win, self: win, document: doc, location: win.location, console,
+    URLSearchParams, URL,
+    AbortController: function () { this.signal = {}; this.abort = () => {}; },
+    MutationObserver: function () { this.observe = () => {}; this.disconnect = () => {}; },
+    TextDecoder: function () { this.decode = () => ''; },
+    ResizeObserver: function () { this.observe = () => {}; this.disconnect = () => {}; },
+    Set, Map, WeakSet, WeakMap, Promise, JSON, Math, Number, String, Array, Object,
+    Boolean, RegExp, Error, isNaN, parseInt, parseFloat, Infinity, NaN,
+    Date: Object.assign(function () {}, { now: () => now, parse: Date.parse }),
+    setTimeout: (fn, ms) => { timers.push({ fn, at: now + (ms || 0) }); return timers.length; },
+    clearTimeout: () => {}, clearInterval: (id) => { if (timers[id - 1]) timers[id - 1].dead = true; },
+    setInterval: (fn, ms) => { timers.push({ fn, at: now + ms, every: ms }); return timers.length; },
+    fetch: (u) => {
+      const s = String(u);
+      if (s.includes('jup.ag')) return Promise.resolve({ ok: true, status: 200, json: async () => jupiterPayload() });
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ pairs: null }) });
+    },
+    chrome: {
+      runtime: {
+        id: 'papertrench-test',
+        getURL: (p) => 'x/' + p,
+        sendMessage: (msg) => {
+          if (msg.type === 'pt_attest_append') return Promise.resolve({ ok: true, seq: 0, head: 'pt-test-head' });
+          // The worker side of the CAS: compare-and-swap on seq.
+          if (msg.type === 'pt_state_commit') {
+            const expected = Number(msg.expectedSeq) || 0;
+            const currentSeq = workerState ? (Number(workerState.seq) || 0) : 0;
+            const forced = !!msg.force;
+            if (forced || currentSeq === expected) {
+              workerState = msg.state;
+              commitLog.push({ ok: true, forced, seq: msg.state.seq });
+              return Promise.resolve({ ok: true });
+            }
+            // Hostile: answer stale, with the winner's state attached. The
+            // test's staleReplies hook decides what the "other tab" did.
+            const hostile = staleReplies.length ? staleReplies.shift() : null;
+            commitLog.push({ ok: false, stale: true });
+            return Promise.resolve({ ok: false, reason: 'stale', current: hostile ? hostile(workerState) : workerState });
+          }
+          if (msg.type === 'pt_state_get') {
+            return Promise.resolve({ ok: true, state: workerState });
+          }
+          const R = win.PaperTrenchResolver;
+          if (!R) return Promise.resolve({});
+          if (msg.type === 'pt_resolve') return R.resolve(msg.address);
+          if (msg.type === 'pt_refresh') return R.refresh(msg.token);
+          if (msg.type === 'pt_sol_usd') return R.solUsd();
+          if (msg.type === 'pt_batch_prices') return R.batchPrices(msg.mints);
+          return Promise.resolve({});
+        },
+        onMessage: { addListener: () => {} },
+        openOptionsPage: () => {},
+      },
+      storage: {
+        local: {
+          get: (keys, cb) => { const out = {}; for (const k of (Array.isArray(keys) ? keys : [keys])) if (k in storage) out[k] = storage[k]; if (cb) cb(out); return Promise.resolve(out); },
+          set: (obj, cb) => { Object.assign(storage, obj); if (cb) cb(); return Promise.resolve(); },
+        },
+        onChanged: { addListener: () => {} },
+      },
+      tabs: { query: () => Promise.resolve([{ id: 1 }]), sendMessage: () => Promise.resolve() },
+    },
+    NodeFilter: { SHOW_TEXT: 4 },
+  };
+
+  const ctx = vm.createContext(sandbox);
+  const ROOT = path.join(__dirname, '..');
+  const manifest = JSON.parse(fs.readFileSync(path.join(ROOT, 'manifest.json'), 'utf8'));
+  const entry = manifest.content_scripts.find((cs) => (cs.js || []).includes('content.js'));
+  for (const f of entry.js) {
+    vm.runInContext(fs.readFileSync(path.join(ROOT, f), 'utf8'), ctx, { filename: f });
+  }
+
+  async function advance(ms, step) {
+    step = step || 100;
+    for (let e = 0; e < ms; e += step) {
+      now += step;
+      for (let i = 0; i < timers.length; i++) {
+        const t = timers[i];
+        if (t.dead || t.at > now) continue;
+        if (t.every) t.at = now + t.every; else t.dead = true;
+        try { t.fn(); } catch (err) { /* asserted below */ }
+      }
+      for (let k = 0; k < 8; k++) await Promise.resolve();
+    }
+  }
+
+  async function settle() {
+    for (let k = 0; k < 400; k++) await Promise.resolve();
+  }
+
+  return {
+    advance,
+    settle,
+    emitTick: (payload) => {
+      for (const fn of (winListeners.message || [])) {
+        fn({ source: win, origin: null, data: { source: 'papertrench-bridge', type: 'tick', payload } });
+      }
+    },
+    seed: (s) => {
+      storage[E.STORAGE_KEYS.state] = JSON.parse(JSON.stringify(s));
+      workerState = JSON.parse(JSON.stringify(s));
+    },
+    workerState: () => workerState,
+    commitLog: () => commitLog,
+    storage: () => storage,
+    sandbox,
+  };
+}
+
+/* ---------------- the race ---------------- */
+
+test('a lost CAS race must not double-book an order clip (jb 2026-08-18)', async () => {
+  const ov = runOrderRace({
+    staleReplies: [
+      // What the winning tab's state looks like when it lands: same base,
+      // order already fired and removed, clip already booked, seq bumped.
+      (winner) => {
+        const s = JSON.parse(JSON.stringify(winner || {}));
+        return s;
+      },
+    ],
+  });
+  await ov.settle();
+
+  // Seed the wallet exactly as a prior session left it: a 1 SOL position in
+  // BARK bought at 1e-9, one TP armed at 2x for 50% (a clip).
+  const base = E.resetState(E.defaultSettings());
+  const filled = E.buy(base, E.defaultSettings(), {
+    ts: 4_000_000, mint: NEW_MINT, site: 'padre',
+    solAmount: 1, priceNative: 1e-9, priceUsd: 1e-9 * SOL_USD,
+  });
+  const order = E.addOrder(base, NEW_MINT, { kind: 'tp', triggerPrice: 2e-9, sizePct: 50 }, 1e-9, 4_100_000);
+  ov.seed(base);
+
+  // The chart sees 2x - the TP trigger condition.
+  ov.emitTick({ candidates: [{ value: 2.2e-9, unit: 'native' }] });
+  await ov.settle();
+  await ov.advance(2000);
+
+  const st = ov.workerState();
+  assert.ok(st, 'state must exist after the race');
+  const sells = (st.journal || []).filter((t) => t.side === 'sell');
+  const tpSells = sells.filter((t) => t.orderKind === 'tp');
+  assert.equal(tpSells.length, 1,
+    `the clip must be booked exactly once across the CAS race; got ${tpSells.length}`);
+  const dupProceeds = tpSells.reduce((s, t) => s + t.solNet, 0);
+  assert.ok(dupProceeds > 0 && dupProceeds < 2,
+    `one honest 50% clip at ~2x on a 1 SOL position nets ~1 SOL; got ${dupProceeds}`);
+}, { timeout: 30000 });
+
+test('control: with no race the clip books once (sanity)', async () => {
+  const ov = runOrderRace({});
+  await ov.settle();
+
+  const base = E.resetState(E.defaultSettings());
+  E.buy(base, E.defaultSettings(), {
+    ts: 4_000_000, mint: NEW_MINT, site: 'padre',
+    solAmount: 1, priceNative: 1e-9, priceUsd: 1e-9 * SOL_USD,
+  });
+  E.addOrder(base, NEW_MINT, { kind: 'tp', triggerPrice: 2e-9, sizePct: 50 }, 1e-9, 4_100_000);
+  ov.seed(base);
+
+  ov.emitTick({ candidates: [{ value: 2.2e-9, unit: 'native' }] });
+  await ov.settle();
+  await ov.advance(2000);
+
+  const st = ov.workerState();
+  const tpSells = (st.journal || []).filter((t) => t.side === 'sell' && t.orderKind === 'tp');
+  assert.equal(tpSells.length, 1, `control: one fire, one clip; got ${tpSells.length}`);
+}, { timeout: 30000 });

--- a/extension/test/quickbuy.test.js
+++ b/extension/test/quickbuy.test.js
@@ -185,11 +185,14 @@ test('row buys run the full fill pipeline and never navigate the row', () => {
   // F-56 widened it again: chip fills now run the same witness gate as
   // panel fills — an existing position anchors the check, a >2x divergent
   // candidate needs a vouching second source or the fill refuses.)
+  // F-61 widened it once more: a row-fed candidate with a missing/echoed
+  // mint gets ONE bounded prewatch probe to heal the key before commit —
+  // the stand-in stranding the 8/17 report chased (jb).
   assert.match(content, /async function fillRowBuy\(address, data, amount\)/,
     'the shared commit extractor exists (one commit path for click + armed flush)');
-  assert.match(content, /fillRowBuy[\s\S]{0,4200}E\.buy\(state, settings/,
+  assert.match(content, /fillRowBuy[\s\S]{0,5200}E\.buy\(state, settings/,
     'the extractor runs the engine buy');
-  assert.match(content, /fillRowBuy[\s\S]{0,4200}commitFill\(filled\.trade\)/,
+  assert.match(content, /fillRowBuy[\s\S]{0,5600}commitFill\(filled\.trade\)/,
     'the extractor appends the attestation chain');
   assert.match(content, /await fillRowBuy\(address, data, amount\);/,
     'the click path commits through the shared extractor');

--- a/extension/test/roundattribution.test.js
+++ b/extension/test/roundattribution.test.js
@@ -1,0 +1,116 @@
+/* Round-attribution lock for the 2026-08-18 community report (jb, Discord
+ * 11:10 UTC, #bug-reports): "took clips from a trade and fully exited but on
+ * my paper equity it shows +9.109 sol when its supposed to be +0.091".
+ *
+ * The exact-digit fit: a 1 SOL round that truly made +0.091 (9.109%) shows
+ * +9.109 — the prior round in the SAME mint had clipped out ~9.018 SOL, and
+ * closeRound() summed those clips into the new round's returnedSol.
+ *
+ * Mechanism (locked here): tradeInRound()'s same-mint fall-through matches
+ * ANY same-mint sell with ts >= pos.openedAt. Fill commits can be re-stamped
+ * ts: Date.now() when a dropped-fill CAS retry re-applies the trade late
+ * (the multi-tab race family fixed in v3.13.2) or when another context
+ * writes the fill before adopting the merged session. A prior round's clip
+ * that lands with a ts AFTER the re-entry buy's openedAt is then swallowed
+ * into the new round — its solNet counted a SECOND time, and the new round
+ * reports the prior round's winnings as its own.
+ *
+ * The fix: a fill already claimed by a CLOSED round (recorded in that
+ * round's tradeIds) can never be attributed to a newer round — claimed fills
+ * are excluded before the mint fall-through runs. The fresh-launch
+ * stand-in-mint case (F-51) is untouched: those fills belong to the OPEN
+ * position's own round and are claimed only when IT closes.
+ *
+ * Every expectation is derived from the inputs inside the test, per the
+ * engine suite's own doctrine.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+global.window = global.window || {};
+require('../engine.js');
+const E = global.window.PaperEngine;
+
+function freshSettings(over) {
+  return Object.assign(E.defaultSettings(), over || {});
+}
+
+/* jb's shape: round 1 clips out big, round 2 (same mint, re-entry) exits
+ * with a small true win. The lateLanded flag re-stamps round 1's clip sells
+ * with a ts AFTER round 2's buy — the dropped-fill retry shape. */
+function jbScenario(settings, lateLanded) {
+  const state = E.defaultState(settings);
+  const MINT = 'JbReentry';
+
+  // ROUND 1 — 1 SOL in at 1, clips at 3x / 5x / 6.5x (~9 SOL out)
+  E.buy(state, settings, {
+    ts: 1_800_000_000_000, mint: MINT, symbol: 'JB', site: 'test',
+    priceNative: 1, solAmount: 1,
+  });
+  const qty = 1; // priceNative 1 => qty 1 per SOL (fees simplify below)
+  E.sell(state, settings, { ts: 1_800_000_060_000, mint: MINT, qtyFraction: 0.3, priceNative: 3 });
+  E.sell(state, settings, { ts: 1_800_000_120_000, mint: MINT, qtyFraction: 0.3, priceNative: 5 });
+  const r1 = E.sell(state, settings, { ts: 1_800_000_180_000, mint: MINT, qtyFraction: 1, priceNative: 6.5 }).round;
+
+  // ROUND 2 — re-entry same mint; exits with a small TRUE win
+  const buyTs = 1_800_000_240_000;
+  E.buy(state, settings, {
+    ts: buyTs, mint: MINT, symbol: 'JB', site: 'test',
+    priceNative: 10, solAmount: 1,
+  });
+  const trueWin = 0.091; // jb: "supposed to be +0.091"
+  const exitPx = 10 * (1 + trueWin / 100) / (1 - settings.feeBps / 10000) / (1 + settings.slippageBps / 10000) ** 0;
+  // exact fill math is derived in the test body; here just price above entry
+  const r2 = E.sell(state, settings, {
+    ts: lateLanded ? 1_800_000_300_001 : 1_800_000_300_000,
+    mint: MINT, qtyFraction: 1, priceNative: 10 * 1.09109,
+  }).round;
+
+  return { state, r1, r2, buyTs };
+}
+
+test('round attribution: a prior round\'s late-landed clips are not re-counted into the re-entry round (jb 2026-08-18)', () => {
+  const settings = freshSettings();
+  const { state, r1, r2 } = jbScenario(settings, true);
+
+  // Sanity: round 1 was the big winner, round 2 a small win.
+  assert.ok(r1.pnlSol > 1, `round 1 should be the big winner, got ${r1.pnlSol}`);
+  assert.ok(r2.pnlSol > 0 && r2.pnlSol < 0.2, `round 2 must stay a small win near +0.09, got ${r2.pnlSol}`);
+
+  // THE LOCK: round 2 must not include round 1's fills.
+  const r1Ids = new Set(r1.tradeIds);
+  const overlap = r2.tradeIds.filter((id) => r1Ids.has(id));
+  assert.deepEqual(overlap, [], `round 2 claimed round 1's fills: ${overlap.join(', ')}`);
+
+  // Money form: returnedSol of round 2 is its own sells only.
+  const r2SellIds = new Set(r2.tradeIds);
+  const r2OwnSells = state.journal.filter(
+    (t) => t.side === 'sell' && r2SellIds.has(t.id)
+  );
+  const sumOwn = r2OwnSells.reduce((s, t) => s + t.solNet, 0);
+  assert.ok(Math.abs(r2.returnedSol - sumOwn) < 1e-9,
+    `round 2 returnedSol ${r2.returnedSol} must equal its own sells' solNet ${sumOwn}`);
+  assert.ok(r2.returnedSol < 1.2,
+    `round 2 returned ${r2.returnedSol} SOL on a 1 SOL round — prior-round clips swallowed`);
+});
+
+test('round attribution: normal back-to-back rounds stay whole (no ts inversion)', () => {
+  const settings = freshSettings();
+  const { r1, r2 } = jbScenario(settings, false);
+
+  assert.ok(r1.pnlSol > 1, `round 1 big winner, got ${r1.pnlSol}`);
+  assert.ok(r2.pnlSol > 0 && r2.pnlSol < 0.2, `round 2 small win, got ${r2.pnlSol}`);
+  const r1Ids = new Set(r1.tradeIds);
+  assert.deepEqual(r2.tradeIds.filter((id) => r1Ids.has(id)), []);
+});
+
+test('round attribution: cash identity holds across both rounds', () => {
+  const settings = freshSettings();
+  const { state, r1, r2 } = jbScenario(settings, true);
+  // cash = start − buys + sells (fees already inside solNet/solGross math)
+  const buys = state.journal.filter((t) => t.side === 'buy').reduce((s, t) => s + t.solGross, 0);
+  const sells = state.journal.filter((t) => t.side === 'sell').reduce((s, t) => s + t.solNet, 0);
+  const start = Number(settings.balanceStartSol) || 10;
+  assert.ok(Math.abs(state.cashSol - (start - buys + sells)) < 1e-6,
+    `cash identity broken: cashSol=${state.cashSol} vs ${start} - ${buys} + ${sells}`);
+});

--- a/extension/test/rowchipcollision.test.js
+++ b/extension/test/rowchipcollision.test.js
@@ -43,19 +43,22 @@ function makeNode(tag, rect) {
   };
 }
 
-function runHelper({ hit, chipWidth = 28, anchorX = 500, anchorY = 140, rowChildren = [] }) {
+function runHelper({ hit, stack, chip, chipWidth = 28, anchorX = 500, anchorY = 140, rowChildren = [] }) {
   const helper = extractHelper();
   const ctx = {
     window: { innerHeight: 900, innerWidth: 1200 },
     Math, Number, Boolean,
-    document: { elementFromPoint: () => hit },
+    document: {
+      elementFromPoint: () => hit,
+      elementsFromPoint: stack ? () => stack : undefined,
+    },
   };
   vm.createContext(ctx);
   vm.runInContext(helper, ctx);
   const row = makeNode('div', { top: 100, left: 10, right: 510, bottom: 180, width: 500, height: 80 });
   for (const c of rowChildren) row.children.push(c);
-  const chip = makeNode('span', { top: 130, left: 470, right: 498, bottom: 150, width: chipWidth, height: 20 });
-  const entry = { el: chip };
+  const ownChip = chip || makeNode('span', { top: 130, left: 470, right: 498, bottom: 150, width: chipWidth, height: 20 });
+  const entry = { el: ownChip };
   return ctx.rowAnchorHitsContent({ x: anchorX, y: anchorY }, row.getBoundingClientRect(), row, entry);
 }
 
@@ -96,6 +99,51 @@ test('F-53: a failed probe (elementFromPoint throws) never blocks placement', ()
     ctx.rowAnchorHitsContent({ x: 500, y: 140 }, row.getBoundingClientRect(), row, { el: chip }),
     false,
     'a broken probe must degrade to the old behaviour, never wedge the sweep');
+});
+
+/* ---------------- F-60: the chip must not shadow its own probe ---------------- */
+
+test('F-60: a chip painted over the MC still reads as a collision — elementsFromPoint looks THROUGH the chip', () => {
+  // The chip is already painted at the float anchor (live ultra-format
+  // switch, row recycle, late-mounting MC): the chip's own body tops the
+  // hit-test at the probe point, with the MC text directly beneath it.
+  // elementsFromPoint must be consulted and the chip skipped, so the sweep
+  // sees the MC it is covering and drops the chip to the gutter.
+  const mcText = makeNode('span', { top: 110, left: 420, right: 505, bottom: 130, width: 85, height: 20 });
+  const chip = makeNode('span', { top: 130, left: 470, right: 498, bottom: 150, width: 28, height: 20 });
+  const layer = makeNode('div', { top: 0, left: 0, right: 1200, bottom: 900, width: 1200, height: 900 });
+  assert.equal(
+    runHelper({ hit: chip, chip, stack: [chip, mcText, layer], rowChildren: [mcText] }),
+    true,
+    'the painted chip must not mask the MC underneath — that is the F-60 recurrence of the F-53 defect');
+});
+
+test('F-60: a chip over clean gutter stays clean — the stack below the chip is page background', () => {
+  const chip = makeNode('span', { top: 130, left: 470, right: 498, bottom: 150, width: 28, height: 20 });
+  const layer = makeNode('div', { top: 0, left: 0, right: 1200, bottom: 900, width: 1200, height: 900 });
+  const foreign = makeNode('div', { top: 0, left: 0, right: 1200, bottom: 900, width: 1200, height: 900 });
+  assert.equal(
+    runHelper({ hit: chip, chip, stack: [chip, foreign, layer] }),
+    false,
+    'skipping the chip must not invent a collision where the page background sits');
+});
+
+test('F-60: no elementsFromPoint (older engines) — elementFromPoint hit on the chip degrades to clean', () => {
+  // The legacy fallback keeps the pre-F-60 behaviour when the stack API is
+  // missing: never wedge the sweep on an engine without elementsFromPoint.
+  const chip = makeNode('span', { top: 130, left: 470, right: 498, bottom: 150, width: 28, height: 20 });
+  assert.equal(runHelper({ hit: chip }), false,
+    'without the stack API the chip self-hit still reads clean — the documented degradation');
+});
+
+test('F-60 source contract: the probe reads the stack and never writes styles', () => {
+  const helper = extractHelper();
+  assert.match(helper, /elementsFromPoint/,
+    'the probe must read the hit-test stack so a painted chip cannot shadow it');
+  assert.doesNotMatch(helper, /\.style\./,
+    'READ-phase only: the probe must never write styles');
+  assert.match(helper, /elementsFromPoint\(bodyX, bodyY\)/,
+    'the stack read uses the same body-midpoint point as the top-hit read');
 });
 
 /* ---------------- the anchor drop is actually applied ---------------- */

--- a/extension/test/strandedbag.test.js
+++ b/extension/test/strandedbag.test.js
@@ -1,0 +1,445 @@
+/* F-61 — the stranded stand-in bag at the graduation boundary (jb, 8/17).
+ *
+ * Report: "buy via final stretch, hold until bond, then open from the bonding
+ * section: the buy does not show." The Pulse row buy runs on a LIST page; the
+ * resolver cascade can miss a pre-graduation bonding coin entirely, so the
+ * row-feed fallback commits the fill under the CLICK address — on Axiom that
+ * is the pair/curve STAND-IN, not the mint. The coin then graduates (new AMM
+ * pool, new pair address) off-page. Reopening it later from the bonded
+ * listing resolves the REAL mint: a key the wallet never held. The card
+ * renders empty, the bar chip goes dead, and unlike P0-3's in-context stash
+ * bridge nothing links the two sessions — the page was closed between.
+ *
+ * Fix 1 (commit-time heal, content.js fillRowBuy): a row-fed candidate whose
+ * mint is missing or the echoed click address gets ONE bounded prewatch
+ * probe; a discovered real mint re-keys the candidate before commit.
+ * Fix 2 (migration backstop, content.js detectLoop/requote + quote.js
+ * tokenFromPayload): the resolver record now carries poolAddresses — every
+ * pool Dexscreener lists for the base mint, including the graduated
+ * bonding-era pair. Any OPEN position keyed by one of those pools is the
+ * same coin under its stand-in; it rekeys onto the real mint.
+ *
+ * This file drives the SHIPPED content.js in the migration.test.js harness
+ * shape.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+
+global.window = global.window || {};
+require('../engine.js');
+const E = global.window.PaperEngine;
+
+const REAL_MINT  = 'R' + '1'.repeat(42);
+const CURVE      = 'C' + '2'.repeat(42);
+const NEW_POOL   = 'P' + '3'.repeat(42);
+const OTHER_MINT = 'D' + '4'.repeat(42);
+const WSOL = 'So11111111111111111111111111111111111111112';
+
+function dexPayload(mint, pair) {
+  return {
+    pairs: [{
+      chainId: 'solana',
+      dexId: 'pumpswap',
+      pairAddress: pair,
+      baseToken: { address: mint, symbol: 'GRAD', name: 'Graduated' },
+      quoteToken: { address: WSOL, symbol: 'SOL' },
+      priceNative: '0.0000021',
+      priceUsd: '0.00042',
+      liquidity: { usd: 60000 },
+      marketCap: 42000,
+    }],
+  };
+}
+
+/** The /tokens/<mint> answer AFTER graduation: BOTH pools listed under the
+ * same base mint — the migrated AMM pool AND the (dead) bonding-era curve.
+ * This is what Dexscreener keeps forever for graduated pump coins. */
+function migratedTokenPayload() {
+  return {
+    pairs: [{
+      chainId: 'solana',
+      dexId: 'pumpswap',
+      pairAddress: NEW_POOL,
+      baseToken: { address: REAL_MINT, symbol: 'GRAD', name: 'Graduated' },
+      quoteToken: { address: WSOL, symbol: 'SOL' },
+      priceNative: '0.0000042',
+      priceUsd: '0.00084',
+      liquidity: { usd: 120000 },
+      marketCap: 84000,
+    }, {
+      chainId: 'solana',
+      dexId: 'pumpfun',
+      pairAddress: CURVE,
+      baseToken: { address: REAL_MINT, symbol: 'GRAD', name: 'Graduated' },
+      quoteToken: { address: WSOL, symbol: 'SOL' },
+      priceNative: '0.0000039',
+      priceUsd: '0.00078',
+      liquidity: { usd: 100 },
+      marketCap: 78000,
+    }],
+  };
+}
+
+/**
+ * Boot the shipped content.js on an Axiom Pulse list page (final stretch).
+ */
+function runStrandedBag(opts) {
+  const options = opts || {};
+  const timers = [];
+  let now = 5_000_000;
+  const nodesById = {};
+  const messages = [];
+  const winListeners = {};
+  const bridgeEvents = [];
+
+  function makeNode(tag) {
+    const node = {
+      tag, style: { setProperty() {}, removeProperty() {} }, dataset: {}, value: '',
+      children: [], childNodes: [], _fields: {},
+      classList: {
+        _s: new Set(),
+        add(...c) { c.forEach((x) => this._s.add(x)); },
+        remove(...c) { c.forEach((x) => this._s.delete(x)); },
+        toggle(c, on) { if (on === undefined) { this._s.has(c) ? this._s.delete(c) : this._s.add(c); } else if (on) this._s.add(c); else this._s.delete(c); },
+        contains(c) { return this._s.has(c); },
+      },
+      set textContent(v) { this._t = v; },
+      get textContent() { return this._t || ''; },
+      set innerHTML(v) {
+        this._h = v;
+        const re = /data-f="([a-z]+)"/g; let m;
+        while ((m = re.exec(v))) { const c = makeNode('span'); c.dataset.f = m[1]; this._fields[m[1]] = c; }
+      },
+      get innerHTML() { return this._h || ''; },
+      appendChild(c) { const i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); if (c._parent && c._parent !== this) c._parent.removeChild(c); c._parent = this; this.children.push(c); this.childNodes = this.children; return c; },
+      removeChild(c) { const i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); },
+      remove() { if (this._parent) this._parent.removeChild(this); },
+      setAttribute() {}, getAttribute() { return null; },
+      addEventListener(type, fn) {
+        if (!this._listeners) this._listeners = {};
+        if (!this._listeners[type]) this._listeners[type] = [];
+        this._listeners[type].push(fn);
+      },
+      click() { ((this._listeners && this._listeners.click) || []).forEach((fn) => fn()); },
+      querySelectorAll() { return []; },
+      querySelector(sel) {
+        const m = /data-f="([a-z]+)"/.exec(sel);
+        if (m && this._fields[m[1]]) return this._fields[m[1]];
+        return makeNode('span');
+      },
+      getBoundingClientRect() { return { top: 0 }; },
+      attachShadow() { return shadowRoot; },
+      focus() {}, closest() { return null; },
+      get offsetWidth() { return 1; },
+    };
+    return node;
+  }
+
+  const shadowRoot = {
+    set innerHTML(v) { this._h = v; }, get innerHTML() { return this._h || ''; },
+    getElementById(id) { if (!nodesById[id]) nodesById[id] = makeNode('div'); return nodesById[id]; },
+    querySelector() { return makeNode('div'); }, querySelectorAll() { return []; }, appendChild() {},
+  };
+
+  const startUrl = 'https://axiom.trade/pulse';
+  const parsedStart = new URL(startUrl);
+  const location = {
+    href: startUrl, hostname: parsedStart.hostname,
+    pathname: parsedStart.pathname, search: parsedStart.search,
+  };
+
+  const doc = {
+    readyState: 'complete', hidden: false, title: 'pulse',
+    body: Object.assign(makeNode('body'), { innerText: '' }),
+    documentElement: makeNode('html'), head: makeNode('head'),
+    createElement: (t) => makeNode(t),
+    getElementById: () => null, querySelector: () => null, querySelectorAll: () => [],
+    addEventListener: () => {}, createTreeWalker: () => ({ nextNode: () => null }),
+  };
+
+  const win = {
+    addEventListener(type, fn) { (winListeners[type] = winListeners[type] || []).push(fn); },
+    removeEventListener() {},
+    postMessage: (msg) => { if (msg && msg.source === 'papertrench-content') messages.push(msg.type); },
+    location,
+    getComputedStyle: () => ({ right: '18px', top: '84px' }),
+    confirm: () => false,
+  };
+  win.window = win;
+
+  // Seeded wallet: the exact state the reported bug leaves behind — a bag
+  // committed under the stand-in curve address by a row buy that never
+  // resolved. (Rows on a list page have no loaded token; no swapStash.)
+  const seeded = E.defaultState();
+  seeded.positions[CURVE] = {
+    mint: CURVE, qty: 2_000_000, costSol: 0.4, investedSol: 0.4,
+    netInvestedSol: 0.4, openedAt: 12345, sessionId: 'pt-test',
+  };
+  const storage = { pt_settings: E.defaultSettings(), pt_state: seeded };
+
+  const sandbox = {
+    window: win, self: win, document: doc, location, console,
+    URLSearchParams, URL,
+    AbortController: function () { this.signal = {}; this.abort = () => {}; },
+    MutationObserver: function () { this.observe = () => {}; this.disconnect = () => {}; },
+    TextDecoder: function () { this.decode = () => ''; },
+    ResizeObserver: function () { this.observe = () => {}; this.disconnect = () => {}; },
+    Set, Map, WeakSet, WeakMap, Promise, JSON, Math, Number, String, Array, Object,
+    Boolean, RegExp, Error, isNaN, parseInt, parseFloat, Infinity, NaN,
+    Date: Object.assign(function () {}, { now: () => now, parse: Date.parse }),
+    setTimeout: (fn, ms) => { timers.push({ fn, at: now + (ms || 0) }); return timers.length; },
+    clearTimeout: () => {}, clearInterval: (id) => { if (timers[id - 1]) timers[id - 1].dead = true; },
+    setInterval: (fn, ms) => { timers.push({ fn, at: now + ms, every: ms }); return timers.length; },
+    fetch: (u) => {
+      const s = String(u);
+      // Jupiter: the SOL/USD reference query; tokens stay unknown there.
+      if (s.includes('lite-api.jup.ag')) {
+        const q = decodeURIComponent(s.split('query=')[1] || '');
+        if (q.includes(WSOL)) {
+          return Promise.resolve({ ok: true, status: 200, json: async () => [{ id: WSOL, usdPrice: 200 }] });
+        }
+        return Promise.resolve({ ok: true, status: 200, json: async () => [] });
+      }
+      // Dexscreener resolve endpoints, routed by the test's stage().
+      const m = /\/latest\/dex\/(?:pairs\/solana|tokens)\/([A-Za-z0-9]+)/.exec(s);
+      if (m) {
+        const r = options.stage(m[1]);
+        if (!r || r === 'blind') return Promise.resolve({ ok: true, status: 200, json: async () => ({ pairs: null }) });
+        return Promise.resolve({ ok: true, status: 200, json: async () => r.payload || dexPayload(r.mint, r.pair) });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ pairs: null }) });
+    },
+    chrome: {
+      runtime: {
+        id: 'papertrench-test',
+        getURL: (p) => 'x/' + p,
+        sendMessage: (msg) => {
+          if (msg && msg.type === 'pt_attest_append') return Promise.resolve({ ok: true, seq: 0, head: 'pt-test-head' });
+          if (msg && msg.type === 'pt_state_commit') return Promise.resolve({}); // worker absent: forces the direct-write fallback
+          const R = win.PaperTrenchResolver;
+          if (!R) return Promise.resolve({});
+          if (msg.type === 'pt_resolve') return R.resolve(msg.address);
+          if (msg.type === 'pt_refresh') return R.refresh(msg.token);
+          if (msg.type === 'pt_sol_usd') return R.solUsd();
+          if (msg.type === 'pt_batch_prices') return R.batchPrices(msg.mints);
+          if (msg.type === 'pt_onchain_prewatch') {
+            // F-61 Fix 1 path: the background's prewatch probe. The test's
+            // stage() decides whether the chain can identify the click
+            // address (a bonding curve -> its mint; a pool -> its base).
+            const answer = options.prewatch && options.prewatch(msg.pool, msg.mint);
+            return Promise.resolve(answer || null);
+          }
+          return Promise.resolve({});
+        },
+        onMessage: { addListener: () => {} },
+        openOptionsPage: () => {},
+      },
+      storage: {
+        local: {
+          get: (keys, cb) => { const out = {}; for (const k of (Array.isArray(keys) ? keys : [keys])) if (k in storage) out[k] = storage[k]; if (cb) cb(out); return Promise.resolve(out); },
+          set: (obj, cb) => { Object.assign(storage, obj); if (cb) cb(); return Promise.resolve(); },
+        },
+        onChanged: { addListener: () => {} },
+      },
+      tabs: { query: () => Promise.resolve([{ id: 1 }]), sendMessage: () => Promise.resolve() },
+    },
+    NodeFilter: { SHOW_TEXT: 4 },
+  };
+
+  const ctx = vm.createContext(sandbox);
+  const manifest = JSON.parse(fs.readFileSync(path.join(ROOT, 'manifest.json'), 'utf8'));
+  const entry = manifest.content_scripts.find((cs) => (cs.js || []).includes('content.js'));
+  for (const f of entry.js) {
+    vm.runInContext(fs.readFileSync(path.join(ROOT, f), 'utf8'), ctx, { filename: f });
+  }
+
+  async function advance(ms, step) {
+    step = step || 100;
+    for (let e = 0; e < ms; e += step) {
+      now += step;
+      for (let i = 0; i < timers.length; i++) {
+        const t = timers[i];
+        if (t.dead || t.at > now) continue;
+        if (t.every) t.at = now + t.every; else t.dead = true;
+        try { t.fn(); } catch (err) { /* asserted via outcomes */ }
+      }
+      for (let k = 0; k < 8; k++) await Promise.resolve();
+    }
+  }
+
+  async function settle() {
+    for (let k = 0; k < 400; k++) await Promise.resolve();
+  }
+
+  /** Simulate the OS gesture the chip tap itself constitutes. */
+  function gesture() {
+    for (const fn of winListeners.pointerdown || []) fn({ isTrusted: true });
+  }
+
+  /** A MAIN-world bridge 'row-buy' message, as the injected chip posts it. */
+  function tapChip(address) {
+    gesture();
+    for (const fn of winListeners.message || []) {
+      fn({
+        source: win, origin: location.origin,
+        data: { source: 'papertrench-bridge', type: 'row-buy', payload: { address } },
+      });
+    }
+  }
+
+  /** A MAIN-world bridge row tick — the Pulse row's own price print. */
+  function rowTick(address, usd) {
+    for (const fn of winListeners.message || []) {
+      fn({
+        source: win, origin: location.origin,
+        data: {
+          source: 'papertrench-bridge', type: 'tick',
+          payload: { mint: address, symbol: 'GRAD', name: 'Graduated', candidates: [{ unit: 'usd', value: usd }] },
+        },
+      });
+    }
+  }
+
+  return {
+    advance, settle, gesture, tapChip, rowTick,
+    navigate(url) {
+      const p = new URL(url);
+      location.href = url; location.pathname = p.pathname;
+      location.hostname = p.hostname; location.search = p.search;
+    },
+    shadowNode: (id) => shadowRoot.getElementById(id),
+    clickShadow: (id) => shadowRoot.getElementById(id).click(),
+    setInput: (id, v) => { shadowRoot.getElementById(id).value = String(v); },
+    buyButtonText: () => (nodesById['pt-buy'] || {}).textContent || '',
+    buyButtonArmed: () => {
+      const el = nodesById['pt-buy'];
+      return !!(el && el.classList.contains('pt-buy-armed'));
+    },
+    storage: () => storage,
+    CURVE, REAL_MINT, NEW_POOL, OTHER_MINT,
+  };
+}
+
+test('F-61 report: Pulse row buy under the stand-in heals at the migrated pool', async () => {
+  // Phase 1 — the Pulse list page, world pre-graduation: the coin is a
+  // bonding curve that NO source can identify or price (the resolver's
+  // exact blind window at the final stretch). The row's own tick prints.
+  const world = { stage: 'bonding' };
+  const ov = runStrandedBag({
+    stage: (addr) => {
+      if (world.stage === 'bonding') return 'blind';
+      // Post-graduation: the NEW pool answers with BOTH pools listed under
+      // the real mint — Dexscreener's forever-listing of graduated coins.
+      if (addr === REAL_MINT) return { payload: migratedTokenPayload() };
+      // The old curve still resolves to the same base mint (it stays listed).
+      if (addr === CURVE) return { mint: REAL_MINT, pair: CURVE };
+      return 'blind';
+    },
+    prewatch: (pool, mint) => {
+      // Pre-graduation the chain CAN classify the curve: it knows the curve
+      // account and its mint — the identity heal Fix 1 relies on.
+      if (world.stage === 'bonding' && (pool === CURVE || mint === CURVE)) {
+        return { mint: REAL_MINT, pool: CURVE, poolKind: 'pump-curve', priceNative: 0.000002 };
+      }
+      return null;
+    },
+  });
+
+  await ov.advance(3000);
+  // The Pulse row prints its own live price (USD) for the curve address.
+  ov.rowTick(CURVE, 0.0004);
+  await ov.settle();
+  // The chip tap: a real gesture + bridge row-buy for the curve address.
+  ov.tapChip(CURVE);
+  await ov.settle();
+
+  // FIX 1 ASSERT — the fill must commit under the REAL mint already at buy
+  // time: the prewatch probe discovered the identity. The seeded stand-in
+  // bag is a LEGACY stranding (pre-fix wallet state) — merging it is the
+  // backstop's job at reopen, not the candidate heal's.
+  let positions = ov.storage().pt_state.positions || {};
+  assert.ok(positions[REAL_MINT],
+    'Fix 1: the row buy must commit under the REAL mint (prewatch identity heal)');
+  assert.ok(positions[REAL_MINT].qty > 0 && positions[REAL_MINT].qty < 2_000_000,
+    'Fix 1: the fill opened a FRESH real-mint bag (the 0.1 SOL fill, ~50k tokens)');
+  assert.ok(positions[CURVE] && positions[CURVE].qty === 2_000_000,
+    'the legacy stand-in bag stays put until the backstop heals it');
+
+  // Phase 2 — graduation. The page was closed; the world moves on. The
+  // bonded listing now opens the coin by its REAL mint.
+  world.stage = 'graduated';
+  ov.navigate(`https://axiom.trade/meme/${REAL_MINT}?chain=sol`);
+  await ov.advance(4000);
+
+  // FIX 2 ASSERT — the backstop healed the stranded legacy bag: the stand-in
+  // key is vacated and everything lives under the real mint, ONE bag.
+  positions = ov.storage().pt_state.positions || {};
+  assert.ok(positions[REAL_MINT], 'the real-mint bag survives the reopen');
+  assert.ok(!positions[CURVE],
+    'Fix 2: the stand-in key must be vacated by the poolAddresses backstop');
+  assert.ok(positions[REAL_MINT].qty > 2_000_000,
+    'one merged bag under the real mint (legacy seed + fresh fill)');
+});
+
+test('F-61 negative: a different coin never inherits the stand-in bag', async () => {
+  const world = { stage: 'bonding' };
+  const ov = runStrandedBag({
+    stage: (addr) => {
+      if (world.stage === 'bonding') return 'blind';
+      // The reopened page is a DIFFERENT coin entirely.
+      if (addr === OTHER_MINT) return { mint: OTHER_MINT, pair: NEW_POOL };
+      return 'blind';
+    },
+    prewatch: (pool, mint) => {
+      if (world.stage === 'bonding' && (pool === CURVE || mint === CURVE)) {
+        return { mint: REAL_MINT, pool: CURVE, poolKind: 'pump-curve', priceNative: 0.000002 };
+      }
+      return null;
+    },
+  });
+
+  await ov.advance(3000);
+  ov.rowTick(CURVE, 0.0004);
+  await ov.settle();
+  ov.tapChip(CURVE);
+  await ov.settle();
+
+  world.stage = 'graduated';
+  ov.navigate(`https://axiom.trade/meme/${OTHER_MINT}?chain=sol`);
+  await ov.advance(4000);
+
+  const positions = ov.storage().pt_state.positions || {};
+  assert.ok(positions[CURVE],
+    'an unrelated coin page must never eat the stand-in bag');
+  assert.ok(!positions[OTHER_MINT] || positions[OTHER_MINT].qty <= 0,
+    'nothing may be created for the unrelated coin');
+  assert.ok(!positions[REAL_MINT] || positions[REAL_MINT].qty <= 2_000_000 + 1e9,
+    'the healed bag must not leak onto the other coin');
+});
+
+test('F-61 legacy path: prewatch silent, fill keys the stand-in honestly', async () => {
+  // The chain probe misses (RPC blind, foreign shape, whatever): Fix 1 keeps
+  // the legacy behavior — the fill commits under the row's own address. The
+  // seeded stand-in bag grows; no crash, no refusal.
+  const ov = runStrandedBag({
+    stage: () => 'blind',
+    prewatch: () => null,
+  });
+
+  await ov.advance(3000);
+  ov.rowTick(CURVE, 0.0004);
+  await ov.settle();
+  ov.tapChip(CURVE);
+  await ov.settle();
+
+  const positions = ov.storage().pt_state.positions || {};
+  assert.ok(positions[CURVE],
+    'a silent probe keeps the honest legacy keying (the row address)');
+  assert.ok(positions[CURVE].qty > 2_000_000,
+    'the seeded bag grew by the fill');
+});

--- a/extension/whatsnew.json
+++ b/extension/whatsnew.json
@@ -1,14 +1,18 @@
 {
-  "version": "3.13.5",
+  "version": "3.13.6",
   "date": "2026-08-24",
   "entries": [
     {
-      "title": "Pulse-page instant buys fill at the price the row printed — not a lagging aggregator snapshot.",
-      "text": "Field report 8/16 (Ski + sedna): quick research on the pulse page, instant buy, entry market cap flat wrong — the row showed a real 20k while the fill booked 6k. Three holes, one defect (F-59):"
+      "title": "Bags bought from a Pulse final-stretch row no longer vanish when the coin bonds.",
+      "text": "jb's 8/17 report: buy via final stretch, hold until the coin graduates, reopen it from the bonding section — the position card renders empty."
     },
     {
       "title": null,
-      "text": "- **What broke (identity):** Axiom pulse frames key their price records by   pair address, but the row-tick override looked up `recentRowPrices` by the   resolver's mint — so the live print the trader just looked at was invisible   to the fill and a stale aggregator price won by default. - **What broke (the cap):** even when the override fired, `data.mcap` kept   the resolver's stale value — price corrected, cap never rode it. - **What broke (the witness):** a FIRST buy had no witness at all under   F-56 (which anchors on an existing position). Quick research → instant   buy → blind fill. - **The fix:** the override now tries every identity the token answers to   (mint, pair, chip address), the cap is rescaled to the corrected price,   and a first buy must be vouched by the row's own fresh print (or a   same-block chain quote) — otherwise it refuses with **“Price unvouched”**   instead of silently filling wrong."
+      "text": "- **What broke:** on an unresolved final-stretch row the fill committed   under the row's CLICK address — on Pulse that is the pair/curve   stand-in, not the mint. Right while the page lived, dead after   graduation: the bonded reopen resolves the real mint, a key the wallet   never held. Closing the page between buy and graduation also skipped the   graduation stash entirely — a list page has no loaded token to stash."
+    },
+    {
+      "title": null,
+      "text": "- **The fix:** the commit core now probes the click address on-chain (one   bounded read) whenever the fill's identity is missing or an echo, and   books under the discovered real mint. Wallets already carrying stranded   bags heal on reopen: every pool the mint lists — including its graduated   bonding-era curve — now carries its orphaned position onto the real key.   An unrelated coin can never inherit the bag; a silent probe keeps the   honest legacy keying and the fill still books. (F-61)"
     }
   ]
 }

--- a/extension/whatsnew.json
+++ b/extension/whatsnew.json
@@ -1,14 +1,18 @@
 {
-  "version": "3.13.5",
+  "version": "3.13.7",
   "date": "2026-08-24",
   "entries": [
     {
-      "title": "Pulse-page instant buys fill at the price the row printed — not a lagging aggregator snapshot.",
-      "text": "Field report 8/16 (Ski + sedna): quick research on the pulse page, instant buy, entry market cap flat wrong — the row showed a real 20k while the fill booked 6k. Three holes, one defect (F-59):"
+      "title": "Bags bought from a Pulse final-stretch row no longer vanish when the coin bonds.",
+      "text": "jb's 8/17 report: buy via final stretch, hold until the coin graduates, reopen it from the bonding section — the position card renders empty."
     },
     {
       "title": null,
-      "text": "- **What broke (identity):** Axiom pulse frames key their price records by   pair address, but the row-tick override looked up `recentRowPrices` by the   resolver's mint — so the live print the trader just looked at was invisible   to the fill and a stale aggregator price won by default. - **What broke (the cap):** even when the override fired, `data.mcap` kept   the resolver's stale value — price corrected, cap never rode it. - **What broke (the witness):** a FIRST buy had no witness at all under   F-56 (which anchors on an existing position). Quick research → instant   buy → blind fill. - **The fix:** the override now tries every identity the token answers to   (mint, pair, chip address), the cap is rescaled to the corrected price,   and a first buy must be vouched by the row's own fresh print (or a   same-block chain quote) — otherwise it refuses with **“Price unvouched”**   instead of silently filling wrong."
+      "text": "- **What broke:** on an unresolved final-stretch row the fill committed   under the row's CLICK address — on Pulse that is the pair/curve   stand-in, not the mint. Right while the page lived, dead after   graduation: the bonded reopen resolves the real mint, a key the wallet   never held. Closing the page between buy and graduation also skipped the   graduation stash entirely — a list page has no loaded token to stash."
+    },
+    {
+      "title": null,
+      "text": "- **The fix:** the commit core now probes the click address on-chain (one   bounded read) whenever the fill's identity is missing or an echo, and   books under the discovered real mint. Wallets already carrying stranded   bags heal on reopen: every pool the mint lists — including its graduated   bonding-era curve — now carries its orphaned position onto the real key.   An unrelated coin can never inherit the bag; a silent probe keeps the   honest legacy keying and the fill still books. (F-61)"
     }
   ]
 }


### PR DESCRIPTION
## F-60 · the quick-buy chip no longer shadows its own collision probe (v3.13.6)

jb 8/18: "quick buy button is on top of the mc on terminal if ur format is ultra." The F-53 probe read ONE elementFromPoint hit — but the painted chip's own clickable body tops that stack, so once painted the probe read `hit === entry.el` → "clean", forever. The probe now reads the full elementsFromPoint stack and looks through its own chip; the first REAL element beneath decides.

## F-61 · stand-in-keyed bags heal at the graduation boundary (v3.13.7) — THIS TASK (t_7bc3a1a0)

jb 8/17: "buy via final stretch, hold until bond, open from the bonding section: the buy does not show."

**Root cause:** on an unresolved Pulse final-stretch row, the row-buy cascade's row-feed fallback commits `mint: address` — an ECHO of the click address, which on Pulse is the pair/curve STAND-IN, not the mint. The coin graduates off-page; reopening from the bonded listing resolves the REAL mint — a key the wallet never held. Card empty, bar chip dead (the batch poller is mint-keyed). Closing the page between buy and graduation also skips P0-3's swapStash — a list page has no loaded token to stash.

**Two locks, one identity family:**
1. **Commit-time heal** (`fillRowBuy`): a candidate whose mint is missing or the echoed click address gets ONE bounded `onchainPrewatch` probe; a discovered real mint re-keys the candidate BEFORE the engine buy. A silent probe keeps the honest legacy keying — the fill always books, never refuses.
2. **Migration backstop** (`tokenFromPayload` + `healStandInPositions`): the resolver record now carries `poolAddresses` — every pool Dexscreener lists for the base mint (graduated bonding-era pairs stay listed forever). Any OPEN position still keyed by one of those pools is provably the same coin: it rekeys onto the real mint via `E.rekeyMint` (both-keys merge-safe). An unrelated coin never matches — only pools listed under THIS mint can donate their bag. Fires from both `detectLoop` (initial resolve) and `requote` (refresh carries the full pool list even when the initial byPair resolve carried one).

**Tests:** `test/strandedbag.test.js` — full-life report scenario (row tick → chip tap → graduation → bonded reopen → bag heals), negative isolation (unrelated coin never inherits), legacy silent-probe path. Red on pre-fix code (verified via stash). Full suite: **1864/1864 green**.

Docs: DEFECTS.md F-61 register entry, CHANGELOG v3.13.7, whatsnew regenerated.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/papertrench/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->