### PR TITLE
v3.13.10 — armed stops fire, migrated coins price, streams roster (D-57/58/59, #64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 Stream-style log of what shipped, newest first. User-facing wording; the gory
 details live in the commit messages.
 
+## v3.13.10 — 2026-08-25
+
+**Migrated coins have a live price again.** When a pump.fun coin graduates,
+its bonding curve stops carrying a price — and PaperTrench never looked for
+the pool it had just migrated *into*. So for the minutes right after
+migration, the window where the coin is most tradable, the panel sat on
+"Fetching live price…" waiting for an aggregator to catch up.
+
+It now asks the chain which PumpSwap pool holds the coin and prices it
+directly. Against live mainnet, 4/4 freshly migrated coins price in about two
+seconds where all 4 previously showed nothing.
+
+- Only a SOL-quoted pool from a program we have a verified decoder for is ever
+  adopted, and where a coin has several, the deepest one wins — a dust pool
+  quotes a price nobody could fill against. No pool on chain still means no
+  price shown, never a guessed one.
+- Covers non-pump.fun launchpads too (Bags, Believe, moonshot), which reach
+  the same code path.
+
+Thanks to **cheng.4848** and **ark_trades13**, who reported this independently
+and pinned it to migrated tokens specifically — that detail is what made it
+findable.
+
 ## v3.13.9 — 2026-08-25
 
 **Your stop fires now.** Two separate bugs behind the same family of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 Stream-style log of what shipped, newest first. User-facing wording; the gory
 details live in the commit messages.
 
+## v3.13.6 — 2026-08-24
+
+**Bags bought from a Pulse final-stretch row no longer vanish when the coin
+bonds.** jb's 8/17 report: buy via final stretch, hold until the coin
+graduates, reopen it from the bonding section — the position card renders
+empty.
+
+- **What broke:** on an unresolved final-stretch row the fill committed
+  under the row's CLICK address — on Pulse that is the pair/curve
+  stand-in, not the mint. Right while the page lived, dead after
+  graduation: the bonded reopen resolves the real mint, a key the wallet
+  never held. Closing the page between buy and graduation also skipped the
+  graduation stash entirely — a list page has no loaded token to stash.
+
+- **The fix:** the commit core now probes the click address on-chain (one
+  bounded read) whenever the fill's identity is missing or an echo, and
+  books under the discovered real mint. Wallets already carrying stranded
+  bags heal on reopen: every pool the mint lists — including its graduated
+  bonding-era curve — now carries its orphaned position onto the real key.
+  An unrelated coin can never inherit the bag; a silent probe keeps the
+  honest legacy keying and the fill still books. (F-61)
+
 ## v3.13.4 — 2026-08-24
 
 **Armed buys fire the moment the first quote lands — even when the launch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,44 @@
 Stream-style log of what shipped, newest first. User-facing wording; the gory
 details live in the commit messages.
 
+## v3.13.9 — 2026-08-25
+
+**Your stop fires now.** Two separate bugs behind the same family of
+reports — "my stop never went off while it rugged", "I made a minus 12%
+but should have been plus", "my paper equity shows +9.109 when it should
+be +0.091".
+
+- **An armed stop or take-profit was only judged when the price
+  CHANGED.** The level check lived in one place: the tick path, below the
+  "this price is the same as the last one, nothing to redraw" shortcut.
+  That shortcut is right about redrawing and wrong about levels — because
+  a level can be armed *after* the last price move. Reload a chart and
+  your wallet loads a beat after the first ticks land; drag a stop on
+  while the tape is quiet; arm one from another tab. In every case the
+  level was already crossed by the price on screen, and PaperTrench was
+  waiting for a *different* number before it would look.
+
+  The books where a different number never comes are exactly the ones a
+  stop exists for: a dead market, or a rug printing the same number all
+  the way down. So the stop sat there while the position bled out.
+  Levels are now judged before that shortcut, and the 100 ms heartbeat
+  re-asks the question every beat — the same watchdog armed buys have
+  had since F-16. It cannot double-fire: one function decides every
+  fill, and asking it twice about a level it already spent is a no-op.
+  (D-57)
+
+- **A take-profit clip could be booked twice.** With two chart tabs open
+  on the same coin — routine, since every quick-buy chip tap opens one —
+  both tabs see the trigger. The one that loses the write race re-applies
+  its fill onto the winner's wallet, and it only checked that the
+  position was still open. A 50% clip doesn't close the position, so the
+  loser sold again: proceeds credited twice, and paper equity inflated by
+  a whole extra set of clips. It now re-checks that the order itself is
+  still live, exactly as armed buys already did. (D-58)
+
+  This is the *second* mechanism behind jb's "+9.109 vs +0.091" report —
+  v3.13.8 fixed the starting-balance half. Both were live at once.
+
 ## v3.13.8 — 2026-08-24
 
 **"Paper equity showed +9.109 SOL, should be +0.091 — exactly 100×."** jb's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 Stream-style log of what shipped, newest first. User-facing wording; the gory
 details live in the commit messages.
 
+## v3.13.11 — 2026-08-25
+
+**Brand-new coins are buyable immediately.** If you installed the extension
+and every coin sat on "Fetching live price…" — only becoming buyable once it
+had aged 20-30 seconds — that was one throttled RPC read poisoning the whole
+token.
+
+The extension probes the chain directly for coins too new for any
+aggregator to know. That probe marked the address as "already probed"
+*before* the read came back, and never un-marked it if the read failed. A
+single blip — a rate-limited public endpoint, a dropped socket — therefore
+switched off the only source that can price a fresh launch, leaving the coin
+waiting on an indexer to catch up.
+
+A failed read is never evidence about the coin. Now a failed probe retries on
+the very next pass (~400ms) instead of waiting on a ~4-second safety net, and
+clicking Buy asks the chain whenever nothing else produced a price, rather
+than only when the panel had never had one.
+
 ## v3.13.10 — 2026-08-25
 
 **Migrated coins have a live price again.** When a pump.fun coin graduates,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,28 @@
 Stream-style log of what shipped, newest first. User-facing wording; the gory
 details live in the commit messages.
 
+## v3.13.7 — 2026-08-24
+
+**Bags bought from a Pulse final-stretch row no longer vanish when the coin
+bonds.** jb's 8/17 report: buy via final stretch, hold until the coin
+graduates, reopen it from the bonding section — the position card renders
+empty.
+
+- **What broke:** on an unresolved final-stretch row the fill committed
+  under the row's CLICK address — on Pulse that is the pair/curve
+  stand-in, not the mint. Right while the page lived, dead after
+  graduation: the bonded reopen resolves the real mint, a key the wallet
+  never held. Closing the page between buy and graduation also skipped the
+  graduation stash entirely — a list page has no loaded token to stash.
+
+- **The fix:** the commit core now probes the click address on-chain (one
+  bounded read) whenever the fill's identity is missing or an echo, and
+  books under the discovered real mint. Wallets already carrying stranded
+  bags heal on reopen: every pool the mint lists — including its graduated
+  bonding-era curve — now carries its orphaned position onto the real key.
+  An unrelated coin can never inherit the bag; a silent probe keeps the
+  honest legacy keying and the fill still books. (F-61)
+
 ## v3.13.4 — 2026-08-24
 
 **Armed buys fire the moment the first quote lands — even when the launch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 Stream-style log of what shipped, newest first. User-facing wording; the gory
 details live in the commit messages.
 
+## v3.13.8 — 2026-08-24
+
+**"Paper equity showed +9.109 SOL, should be +0.091 — exactly 100×."** jb's
+8/18 report, after a full exit: the wallet's session return was welded to the
+"Starting paper balance" setting. Change the form 10 → 1 SOL and a wallet
+that really started at 10 re-denominates its whole history overnight.
+
+- **Who was hit:** every wallet created before v3.9.5 (the D-06 birth
+  snapshot). Newer wallets froze their starting balance at reset; older ones
+  never got the field, so every "vs start" number — popup, overlay,
+  dashboard, even the leaderboard bridge — read the *live* form value.
+
+- **The fix:** the wallet's own fill history now re-derives its birth
+  balance (equity − open P&L − the sum of every fill's effect), and the
+  first load after this update freezes that number onto the wallet. Marks
+  moving or another tab trading in between can't shift it — it's the same
+  arithmetic the equity curve already uses. Until the frozen number lands,
+  every surface falls back to the derived value before the form, so the
+  right number shows on the very first paint. jb's wallet: +0.091 SOL stays
+  +0.091 SOL, whatever the form says. (D-56)
+
+- **Also closed:** a wallet reset from the popup now snapshots its starting
+  balance too — previously a popup-born wallet would have lived its whole
+  life as a "legacy" wallet with the same hole.
+
 ## v3.13.7 — 2026-08-24
 
 **Bags bought from a Pulse final-stretch row no longer vanish when the coin

--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -473,6 +473,34 @@ per-site defaults (`listQuickBuyPlacement`) and an explicit user setting
 once the chip itself is painted → F-60. Locked by
 extension/test/rowchipcollision.test.js (probe decisions, gutter fallback,
 placementPref plumbing, both anchor modes consult the probe).
+**F-61 · S1 · a Pulse final-stretch buy committed under the pair stand-in vanished at the graduation boundary — the bonded reopen resolved a key the wallet never held**
+`content.js` fillRowBuy/detectLoop/requote/healStandInPositions ·
+`quote.js` tokenFromPayload · Axiom Pulse "Final Stretch" list rows (jb
+2026-08-17: "buy via final stretch, hold until bond, open from the bonding
+section: the buy does not show") · **fixed v3.13.7** — two holes, one
+identity family (F-51's stand-in stranding at a different lifecycle point):
+
+(1) *Commit-time.* The row-buy cascade ends in the row-feed fallback
+(`mint: address` — an ECHO, not a discovered identity). On a Pulse
+final-stretch row the click address is the PAIR/curve stand-in, so the fill
+keyed the stand-in: right while the page lived, dead the moment the coin
+graduated to a new AMM pool. `fillRowBuy` now probes the click address with
+ONE bounded `onchainPrewatch` when the candidate's mint is missing or the
+echo (`data.mint === address`); a discovered real mint re-keys the candidate
+BEFORE the engine buy. A silent probe keeps the honest legacy keying — the
+fill still books, never refuses.
+
+(2) *Recovery.* Wallets already carrying stand-in-keyed bags (the reported
+case: page closed between buy and graduation, so P0-3's in-context
+swapStash never ran — no loaded token, nothing stashed) heal at reopen:
+`tokenFromPayload` now carries `poolAddresses` (every pool Dexscreener
+lists for the base mint — graduated bonding-era pairs stay listed forever),
+and detectLoop/requote call `healStandInPositions`, which rekeys any OPEN
+position still keyed by one of those pools onto the real mint (via
+`E.rekeyMint`, both-keys merge-safe). An unrelated coin never matches —
+only pools provably listed under THIS base mint can donate their bag.
+Locked by extension/test/strandedbag.test.js (full-life report scenario,
+negative isolation, legacy silent-probe path) — red on pre-fix code.
 
 **F-41 · S1 · One buy drew TWO bubbles, and the average line never appeared — a dead self-write guard duplicated every fill, and a stale-ledger veto quietly relocated the line off-screen**
 `content.js` watchStorage/doBuy/doSellInner · `price-bridge.js`

--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -430,6 +430,35 @@ extension/test/rowfillaccuracy.test.js (identity lookups, cap rescale on
 both override sites, first-buy witness wiring, refusal voice, ancient-print
 exemption).
 
+**F-61 · S1 · a Pulse final-stretch buy committed under the pair stand-in vanished at the graduation boundary — the bonded reopen resolved a key the wallet never held**
+`content.js` fillRowBuy/detectLoop/requote/healStandInPositions ·
+`quote.js` tokenFromPayload · Axiom Pulse "Final Stretch" list rows (jb
+2026-08-17: "buy via final stretch, hold until bond, open from the bonding
+section: the buy does not show") · **fixed v3.13.6** — two holes, one
+identity family (F-51's stand-in stranding at a different lifecycle point):
+
+(1) *Commit-time.* The row-buy cascade ends in the row-feed fallback
+(`mint: address` — an ECHO, not a discovered identity). On a Pulse
+final-stretch row the click address is the PAIR/curve stand-in, so the fill
+keyed the stand-in: right while the page lived, dead the moment the coin
+graduated to a new AMM pool. `fillRowBuy` now probes the click address with
+ONE bounded `onchainPrewatch` when the candidate's mint is missing or the
+echo (`data.mint === address`); a discovered real mint re-keys the candidate
+BEFORE the engine buy. A silent probe keeps the honest legacy keying — the
+fill still books, never refuses.
+
+(2) *Recovery.* Wallets already carrying stand-in-keyed bags (the reported
+case: page closed between buy and graduation, so P0-3's in-context
+swapStash never ran — no loaded token, nothing stashed) heal at reopen:
+`tokenFromPayload` now carries `poolAddresses` (every pool Dexscreener
+lists for the base mint — graduated bonding-era pairs stay listed forever),
+and detectLoop/requote call `healStandInPositions`, which rekeys any OPEN
+position still keyed by one of those pools onto the real mint (via
+`E.rekeyMint`, both-keys merge-safe). An unrelated coin never matches —
+only pools provably listed under THIS base mint can donate their bag.
+Locked by extension/test/strandedbag.test.js (full-life report scenario,
+negative isolation, legacy silent-probe path) — red on pre-fix code.
+
 **F-41 · S1 · One buy drew TWO bubbles, and the average line never appeared — a dead self-write guard duplicated every fill, and a stale-ledger veto quietly relocated the line off-screen**
 `content.js` watchStorage/doBuy/doSellInner · `price-bridge.js`
 vettedMcapClose/paper-lines · fomo.family, maintainer field test ·

--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -1753,6 +1753,63 @@ invisible one. Fixed by adding 'game' to SECTIONS; locked GENERICALLY: every
 nav data-section id must appear in SECTIONS, proven failing against the
 v2.11.0 tag in a temp worktree.
 
+**D-57 · S1 · An armed stop or take-profit was only ever judged on a price CHANGE — a level armed after the last move never fired on a flat or rugging tape**
+`content.js` (handlePageTick, startPriceLoop) · every trader running a stop or
+TP, worst on exactly the coins a stop exists for · confirmed by test
+(`test/orderrace.test.js`, D-57 case) · field class: bloodfortea 2026-08-19
+("buying low selling high doesnt count as profit, i made a minus 12% but should
+have been plus"), the rug reports in #papertrench-reviews, jb 2026-08-19 ·
+**fixed v3.13.9** (the tick path judges armed levels BEFORE the duplicate-price
+early-return, and the 100 ms heartbeat gained the armed-LEVEL watchdog that
+already existed for armed buys; locked by `test/orderrace.test.js`)
+`evaluateChartOrders()` was reachable from exactly one place: the page-tick
+path, *below* `if (token.priceNative === oldNative) return;`. That return is
+correct for what it was written for — a repeat print needs no re-render, no
+mark, no storage write. But the armed SET changes independently of the price,
+and the level is judged nowhere else. Two everyday sequences leave a stop armed
+against a price that already crossed it:
+  - wallet state finishes loading AFTER the first ticks arrive — the common
+    case on a reload, where the tick that could have fired the level ran while
+    `state.orders` was still empty (this is the sequence the regression test
+    reproduces);
+  - the level is dragged onto the chart, or armed by another tab, between two
+    identical prints.
+The tape then has to produce a *different* number before anything asks the
+question — and the books where it does not are precisely the dangerous ones: a
+dead-quiet market, or a rug where every tick repeats one number on the way
+down. The stop sat armed while the position bled out, which reads to the trader
+as "PaperTrench ignored my stop". `triggeredOrders()` is the sole authority on
+whether a level fires and is idempotent, so asking it on a repeat tick and on
+each heartbeat costs one comparison and cannot double-book — it only closes the
+window in which nothing asked at all. The armed-buy watchdog in `startPriceLoop`
+was the existing precedent for the same class of bug (F-16); levels now carry
+the symmetric one. Negative control run both ways: with either half reverted the
+D-57 case fails, restored byte-identical it passes.
+
+**D-58 · S1 · A lost CAS race re-booked an order clip — the re-applied mutation re-checked the position but not whether the order was already spent (jb's +9.109 equity, second mechanism)**
+`content.js` fireChartOrder · anyone with two chart tabs open on the same
+token, which the quick-buy chip makes routine (each tap opens a tab) ·
+confirmed by test (`test/orderrace.test.js`, the CAS-race case, which shipped
+red) · **fixed v3.13.9** (the remutate re-checks the order id is still live
+before re-applying, matching firePendingBuy's precedent; locked by the same
+test)
+`persistStateNow` hands a `remutate` closure the winner's adopted state and
+re-applies this tab's own mutation onto it — the design that stops a heartbeat
+eating a fill. `fireChartOrder`'s closure re-checked `state.positions[mint]`
+and nothing else. When the tab that WON the race had already fired this very
+order, the position is still open (a 50% clip does not close it), so the loser
+re-ran `E.sell` on the winner's base and booked the clip a second time: cash
+credited twice, the round's `returnedSol` double-counting, paper equity
+inflated by a whole extra set of clip proceeds. `firePendingBuy` already
+re-checked that its armed buy still existed before re-applying; the order fire
+did not. The order id is the thing that must still be live, and `E.removeOrder`
+in the same mutation is what makes the check meaningful on the retry. Note this
+is a SECOND, independent mechanism behind jb's 8/18 "+9.109 SOL where it should
+be +0.091" report — D-56 (the starting-balance anchor) was the first, and both
+were live at once, which is why the number reproduced so exactly. Negative
+control: reverting the id check alone reproduces 2 clips in the race case and 5
+in the control.
+
 **D-56 · S1 · Legacy wallets anchor on the LIVE "Starting paper balance" setting — editing the form retroactively rewrote the session (jb's 100× equity report)**
 `engine.js` (anchorStartSol, defaultState), `content.js`, `dashboard.js`, `popup.js`, `overlay.js`, `background.js` (bridge replay) · wallets born before v3.9.5 (the D-06 birth snapshot) · jb report 2026-08-18: "after a full exit, paper equity showed +9.109 SOL where it should show +0.091 SOL — exactly 100×" · **fixed v3.13.8** (journal-derived birth-anchor backfill: `derivedBirthSol`/`backfillAnchor` in engine.js, `anchorFor`/`derivedAnchor` in popup+overlay, `derivedBirthAnchor` in the worker; locked by `test/d06_backfill.test.js`)
 D-06 (v3.9.5) froze the birth balance onto `state.startSol` — but only for

--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -1753,6 +1753,47 @@ invisible one. Fixed by adding 'game' to SECTIONS; locked GENERICALLY: every
 nav data-section id must appear in SECTIONS, proven failing against the
 v2.11.0 tag in a temp worktree.
 
+**D-60 · S1 · One throttled RPC read left a brand-new coin on "Fetching live price…" — buys only became possible once the coin aged 20-30 seconds**
+`content.js` (prewatchPending, detectLoop, acquireClickQuote)
+
+newws300, 2026-08-24: *"i just downloaded the extension and i cant buy any
+coins its just saying fetching live price 100% of the time … can only buy
+once coin has aged like 20-30 seconds."* Also cheng.4848 on migrated coins,
+and a duplicate report in #general.
+
+`prewatchPending` latched `prewatchedAddress = candidate.address` BEFORE
+awaiting the chain probe, and the failure paths — an empty answer, and a
+`.catch(() => {})` — both left that latch set. The latch is the dedup that
+stops the 800ms detect loop re-probing the same address, so a single failed
+read disabled the one source that can price a coin younger than every
+aggregator. The probe fails for reasons that have nothing to do with the
+coin: a throttled public RPC, a dropped socket, a slot the endpoint has not
+caught up to.
+
+A slow safety net existed (`pendingAttempts % 5` on the 800ms loop) which is
+why coins recovered *eventually* rather than never — and its cadence IS the
+reported number: a retry only every ~4s, first firing on the 5th attempt,
+plus the aggregator wait behind it.
+
+Three changes, one rule — **a failed READ is never evidence about the coin**:
+1. both failure paths release the latch instead of holding it;
+2. the detect loop retries on the very next pass when the last probe failed
+   (`probeFailed || pendingAttempts % 5 === 0`), keeping the slow net only
+   for a probe still outstanding;
+3. `acquireClickQuote` no longer additionally requires `token.pending` before
+   asking the chain — the guarding condition is already the stronger fact
+   (no source priced THIS click), so a token whose pending flag was cleared
+   without a live price could never reach the chain at all.
+
+Measured in the harness: recovery after a transient failure went from
+**2000ms to 400ms** (one detect pass). Test asserts the timing, not the call
+count — the harness re-navigates, so counting probes passes by accident.
+
+**fixed v3.13.11** (`test/freshlaunch.test.js` — "a failed chain probe does
+not permanently strand the coin" drives the real detect loop and fails at
+2000ms when the prompt cadence is reverted; "the click asks the chain
+whenever no source priced it" fails when the `token.pending` gate returns)
+
 **D-59 · S1 · A graduated (migrated) coin had NO on-chain price — the panel sat on "Fetching live price…" through the whole post-migration window**
 `onchain-feed.js` (prewatch, findGraduatedPool), `onchain.js` (decodePumpSwapPool)
 

--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -430,6 +430,50 @@ extension/test/rowfillaccuracy.test.js (identity lookups, cap rescale on
 both override sites, first-buy witness wiring, refusal voice, ancient-print
 exemption).
 
+**F-60 · S3 · The quick-buy chip could pin itself on top of the MC — once painted, its own body shadowed the collision probe and the overlap became undetectable**
+`price-bridge.js` rowAnchorHitsContent/scanScreenerRows · all screener-row
+sites, worst on ultra/compact terminal formats · found by audit of the F-53
+fix while verifying jb's 2026-08-18 report ("quick buy button is on top of
+the mc on terminal if ur format is ultra") · **fixed v3.13.6** (the probe
+reads the elementsFromPoint STACK and looks through its own chip)
+F-53 (v3.6.0) taught the sweep to probe the float anchor before painting:
+elementFromPoint at the chip-body midpoint, drop to the bottom-right gutter
+when the hit is row content. But `.pt-rowbuy` chips are CLICKABLE
+(pointer-events:auto, only the LAYER is pointer-events:none), so the moment
+a chip is painted at the float anchor its own body tops that hit-test:
+`hit === entry.el` → "clean", forever. Anything that moved the MC under an
+ALREADY-painted chip — a live normal→ultra format switch (no reload, React
+recycles the row nodes in place), a late-mounting MC cell losing the mount
+race, a row recycle re-rendering denser content — re-created jb's exact
+symptom, and the F-53 probe was structurally blind to it: in pill mode the
+probe point is the dead centre of the painted chip. The probe now reads the
+hit-test stack (document.elementsFromPoint) and skips every chip-owned
+entry (its own body, its descendants, sibling chips marked
+data-pt-row-chip); the first REAL element beneath decides, same
+inside-the-row / pill-overlap rules as before. READ-phase only, no style
+writes; engines without elementsFromPoint keep the legacy top-hit read
+(documented degradation, never wedges the sweep). Locked by
+extension/test/rowchipcollision.test.js: painted-chip-over-MC must read
+collision, chip-over-gutter must stay clean, legacy single-hit fallback,
+and a source contract pinning the stack read + no style writes.
+
+**F-53 · S3 · The quick-buy chip painted on top of the row's MC in ultra terminal format** *(retroactive entry — shipped in v3.6.0 without a ledger record; registered while auditing F-60)*
+`price-bridge.js` positionRowChip/scanScreenerRows · all screener-row sites
+(ultra/compact formats, Padre's pill row) · field report 2026-08-18
+(Discord #bug-reports, jb: "quick buy button is on top of the mc on
+terminal if ur format is ultra") · **fixed v3.6.0** (anchor probe + gutter
+fallback + placement setting)
+Dense formats leave no gutter at the row's top-right, so the float-anchored
+chip landed on the MC column. The sweep now probes the anchor before
+painting (elementFromPoint at the chip-body midpoint — the chip extends
+LEFT of its anchor, so the anchor point alone cleared while the body still
+covered content) and drops to the bottom-right gutter on a content hit;
+per-site defaults (`listQuickBuyPlacement`) and an explicit user setting
+(Quick-buy chip placement → Bottom-right / Auto) pin it. Probe blind spot
+once the chip itself is painted → F-60. Locked by
+extension/test/rowchipcollision.test.js (probe decisions, gutter fallback,
+placementPref plumbing, both anchor modes consult the probe).
+
 **F-41 · S1 · One buy drew TWO bubbles, and the average line never appeared — a dead self-write guard duplicated every fill, and a stale-ledger veto quietly relocated the line off-screen**
 `content.js` watchStorage/doBuy/doSellInner · `price-bridge.js`
 vettedMcapClose/paper-lines · fomo.family, maintainer field test ·

--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -1753,6 +1753,28 @@ invisible one. Fixed by adding 'game' to SECTIONS; locked GENERICALLY: every
 nav data-section id must appear in SECTIONS, proven failing against the
 v2.11.0 tag in a temp worktree.
 
+**D-56 · S1 · Legacy wallets anchor on the LIVE "Starting paper balance" setting — editing the form retroactively rewrote the session (jb's 100× equity report)**
+`engine.js` (anchorStartSol, defaultState), `content.js`, `dashboard.js`, `popup.js`, `overlay.js`, `background.js` (bridge replay) · wallets born before v3.9.5 (the D-06 birth snapshot) · jb report 2026-08-18: "after a full exit, paper equity showed +9.109 SOL where it should show +0.091 SOL — exactly 100×" · **fixed v3.13.8** (journal-derived birth-anchor backfill: `derivedBirthSol`/`backfillAnchor` in engine.js, `anchorFor`/`derivedAnchor` in popup+overlay, `derivedBirthAnchor` in the worker; locked by `test/d06_backfill.test.js`)
+D-06 (v3.9.5) froze the birth balance onto `state.startSol` — but only for
+wallets BORN AFTER the fix. Every pre-v3.9.5 wallet (jb's 8/18 wallet, and
+every community wallet that existed on 8/21) kept falling through
+`anchorStartSol` to the LIVE setting: edit "Starting paper balance" 10 → 1
+and the whole session re-denominates overnight. jb's exact numbers: born 10,
+real profit +0.091 SOL → equity 10.091; vs-start = 10.091 − **1** = +9.109
+instead of 10.091 − 10 = +0.091 — the 10→1 gap reads as "exactly 100×" on a
+1-SOL round. The derivation is the wallet's own fill arithmetic (the same
+identity equityCurvePoints uses):
+`birth = equity − open P&L − Σ steps`, a BUY steps −(its fee) and a SELL
+steps +(its per-sell pnlSol). It is stable across marks AND concurrent
+fills (proven in tests), so the one-time backfill on first load can race a
+heartbeat and still land the same value; `anchorStartSol` gains the derived
+middle layer (snapshot → derived → setting) so the correct number shows even
+before the persistence lands, and the self-contained surfaces (popup,
+overlay, worker bridge) carry local copies of the rule since none of them
+load engine.js. Conservative: empty journal or dust equity defers to the
+setting, and a wallet born via popup reset now snapshots `startSol` too
+(popup's local `freshState` had the same hole).
+
 **D-54 · S2 · The graduation thesis criterion could never pass — coverage counted only legacy STRING theses while the engine stores objects**
 `mastery.js` thesisCoverage · dashboard graduation bar, all users ·
 found building the gamification rank ladder on top of the criterion

--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -1753,6 +1753,63 @@ invisible one. Fixed by adding 'game' to SECTIONS; locked GENERICALLY: every
 nav data-section id must appear in SECTIONS, proven failing against the
 v2.11.0 tag in a temp worktree.
 
+**D-59 · S1 · A graduated (migrated) coin had NO on-chain price — the panel sat on "Fetching live price…" through the whole post-migration window**
+`onchain-feed.js` (prewatch, findGraduatedPool), `onchain.js` (decodePumpSwapPool)
+
+Reported independently by two users on 2026-08-24. cheng.4848: *"it is
+difficult to make purchases in time after the currency migration."*
+ark_trades13: *"the 'Fetching live price…' thing happens to me too, but only
+on migrated tokens."* Both are the same defect.
+
+A pump.fun bonding curve sets `complete: true` at graduation and stops
+carrying a price — that is what graduation means, and `prewatchPool` correctly
+refuses it (`// migrated: the resolver path owns it`). But the resolver path
+it handed off to only ever read the **mint account**, which yields identity
+and supply and no price at all. Nothing ever looked for the pool the coin had
+just migrated *into*. So on-chain pricing was silently unavailable for exactly
+the minutes after migration — the most tradable window a memecoin has — and
+the panel waited on an aggregator to index the new pool.
+
+The coin was never unpriceable. It had migrated into a PumpSwap AMM pool
+(program `pAMMBay6…`), which `poolKindForOwner` **already** classifies as
+`cp-vaults`: a pool kind PaperTrench already watches, decodes and prices. The
+lookup simply did not exist.
+
+Fix: `findGraduatedPool()` asks the chain which pool holds the mint —
+`getProgramAccounts` on the PumpSwap program with an indexed memcmp on the
+base-mint offset — rather than guessing a PDA whose seeds (creator, index) we
+do not know. It is wired into both paths that could dead-end: the
+`pump`-suffixed branch after the curve refuses, and the mint-facts branch
+(which is how non-`pump` launchpads — Bags, Believe, moonshot — arrive).
+
+Honesty guards, each with a test: only a **WSOL-quoted** pool is adopted (the
+feed prices in SOL end to end; a USDC-quoted pool decodes perfectly and means
+a different number), only a pool owned by a **verified** program is adopted,
+and where several qualify the **deepest** wins — a dust pool quotes a price
+nobody can fill against. No pool on chain still means no price, never an
+invented one.
+
+Layout verified against live mainnet, not a spec: pool account 301 bytes,
+base mint @43, quote mint @75, base vault @139, quote vault @171. The base
+vault is frequently Token-2022 (170 bytes) where the quote vault is classic
+SPL (165) — `decodeTokenAccount`'s shared prefix reads both, and assuming 165
+everywhere would drop the base leg and the price with it.
+
+Proof: driving the real `FEED.prewatch()` against live mainnet, 4/4 freshly
+migrated coins now return a price with the pool address matching pump.fun's
+own `pump_swap_pool` field exactly (~2s). With both hooks removed, the same
+4/4 return no price — the pre-fix behaviour users reported. A separate
+9/9 pool-match run confirmed the discovery before the public RPC throttled.
+Fixtures in `test/migratedprice.test.js` are real captured mainnet bytes, so
+the production decoders run against production data.
+
+**fixed v3.13.10** (`findGraduatedPool` in onchain-feed.js asks the chain via
+an indexed memcmp on the PumpSwap base-mint offset and is wired into both
+dead-end paths; `decodePumpSwapPool` + verified offsets in onchain.js, layout
+transcript in `docs/POOL-LAYOUTS.md`; locked by `test/migratedprice.test.js`,
+whose WSOL, verified-owner and pool-depth guards each fail when the
+corresponding check is removed)
+
 **D-57 · S1 · An armed stop or take-profit was only ever judged on a price CHANGE — a level armed after the last move never fired on a flat or rugging tape**
 `content.js` (handlePageTick, startPriceLoop) · every trader running a stop or
 TP, worst on exactly the coins a stop exists for · confirmed by test

--- a/docs/POOL-LAYOUTS.md
+++ b/docs/POOL-LAYOUTS.md
@@ -1,0 +1,84 @@
+# Verified on-chain pool layouts
+
+Every offset in `onchain.js` is verified against **live mainnet accounts**,
+not against a published spec or an IDL we downloaded. A spec can be stale, a
+field can be reordered by an upgrade, and a decoder that is subtly wrong does
+not throw — it produces a plausible price. That is the one failure mode this
+product must never have, so the rule is: read a real account, prove the fields
+land where we claim, and record the transcript here.
+
+If you add a pool kind, add its transcript here in the same shape.
+
+---
+
+## PumpSwap AMM (`pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA`)
+
+Where a pump.fun coin lives **after** it graduates. Classified `cp-vaults`
+(constant product, priced from the two vault balances).
+
+| Field | Offset | Type |
+|---|---|---|
+| base mint | 43 | pubkey (32) |
+| quote mint | 75 | pubkey (32) |
+| base vault | 139 | pubkey (32) |
+| quote vault | 171 | pubkey (32) |
+
+Account size: **301 bytes**.
+
+### Transcript — 2026-08-25
+
+Coin `vH6HyoNGaWvKHsK1ENNCqFuZhLfR1cpw46TFeGVpump` ("中国石化"), which
+pump.fun's own API reports as `pump_swap_pool: 7vEpDRUy5PSiBJNdBiiuMxN7KbM7HA3fxhFvgrjRrEnV`.
+
+Scanning the pool account for known pubkeys:
+
+```
+owner  pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA   kind cp-vaults   len 301
+  base mint @ 43
+  WSOL mint @ 75
+  VAULT     @ 171   C991coUv   mint=So111111   amt=304518464111
+```
+
+Reading both vault accounts directly:
+
+```
+@139  owner TokenzQdBNbL  len 170  mint vH6HyoNGaW  amt 54631512811375
+@171  owner TokenkegQfeZ  len 165  mint So11111111  amt 304836266120
+```
+
+**Note the vault programs differ.** The base vault is Token-2022
+(`TokenzQdBNbL…`, 170 bytes); the quote vault is classic SPL
+(`TokenkegQfeZ…`, 165 bytes). Both share the prefix `decodeTokenAccount`
+reads (mint @0, amount @64), which is why one decoder serves both. Code that
+assumed a 165-byte account would drop the base leg — and with it the price.
+
+### Discovery
+
+The pool address is **not** derived. Its PDA seeds include the creator and a
+pool index we do not know, so the lookup asks the chain instead:
+
+```js
+getProgramAccounts(PUMP_AMM_PROGRAM, {
+  filters: [{ memcmp: { offset: 43, bytes: mint } }],
+})
+```
+
+An indexed memcmp on a single program — cheap enough to run on a click.
+
+Validated across live migrated coins (2026-08-25): **9/9 discovered pools
+matched pump.fun's reported `pump_swap_pool` exactly** before the public RPC
+throttled the run, and driving the real `FEED.prewatch()` priced **4/4**
+freshly migrated coins in ~2s each. See DEFECTS.md D-59.
+
+Some RPC providers answer `getProgramAccounts` with the payload stripped
+(`data: null`), so the discovered addresses are always re-read with
+`getMultipleAccounts` rather than trusting the gPA response shape.
+
+---
+
+## Others
+
+`whirlpool` (Orca), `clmm` (Raydium CLMM), `cp-vaults` (Raydium CP / CPMM)
+and `pump-curve` (pump.fun bonding curve) offsets live in `onchain.js` with
+their own inline notes. The bonding curve prices on **virtual** reserves —
+never treat a curve's vault balances as a constant-product pool.

--- a/extension/background.js
+++ b/extension/background.js
@@ -3322,6 +3322,54 @@ function senderOnBridgeOrigin(sender) {
 }
 
 /**
+ * D-56: the birth balance re-derived from the fill journal alone — the
+ * anchor for LEGACY wallets created before D-06's state.startSol snapshot
+ * (v3.9.5). Same identity as engine.derivedBirthSol (the service worker
+ * doesn't load engine.js, so the rule is inlined here and the test suite
+ * pins both to the same fixture):
+ *
+ *   equity = birth + Σ per-fill steps + open P&L
+ *   birth  = equity − open P&L − Σ steps
+ *
+ * where a BUY steps −(its fee: the cash that became cost basis) and a SELL
+ * steps +(its per-sell pnlSol: net proceeds − cost share). Returns 0 when
+ * the journal can't support the derivation (empty or non-finite) — 0 means
+ * "no derived anchor", deferring to the setting fallback.
+ */
+function derivedBirthAnchor(state) {
+  if (!state || typeof state !== 'object') return 0;
+  const journal = ((state.journal) || [])
+    .slice().sort((a, b) => (Number(a.ts) || 0) - (Number(b.ts) || 0));
+  if (!journal.length) return 0;
+  let openValue = 0;
+  let openPnl = 0;
+  for (const p of Object.values(state.positions || {})) {
+    const qty = Number(p && p.qty) || 0;
+    const px = Number(p && p.lastPriceNative) || 0;
+    if (qty <= 0) continue;
+    openValue += qty * px;
+    openPnl += qty * px - (Number(p.costSol) || 0);
+  }
+  const equity = (Number(state.cashSol) || 0) + openValue;
+  let walked = 0;
+  for (const t of journal) {
+    if (t.side === 'buy') {
+      const feeRaw = Number(t.feeSol);
+      const fee = Number.isFinite(feeRaw) && feeRaw >= 0
+        ? feeRaw
+        : (Number.isFinite(Number(t.solNet))
+          ? Math.max(0, (Number(t.solGross) || 0) - Number(t.solNet))
+          : 0);
+      walked -= fee;
+    } else if (t.side === 'sell') {
+      walked += Number(t.pnlSol) || 0;
+    }
+  }
+  const derived = equity - openPnl - walked;
+  return Number.isFinite(derived) ? derived : 0;
+}
+
+/**
  * The wallet summary the site header shows: cash, equity, open positions.
  *
  * Deliberately NOT a chain replay. bridgeRecord exists to hand over evidence
@@ -3367,10 +3415,19 @@ async function bridgeRecord() {
   // never disagree with the number the trader sees. (engine.js isn't loaded
   // in the service worker, so the anchor rule is inlined: birth snapshot
   // first, live setting only as a legacy fallback.)
+  // D-56: legacy wallets (pre-v3.9.5) never got the birth snapshot, so the
+  // raw setting fallback welded their replay denominator to the live form.
+  // Re-derive the birth from the journal (same identity as
+  // engine.derivedBirthSol: equity − open P&L − Σ per-fill steps) and trust
+  // it before the setting. The derivation is stable across fills, so the
+  // bridge and the local display agree even before a tab persists the
+  // backfill.
   const state = (await getState()) || {};
   const start = (Number(state.startSol) || 0) > 0
     ? Number(state.startSol)
-    : (Number(settings.balanceStartSol) || 0);
+    : (derivedBirthAnchor(state) > 0
+      ? derivedBirthAnchor(state)
+      : (Number(settings.balanceStartSol) || 0));
   // The claim mirrors the chain-derived replay on purpose: the server ranks
   // on its own replay anyway, and a bridge claim that disagreed with the
   // chain would only flag honest users whose local display drifted.

--- a/extension/content.js
+++ b/extension/content.js
@@ -1058,6 +1058,19 @@
           if (stash.fromMint !== data.mint) rekeyLiveState(stash.fromMint, data.mint);
         }
       }
+      // F-61 backstop: heal stand-in-keyed bags at the graduation boundary.
+      // A Pulse row buy that never resolved (row-feed fallback) commits under
+      // the click address — the PAIR stand-in on Axiom. When the coin bonds,
+      // the migration pool gets a NEW pair address; reopening the coin (from
+      // the bonded listing or any pool URL) resolves the REAL mint, a key this
+      // wallet never held: the card renders empty (jb, 8/17). Unlike the
+      // in-context stash bridge above, nothing links the two sessions. The
+      // resolver's own payload carries the proof for free: Dexscreener lists
+      // EVERY pool for the base mint — including the graduated bonding-era
+      // pair — so a position whose key appears among the pool list is the
+      // same coin under its old stand-in. Deterministic identity proof, one
+      // rekey, no network added.
+      healStandInPositions(data);
       // Rug verdicts read Solana holder state — a foreign chain has no
       // verdict, and the guard stays silent rather than pretending.
       if (!data.chain || data.chain === 'solana') refreshRugVerdict(data.mint);
@@ -1145,6 +1158,24 @@
    * the storage write rides the serialized CAS commit, re-applying itself on
    * contention like every other mutation (F-46).
    */
+  /**
+   * F-61: heal bags stranded under a stand-in key at the graduation boundary.
+   * `tokenRecord` is a resolver record carrying `poolAddresses` — every pool
+   * listed for the base mint. Any OPEN position keyed by one of those pool
+   * addresses (but not the mint itself) is the same coin bought under its
+   * bonding-era pair stand-in; rekey it onto the real mint so the card, the
+   * bar chip, and the batch quote poller all see one bag under one key.
+   * Idempotent; a no-op when no position matches.
+   */
+  function healStandInPositions(tokenRecord) {
+    if (!tokenRecord || !tokenRecord.mint || !Array.isArray(tokenRecord.poolAddresses)) return;
+    if (!state.positions) return;
+    const stranded = Object.keys(state.positions).filter(
+      (k) => k !== tokenRecord.mint && tokenRecord.poolAddresses.indexOf(k) !== -1
+    );
+    for (const standIn of stranded) rekeyLiveState(standIn, tokenRecord.mint);
+  }
+
   function rekeyLiveState(oldMint, newMint) {
     if (!oldMint || !newMint || oldMint === newMint) return;
     const cached = livePositionPrices[oldMint];
@@ -1375,6 +1406,14 @@
       if (!token || token.mint !== forMint) return;
       if (!fresh || !(fresh.priceNative > 0)) return;
       if (fresh.mint && fresh.mint !== token.mint) return;
+      // F-61: a refresh re-quotes /tokens/<mint> — EVERY pool for this base
+      // mint, including graduated bonding-era pairs. An initial resolve via
+      // /pairs/<addr> carried only that one pool; adopt the full list so the
+      // graduation backstop can see a stand-in-held bag.
+      if (Array.isArray(fresh.poolAddresses)) {
+        token.poolAddresses = fresh.poolAddresses;
+        healStandInPositions(token);
+      }
 
       // The resolver quote becomes the new anchor immediately. Live ticks
       // validate against this, so the anchor never lags behind real moves.
@@ -6591,6 +6630,25 @@
     // since moved past (entry MC 6k on a coin printing 20k). The row's own
     // print is the anchor instead (see rowPrintVouchesFirstBuy).
     if (!(await rowPrintVouchesFirstBuy(address, data, posAnchor))) return null;
+    // F-61: a row-fed candidate carries NO mint — the row feed keys its
+    // ticks by whatever the board prints (on Axiom Pulse that is the PAIR
+    // stand-in; F-59 saw the same keying). Committing under that key strands
+    // the bag at the graduation boundary: the coin bonds, the page reopens
+    // under the migration pool, and the resolver hands back the REAL mint —
+    // a key the wallet never held (jb, 8/17: "buy via final stretch, hold
+    // until bond, open from the bonding section: the buy does not show").
+    // The chain classifies the click address the same way prewatch does —
+    // one bounded read, never blocking the fill: a miss keeps the row's own
+    // address as the key, exactly the honest legacy behavior.
+    if (address && (!data.mint || data.mint === address)) {
+      try {
+        const found = await R.onchainPrewatch({ mint: address, pool: address }).catch(() => null);
+        if (found && found.mint && found.mint !== data.mint) {
+          data.mint = found.mint;
+          if (!data.pairAddress && found.pool) data.pairAddress = found.pool;
+        }
+      } catch (_) { /* identity stays the row's own key */ }
+    }
     // Guardrails apply to chip buys exactly like panel buys.
     const guard = E.guardCheck(state, settings, { solAmount: amount });
     if (!guard.ok) { toast(guard.message); return null; }

--- a/extension/content.js
+++ b/extension/content.js
@@ -2057,6 +2057,12 @@
     // already the correct value for that case, so never fabricate over a
     // state this session has since populated.
     if (stored[E.STORAGE_KEYS.state]) state = stored[E.STORAGE_KEYS.state];
+    // D-56: first load of a LEGACY wallet (born before D-06's startSol
+    // snapshot) re-derives its birth balance from the journal and freezes it
+    // onto state. The in-memory write lands in storage with the next
+    // heartbeat CAS — the derivation is stable across concurrent fills, so
+    // no dedicated writer is needed here. Idempotent once startSol exists.
+    E.backfillAnchor(state, settings);
   }
 
   /**
@@ -2067,6 +2073,11 @@
   function adoptState(next) {
     const hadPosition = Boolean(token && state.positions && state.positions[token.mint]);
     state = next;
+    // D-56: a state adopted from another writer (storage listener, CAS
+    // contention) may be the first sighting of a legacy wallet — anchor it
+    // before the re-render below, so the vs-start figures read the derived
+    // birth instead of the live setting on this very paint.
+    E.backfillAnchor(state, settings);
     const hasPosition = Boolean(token && state.positions && state.positions[token.mint]);
     // The card's structure only changes when a position appears or vanishes.
     if (hadPosition !== hasPosition) posEls = null;

--- a/extension/content.js
+++ b/extension/content.js
@@ -875,7 +875,19 @@
       ? { pool: candidate.address }
       : { mint: candidate.address };
     R.onchainPrewatch(ids).then((found) => {
-      if (!found || !found.mint) return;
+      // D-60: a probe that answered NOTHING must not latch. The chain read
+      // can fail for reasons that have nothing to do with this coin — a
+      // throttled public RPC, a dropped socket, a slot the endpoint had not
+      // caught up to. Leaving prewatchedAddress set meant that single blip
+      // permanently disabled the one path that prices a brand-new launch,
+      // and the coin then waited on an aggregator to index it: the
+      // "'Fetching live price' 100% of the time, can only buy once the coin
+      // has aged 20-30 seconds" report. Releasing the latch lets the detect
+      // loop probe again on its next pass.
+      if (!found || !found.mint) {
+        if (prewatchedAddress === candidate.address) prewatchedAddress = null;
+        return;
+      }
       if (!token || !token.pending) return;
       if (token.srcAddress !== candidate.address && token.mint !== candidate.address) return;
 
@@ -930,7 +942,12 @@
           candidates: [{ value: Number(found.priceNative), unit: 'native' }],
         });
       }
-    }).catch(() => {});
+    }).catch(() => {
+      // Same rule as the empty answer above: a thrown probe is a failure of
+      // the READ, never proof about the coin. Release the latch so the next
+      // detect pass can try again instead of stranding the token.
+      if (prewatchedAddress === candidate.address) prewatchedAddress = null;
+    });
   }
 
   async function detectLoop() {
@@ -1024,7 +1041,16 @@
         // aggregators — the exact window prewatch exists for. Re-probe on a
         // slow cadence while still unresolved; the address dedup makes each
         // retry one RPC read, and it stops the moment anything resolves.
-        if (token && token.pending && pendingAttempts % 5 === 0
+        // D-60: two cadences, not one. If the last probe FAILED it released
+        // the latch (prewatchedAddress === null), and there is no reason to
+        // wait — retry on this very pass, because the failure was about the
+        // read, not the coin. Only when a probe is still outstanding or
+        // already answered do we fall back to the slow every-5th-attempt
+        // net. Waiting ~4s to re-ask after a throttled RPC is what left
+        // fresh coins on "Fetching live price" for 20-30 seconds.
+        const probeFailed = prewatchedAddress === null;
+        if (token && token.pending
+          && (probeFailed || pendingAttempts % 5 === 0)
           && (!candidate.chain || candidate.chain === 'solana')) {
           prewatchedAddress = null;
           prewatchPending(candidate);
@@ -2998,11 +3024,20 @@
     if (!data || !(Number(data.priceNative) > 0)) {
       data = await R.resolve(addr, { maxAgeMs: 0, chain });
     }
-    if ((!data || !(Number(data.priceNative) > 0)) && token && token.pending) {
+    if (!data || !(Number(data.priceNative) > 0)) {
       // D-38: the aggregators and venue APIs still do not know a one-second-
       // old coin, but its pool / bonding curve is ALREADY on chain. Probe it
       // directly (prewatch does exactly this for the panel at detection) so
       // the buy never waits on an indexer. Price is chain state.
+      //
+      // D-60: this used to also require `token.pending`. That flag means "the
+      // panel has never had a price", but the condition guarding this block
+      // is already the stronger, more direct fact: no source produced a
+      // usable price for THIS click. A token whose pending flag had been
+      // cleared without a live price — a resolver answering with identity
+      // but no number, a coin whose feed went quiet — could therefore never
+      // reach the chain at all, which is the one source that always knows.
+      // The chain is the authority on price; asking it is never wrong here.
       let found = await R.onchainPrewatch({ pool: addr }).catch(() => null);
       if (!found || !(Number(found.priceNative) > 0)) {
         found = await R.onchainPrewatch({ mint: addr }).catch(() => null);

--- a/extension/content.js
+++ b/extension/content.js
@@ -770,6 +770,25 @@
       persistSoon();
     }
     flushArmedBuy();
+    // Armed levels are judged against THIS observed price — the honest fill
+    // rule depends on it being the tick that first crossed the level, so this
+    // sits in the tick path and nowhere else.
+    //
+    // D-57: this MUST run before the duplicate-price early-return below. The
+    // armed SET changes independently of the price: a stop dragged onto the
+    // chart, an order restored when wallet state finished loading, or a level
+    // added from another tab all arm against a price the feed has already
+    // printed. Gating the evaluation on "the price moved" meant a level armed
+    // after the last move waited for the NEXT distinct price to be judged —
+    // and a feed printing a flat quote (a dead-quiet book, a rug where every
+    // tick repeats the same number) never produces one. The stop sat armed
+    // while the position bled out. triggeredOrders() is the only thing that
+    // decides a fire, and it is idempotent, so running it on a repeat tick
+    // costs one comparison and cannot double-book.
+    evaluateChartOrders();
+    // N2: armed limit buys fire on the SAME tick path, same honest-fill rule.
+    evaluatePendingBuys();
+
     // A duplicate tick still proves the feed is alive, but it does not need a
     // position mark, storage write, or DOM render.
     if (token.priceNative === oldNative) return;
@@ -782,12 +801,6 @@
     // maybeRepostAverageLines) — a spec frozen at fill time made mcap lines
     // ride the candle at ratio ≈ 1 instead of holding the entry level.
     maybeRepostAverageLines();
-    // Armed levels are judged against THIS observed price — the honest fill
-    // rule depends on it being the tick that first crossed the level, so this
-    // sits in the tick path and nowhere else.
-    evaluateChartOrders();
-    // N2: armed limit buys fire on the SAME tick path, same honest-fill rule.
-    evaluatePendingBuys();
     // The token ON SCREEN is excluded from the batch poller (its price comes
     // from the page's own feed), so its alerts are judged here — otherwise
     // the one chart you are actually watching is the one that never pings.
@@ -1374,6 +1387,24 @@
           renderBuyButton();
           toast('Armed buy expired — no fillable quote arrived in time');
         }
+      }
+      // D-57: the same watchdog, for armed LEVELS. evaluateChartOrders() only
+      // ran from the page-tick path, so an order that became armed while the
+      // price stood still was never judged against a price already on screen.
+      // Two ways that happens in the field, both reported as "my stop/TP
+      // never fired":
+      //   - wallet state finishes loading AFTER the first ticks arrive (the
+      //     common one on a reload — the tick that could have fired the level
+      //     ran while state.orders was still empty);
+      //   - the level is armed from the chart, or by another tab, between two
+      //     identical prints on a quiet or rugging book.
+      // Both leave a level armed against a price that already crossed it.
+      // triggeredOrders() decides every fire and is idempotent, so re-asking
+      // each beat cannot double-book — it only closes the window where
+      // nothing asked at all.
+      if (token && Number(token.priceNative) > 0) {
+        evaluateChartOrders();
+        evaluatePendingBuys();
       }
       renderHeader();
       renderPosition();
@@ -2481,6 +2512,16 @@
         const mutate = () => {
           filled = null;
           if (!state.positions[mint]) return;
+          // D-58 / jb 2026-08-18: the position is NOT enough to decide this
+          // is still ours to fire. A lost CAS race re-runs this mutation on
+          // the winner's adopted state — and if the winning context already
+          // spent this very order, re-applying the sell books the clip a
+          // SECOND time: cash credited twice, the round's returnedSol
+          // double-counts, paper equity inflates by a whole extra set of clip
+          // proceeds (jb: +0.091 true, +9.109 shown). The order id is the
+          // thing that must still be live, exactly as firePendingBuy
+          // re-checks its armed buy still exists before re-applying.
+          if (!E.ordersFor(state, mint).some((o) => o.id === order.id)) return;
           filled = E.sell(state, settings, {
             ts: Date.now(), mint, site: site && site.id,
             qtyFraction: order.sizePct / 100,

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -543,6 +543,17 @@ async function loadAll(changedKeys) {
   renderStorageErrorBanner();
   settings = E.mergeSettings(s.pt_settings);
   state = s.pt_state || E.defaultState(settings);
+  // D-56: first sighting of a LEGACY wallet (born before D-06's startSol
+  // snapshot): re-derive the birth balance from the journal and freeze it
+  // onto state. The in-memory anchor fixes THIS render; the CAS persist
+  // lands it in storage so no later reader sees the setting fallback again.
+  // The derivation is stable across concurrent fills (it is the wallet's
+  // own fill arithmetic), so a race re-derives the same value — and
+  // backfillAnchor is a no-op once startSol exists.
+  const anchored = E.backfillAnchor(state, settings);
+  if (anchored) {
+    mutateState((fresh) => { E.backfillAnchor(fresh, settings); }).catch(() => {});
+  }
   if (wantFrames) frames = s.pt_frames || [];
   turboStats = s.pt_turbo_stats || {};
   // The perps book is revision-wrapped by its content script ({rev, state}).

--- a/extension/engine.js
+++ b/extension/engine.js
@@ -913,6 +913,34 @@
    * a single dropped fill is far above it. */
   const CURVE_ANCHOR_EPS = 1e-6;
 
+  /**
+   * D-56: the per-fill equity step, in SOL.
+   *
+   * The ONE definition of "what this fill did to equity" — shared by the
+   * curve walk (equityCurvePoints) and the birth backfill (derivedBirthSol)
+   * so the two can never drift apart. A BUY debits its fee: the cash that
+   * left the wallet to buy it was solGross, only solGross − fee became
+   * position cost, and that missing sliver is the fee (feeSol, falling back
+   * to solGross − solNet for fills recorded before the field existed; the
+   * flat tx cost rides costSol, so it stays inside the open-position term
+   * and is never stepped separately). A SELL credits its per-sell pnlSol —
+   * net proceeds minus the position's cost share, so the whole open→closed
+   * transition nets exactly to the banked pnl.
+   */
+  function stepOf(t) {
+    if (t.side === 'buy') {
+      const feeRaw = Number(t.feeSol);
+      const fee = Number.isFinite(feeRaw) && feeRaw >= 0
+        ? feeRaw
+        : (Number.isFinite(Number(t.solNet))
+          ? Math.max(0, (Number(t.solGross) || 0) - Number(t.solNet))
+          : 0);
+      return -fee;
+    }
+    if (t.side === 'sell') return Number(t.pnlSol) || 0;
+    return 0;
+  }
+
   function equitySol(state) {
     let eq = state.cashSol;
     for (const mint of Object.keys(state.positions)) {
@@ -920,6 +948,69 @@
       eq += p.qty * (p.lastPriceNative || 0);
     }
     return eq;
+  }
+
+  /**
+   * D-56: the wallet's BIRTH balance, re-derived from the fill journal alone.
+   *
+   * equityCurvePoints proves the identity: equity = birth + Σ stepOf(fills)
+   * + openPnl, so birth = equity − Σ stepOf − openPnl. That derivation is
+   * the wallet's own arithmetic — it needs no mark that the journal doesn't
+   * already hold (an unmarked bag contributes lastPrice 0, exactly like
+   * bridgeWallet), and it is stable across every writer that only appends
+   * fills or moves marks.
+   *
+   * This is the anchor every legacy wallet (created before D-06's
+   * state.startSol snapshot, v3.9.5) is missing. For those,
+   * anchorStartSol was still reading the LIVE "Starting paper balance"
+   * setting, so editing the form retroactively rewrote the whole session —
+   * jb's 8/18 wallet: born 10, setting edited to 1, +0.091 SOL of real
+   * profit displayed as +9.109 SOL (exactly the 10→1 gap).
+   *
+   * Returns the derived birth, or null when the derivation is not trustworthy
+   * (no fills to derive from, or a non-finite result) — a null never
+   * overwrites the setting fallback, it just defers to it.
+   */
+  function derivedBirthSol(state) {
+    if (!state) return null;
+    const journal = (state.journal || []).slice().sort((a, b) => (Number(a.ts) || 0) - (Number(b.ts) || 0));
+    if (!journal.length) return null;
+    let openPnl = 0;
+    for (const pos of Object.values(state.positions || {})) {
+      if (pos && Number(pos.qty) > 0) openPnl += unrealizedPnl(pos);
+    }
+    let walked = 0;
+    for (const t of journal) walked += stepOf(t);
+    const derived = equitySol(state) - openPnl - walked;
+    if (!Number.isFinite(derived)) return null;
+    return derived;
+  }
+
+  /**
+   * D-56: one-time birth-anchor backfill.
+   *
+   * Freezes the journal-derived birth balance onto state.startSol for wallets
+   * created before D-06 snapshotted it at birth. Idempotent — a state that
+   * already carries a positive startSol is left byte-for-byte untouched —
+   * and conservative: it only writes when the derivation is finite and
+   * clearly positive (well above float dust), so a wallet whose equity
+   * drifted to zero is never anchored on noise, and an empty journal is
+   * never anchored on nothing.
+   *
+   * Callers persist the returned state through their normal CAS writer; the
+   * read-only surfaces (popup/overlay/bridge) that can't write use
+   * anchorStartSol's derived layer directly.
+   *
+   * Returns true when a snapshot was written.
+   */
+  function backfillAnchor(state, settings) {
+    if (!state || typeof state !== 'object') return false;
+    const birth = Number(state.startSol);
+    if (Number.isFinite(birth) && birth > 0) return false; // already anchored
+    const derived = derivedBirthSol(state);
+    if (derived === null || derived <= CURVE_ANCHOR_EPS) return false;
+    state.startSol = derived;
+    return true;
   }
 
   /**
@@ -959,20 +1050,9 @@
     const startedAt = Number(state && state.startedAt)
       || (journal[0] ? Number(journal[0].ts) : Date.now());
 
-    const stepOf = (t) => {
-      if (t.side === 'buy') {
-        const feeRaw = Number(t.feeSol);
-        const fee = Number.isFinite(feeRaw) && feeRaw >= 0
-          ? feeRaw
-          : (Number.isFinite(Number(t.solNet))
-            ? Math.max(0, (Number(t.solGross) || 0) - Number(t.solNet))
-            : 0);
-        return -fee;
-      }
-      if (t.side === 'sell') return Number(t.pnlSol) || 0;
-      return 0;
-    };
-
+    // D-56: the per-fill step is the shared stepOf — the curve and the birth
+    // backfill must walk the journal by the same rule or the two anchors
+    // drift apart.
     let openPnl = 0;
     const positions = (state && state.positions) || {};
     for (const mint of Object.keys(positions)) openPnl += unrealizedPnl(positions[mint]);
@@ -1062,10 +1142,19 @@
    * became "+90%" against 1 — retroactively rewriting history with a
    * settings form. The anchor is frozen at birth; only a wallet reset moves
    * it.
+   *
+   * D-56: the middle layer. Legacy wallets (pre-v3.9.5) never got
+   * state.startSol, so the raw setting fallback kept their % — and their
+   * SOL-vs-start — welded to a live form. When the journal can re-derive
+   * the birth balance (derivedBirthSol), trust THAT before the setting.
+   * backfillAnchor() persists the derived value onto state.startSol so this
+   * layer is only ever needed on the first read after an update.
    */
   function anchorStartSol(state, settings) {
     const birth = Number(state && state.startSol);
     if (Number.isFinite(birth) && birth > 0) return birth;
+    const derived = derivedBirthSol(state);
+    if (derived !== null && derived > CURVE_ANCHOR_EPS) return derived;
     const setting = Number(settings && settings.balanceStartSol);
     return Number.isFinite(setting) && setting > 0 ? setting : 0;
   }
@@ -2193,6 +2282,9 @@
     unrealizedPnl,
     equitySol,
     equityCurvePoints,
+    stepOf,
+    derivedBirthSol,
+    backfillAnchor,
     grossOpenCostSol,
     positionPnlPct,
     beginPostWatch,

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PaperTrench",
-  "version": "3.13.10",
+  "version": "3.13.11",
   "description": "Paper-trade Solana memecoins with live P&L, native chart fills, session replay, AI coaching, and a verifiable track record.",
   "permissions": [
     "storage",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PaperTrench",
-  "version": "3.13.5",
+  "version": "3.13.7",
   "description": "Paper-trade Solana memecoins with live P&L, native chart fills, session replay, AI coaching, and a verifiable track record.",
   "permissions": [
     "storage",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PaperTrench",
-  "version": "3.13.8",
+  "version": "3.13.9",
   "description": "Paper-trade Solana memecoins with live P&L, native chart fills, session replay, AI coaching, and a verifiable track record.",
   "permissions": [
     "storage",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PaperTrench",
-  "version": "3.13.5",
+  "version": "3.13.6",
   "description": "Paper-trade Solana memecoins with live P&L, native chart fills, session replay, AI coaching, and a verifiable track record.",
   "permissions": [
     "storage",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PaperTrench",
-  "version": "3.13.9",
+  "version": "3.13.10",
   "description": "Paper-trade Solana memecoins with live P&L, native chart fills, session replay, AI coaching, and a verifiable track record.",
   "permissions": [
     "storage",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "PaperTrench",
-  "version": "3.13.7",
+  "version": "3.13.8",
   "description": "Paper-trade Solana memecoins with live P&L, native chart fills, session replay, AI coaching, and a verifiable track record.",
   "permissions": [
     "storage",

--- a/extension/onchain-feed.js
+++ b/extension/onchain-feed.js
@@ -757,6 +757,9 @@
   async function prewatch({ pool, mint }) {
     if (!O || !POOL) return null;
     try {
+      // Which address (if any) has already paid for the heavy PumpSwap
+      // program scan on this lookup, so it is never run twice.
+      let scannedFor = null;
       // A pump-suffixed mint: the derived curve is the strongest answer (a
       // live PRICE, not just supply facts), so try it first.
       if (!pool && typeof mint === 'string' && /pump$/.test(mint)) {
@@ -770,6 +773,7 @@
         // — the PumpSwap AMM it migrated into — and that pool is exactly
         // where the volume is in the minutes after migration. Ask the chain
         // for it rather than waiting on an aggregator to index it.
+        scannedFor = mint;
         const graduated = await findGraduatedPool(mint);
         if (graduated) {
           const found = await prewatchPool(graduated, mint);
@@ -796,7 +800,12 @@
         // is a live price; supply facts alone are not. Worth one lookup
         // before settling for the weaker answer, and this is the path
         // non-"pump"-suffixed launchpads (Bags, Believe, moonshot) take.
-        const graduated = await findGraduatedPool(address);
+        //
+        // A pump-suffixed mint may already have paid for this scan in the
+        // branch above; `getProgramAccounts` is the heaviest read the module
+        // makes and the public endpoint is keyless, so never run it twice
+        // for one lookup.
+        const graduated = scannedFor === address ? null : await findGraduatedPool(address);
         if (graduated) {
           const found = await prewatchPool(graduated, address);
           if (found) return found;

--- a/extension/onchain-feed.js
+++ b/extension/onchain-feed.js
@@ -676,6 +676,78 @@
     };
   }
 
+  /** A plausible base58 account address. Local to the feed so the module
+   * stays standalone (background.js has its own copy for message validation). */
+  function isAddress(s) {
+    return typeof s === 'string' && /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(s);
+  }
+
+  /**
+   * The PumpSwap pool a graduated pump.fun coin trades in, or null.
+   *
+   * A completed bonding curve stops carrying a price — that is what
+   * graduation MEANS — so `prewatchPool` refuses it and the coin used to fall
+   * through to the mint-facts path, which yields supply and identity but no
+   * price. On a just-migrated coin no aggregator has indexed the new pool
+   * yet either, so the panel sat on "Fetching live price…" for the exact
+   * minutes the coin was most tradable (cheng.4848 2026-08-24 "difficult to
+   * make purchases in time after the currency migration"; ark_trades13
+   * "only on migrated tokens").
+   *
+   * getProgramAccounts filtered on the base-mint offset is the authoritative
+   * lookup — it asks the chain which pool holds this coin rather than
+   * guessing a PDA whose seeds (creator, index) we do not know. The filter is
+   * an indexed memcmp on a single program, so it is cheap.
+   *
+   * Only a WSOL-quoted pool is usable: the whole feed prices in SOL, and a
+   * USDC-quoted pool would silently be a different unit. Where several
+   * qualify, the deepest one wins — that is the pool the router fills
+   * against, and a dust pool would quote a price nobody can trade.
+   */
+  async function findGraduatedPool(mint) {
+    if (!O || !isAddress(mint)) return null;
+    let found;
+    try {
+      found = await rpc('getProgramAccounts', [O.PUMP_AMM_PROGRAM, {
+        encoding: 'base64',
+        commitment: COMMITMENT,
+        filters: [{ memcmp: { offset: O.PUMPSWAP_BASE_MINT, bytes: mint } }],
+      }]);
+    } catch (_) { return null; }
+    // Some providers answer gPA with the payload stripped; re-read by address
+    // rather than trusting a shape we did not get.
+    const entries = Array.isArray(found) ? found : (found && found.value) || [];
+    if (!entries.length) return null;
+    const addresses = entries.map((e) => e && e.pubkey).filter(isAddress).slice(0, 12);
+    if (!addresses.length) return null;
+
+    const accounts = await getAccounts(addresses);
+    const candidates = [];
+    for (let i = 0; i < addresses.length; i++) {
+      const account = accounts[i];
+      if (!account || O.poolKindForOwner(account.owner) !== 'cp-vaults') continue;
+      const decoded = O.decodePumpSwapPool(O.bytesFromBase64(account.data[0]));
+      if (!decoded) continue;
+      if (decoded.baseMint !== mint) continue;
+      if (decoded.quoteMint !== O.WSOL_MINT) continue;
+      candidates.push({ pool: addresses[i], decoded });
+    }
+    if (!candidates.length) return null;
+    if (candidates.length === 1) return candidates[0].pool;
+
+    // Depth decides. One read for every quote vault at once.
+    const vaults = await getAccounts(candidates.map((c) => c.decoded.quoteVault));
+    let best = null;
+    for (let i = 0; i < candidates.length; i++) {
+      const account = vaults[i];
+      if (!account) continue;
+      const token = O.decodeTokenAccount(O.bytesFromBase64(account.data[0]));
+      if (!token || !(token.amount > 0)) continue;
+      if (!best || token.amount > best.amount) best = { pool: candidates[i].pool, amount: token.amount };
+    }
+    return best ? best.pool : candidates[0].pool;
+  }
+
   /**
    * Turn whichever single address the page has into the best instant answer
    * it supports. Returns { mint, pool, poolKind, priceNative } for a live
@@ -694,7 +766,16 @@
           if (found) return found;
         }
         // Not a live curve (migrated, or a non-pump.fun coin that merely
-        // ends in "pump") — the mint account itself may still hold supply.
+        // ends in "pump"). A GRADUATED coin still has a real, priceable pool
+        // — the PumpSwap AMM it migrated into — and that pool is exactly
+        // where the volume is in the minutes after migration. Ask the chain
+        // for it rather than waiting on an aggregator to index it.
+        const graduated = await findGraduatedPool(mint);
+        if (graduated) {
+          const found = await prewatchPool(graduated, mint);
+          if (found) return found;
+        }
+        // Still nothing priceable — the mint account may hold supply facts.
       }
 
       const address = pool || mint;
@@ -709,7 +790,19 @@
         return await prewatchPool(address, hint, account, slot);
       }
       const facts = mintFactsFromAccount(account, address);
-      if (facts) return facts;
+      if (facts) {
+        // The address IS a mint, and no curve answered for it — either it
+        // never had one, or it graduated. A PumpSwap pool holding this mint
+        // is a live price; supply facts alone are not. Worth one lookup
+        // before settling for the weaker answer, and this is the path
+        // non-"pump"-suffixed launchpads (Bags, Believe, moonshot) take.
+        const graduated = await findGraduatedPool(address);
+        if (graduated) {
+          const found = await prewatchPool(graduated, address);
+          if (found) return found;
+        }
+        return facts;
+      }
 
       // A pool whose owner program has NO verified decoder (a launchpad we
       // have not verified — LaunchLab, DBC, whatever ships next week) used
@@ -829,6 +922,7 @@
     _mintFactsFromAccount: mintFactsFromAccount,
     _discoverPoolMint: discoverPoolMint,
     _primeEntry: primeEntry,
+    _findGraduatedPool: findGraduatedPool,
   };
 
   if (typeof self !== 'undefined') self.PTOnchainFeed = api;

--- a/extension/onchain.js
+++ b/extension/onchain.js
@@ -39,6 +39,18 @@
   const WHIRLPOOL_MINT_B = 181;
   const SPL_AMOUNT = 64;             // u64 LE, 165-byte token account
   const SPL_MINT = 0;
+
+  // PumpSwap AMM pool layout (program pAMMBay6…), verified against live
+  // mainnet accounts — see docs/POOL-LAYOUTS.md for the transcript. The pool
+  // account is 301 bytes; these four are all the price needs. The base vault
+  // is frequently a Token-2022 account (170 bytes) while the quote vault is
+  // classic SPL (165), which is why decodeTokenAccount's shared prefix is
+  // what reads them both.
+  const PUMPSWAP_BASE_MINT = 43;
+  const PUMPSWAP_QUOTE_MINT = 75;
+  const PUMPSWAP_BASE_VAULT = 139;
+  const PUMPSWAP_QUOTE_VAULT = 171;
+  const PUMP_AMM_PROGRAM = 'pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA';
   const MINT_SUPPLY = 36;            // u64 LE
   const MINT_DECIMALS = 44;          // u8
   const CURVE_VIRTUAL_TOKEN = 8;     // u64 LE, after Anchor discriminator
@@ -239,6 +251,28 @@
   }
 
   /**
+   * PumpSwap AMM pool (program pAMMBay6…) — where a pump.fun coin LIVES after
+   * it graduates. Offsets verified against live mainnet pools (see
+   * docs/POOL-LAYOUTS.md): the account is 301 bytes, and the four fields we
+   * need sit at fixed offsets after the 8-byte anchor discriminator.
+   *
+   * This is the migrated half of the fresh-launch story. The bonding curve
+   * goes `complete: true` at graduation and stops carrying a price, so a coin
+   * that just migrated had NO on-chain price source at all until the
+   * aggregators indexed the new pool — the "Fetching live price…" wall that
+   * cheng.4848 and ark_trades13 reported on exactly these coins.
+   */
+  function decodePumpSwapPool(bytes) {
+    if (!bytes || bytes.length < PUMPSWAP_QUOTE_VAULT + 32) return null;
+    return {
+      baseMint: readPubkey(bytes, PUMPSWAP_BASE_MINT),
+      quoteMint: readPubkey(bytes, PUMPSWAP_QUOTE_MINT),
+      baseVault: readPubkey(bytes, PUMPSWAP_BASE_VAULT),
+      quoteVault: readPubkey(bytes, PUMPSWAP_QUOTE_VAULT),
+    };
+  }
+
+  /**
    * Orca Whirlpool / Raydium CLMM.
    *
    * price(B per A) = (sqrtPrice / 2^64)^2, then scaled by the decimal delta.
@@ -332,6 +366,9 @@
     PUMP_TOKEN_DECIMALS,
     bytesFromBase64, readU64, readU128, readPubkey, b58decode,
     decodeMint, decodeTokenAccount, decodeWhirlpool, decodePumpCurve,
+    decodePumpSwapPool,
+    PUMP_AMM_PROGRAM, PUMPSWAP_BASE_MINT, PUMPSWAP_QUOTE_MINT,
+    PUMPSWAP_BASE_VAULT, PUMPSWAP_QUOTE_VAULT,
     priceFromSqrtPrice, priceFromPumpCurve, priceFromVaults,
     marketCapFrom, poolKindForOwner, isNewerObservation,
     isOnCurve, derivePumpCurve,

--- a/extension/overlay.js
+++ b/extension/overlay.js
@@ -71,6 +71,58 @@ $('helpBtn').addEventListener('click', () => $('setup').classList.toggle('open')
 
 /* ------------------------------ stats ------------------------------ */
 
+/** D-56: the birth balance re-derived from the fill journal alone — the
+ * anchor for LEGACY wallets that predate D-06's state.startSol snapshot
+ * (created before v3.9.5). Mirrors engine.derivedBirthSol / popup's
+ * derivedAnchor (the overlay is self-contained on purpose — no engine.js
+ * load-order dependency — so the rule is duplicated here and the test
+ * suite pins all three to the same fixture):
+ * equity = birth + Σ(buy fees) + Σ(sell pnl) + open P&L →
+ * birth = equity − open P&L − Σ steps. Null when the journal can't support
+ * the derivation; null defers to the setting fallback. */
+function derivedAnchor(state) {
+  const journal = ((state && state.journal) || [])
+    .slice().sort((a, b) => (Number(a.ts) || 0) - (Number(b.ts) || 0));
+  if (!journal.length) return null;
+  const positions = Object.values((state && state.positions) || {});
+  let openValue = 0;
+  let openPnl = 0;
+  for (const p of positions) {
+    const qty = Number(p.qty) || 0;
+    const px = Number(p.lastPriceNative) || 0;
+    if (qty <= 0) continue;
+    openValue += qty * px;
+    openPnl += qty * px - (Number(p.costSol) || 0);
+  }
+  const equity = (Number(state.cashSol) || 0) + openValue;
+  let walked = 0;
+  for (const t of journal) {
+    if (t.side === 'buy') {
+      const feeRaw = Number(t.feeSol);
+      const fee = Number.isFinite(feeRaw) && feeRaw >= 0
+        ? feeRaw
+        : (Number.isFinite(Number(t.solNet))
+          ? Math.max(0, (Number(t.solGross) || 0) - Number(t.solNet))
+          : 0);
+      walked -= fee;
+    } else if (t.side === 'sell') {
+      walked += Number(t.pnlSol) || 0;
+    }
+  }
+  const derived = equity - openPnl - walked;
+  return Number.isFinite(derived) ? derived : null;
+}
+
+/** D-06 + D-56: the honest "% since start" denominator, in one place. */
+function anchorFor(state, settings) {
+  const birth = Number(state && state.startSol);
+  if (Number.isFinite(birth) && birth > 0) return birth;
+  const derived = derivedAnchor(state);
+  if (derived !== null && derived > 1e-6) return derived;
+  const setting = Number(settings && settings.balanceStartSol);
+  return Number.isFinite(setting) && setting > 0 ? setting : 0;
+}
+
 function computeStats(state, settings) {
   const positions = Object.values(state.positions || {});
   const rounds = state.rounds || [];
@@ -79,8 +131,9 @@ function computeStats(state, settings) {
   const wins = rounds.filter((r) => r.pnlSol > 0).length;
   return {
     equitySol: equity,
-    // D-06: birth anchor first; the live setting is only a legacy fallback.
-    equityVsStart: equity - ((Number(state.startSol) > 0 ? Number(state.startSol) : Number(settings.balanceStartSol)) || 0),
+    // D-06 + D-56: birth snapshot → journal-derived birth (legacy wallets)
+    // → live setting, all through anchorFor.
+    equityVsStart: equity - anchorFor(state, settings),
     realizedPnlSol: rounds.reduce((s, r) => s + (r.pnlSol || 0), 0),
     rounds: rounds.length,
     winRate: rounds.length ? (wins / rounds.length) * 100 : null,
@@ -177,10 +230,10 @@ async function render() {
   $('equity').style.color = up ? 'var(--green)' : 'var(--red)';
 
   const deltaEl = $('delta');
-  // D-06: % vs start uses the wallet's birth balance, not the live setting.
-  const anchor = (state && Number(state.startSol)) > 0
-    ? Number(state.startSol)
-    : (Number(settings.balanceStartSol) > 0 ? Number(settings.balanceStartSol) : 0);
+  // D-06 + D-56: % vs start uses the wallet's birth balance — the snapshot
+  // when one exists, the journal-derived birth for legacy wallets, the
+  // live setting only as the last resort.
+  const anchor = anchorFor(state, settings);
   const pct = anchor > 0 ? (stats.equityVsStart / anchor) * 100 : 0;
   deltaEl.textContent = `${up ? '▲' : '▼'} ${up ? '+' : ''}${fmt(stats.equityVsStart, 3)} SOL (${up ? '+' : ''}${pct.toFixed(1)}%) vs start`;
   deltaEl.style.color = up ? 'var(--green)' : 'var(--red)';

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "papertrench",
-  "version": "3.13.7",
+  "version": "3.13.8",
   "private": true,
   "description": "Paper-trade Solana memecoins on Axiom, Padre, Photon, GMGN, BullX and more.",
   "scripts": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "papertrench",
-  "version": "3.13.5",
+  "version": "3.13.6",
   "private": true,
   "description": "Paper-trade Solana memecoins on Axiom, Padre, Photon, GMGN, BullX and more.",
   "scripts": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "papertrench",
-  "version": "3.13.5",
+  "version": "3.13.7",
   "private": true,
   "description": "Paper-trade Solana memecoins on Axiom, Padre, Photon, GMGN, BullX and more.",
   "scripts": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "papertrench",
-  "version": "3.13.8",
+  "version": "3.13.9",
   "private": true,
   "description": "Paper-trade Solana memecoins on Axiom, Padre, Photon, GMGN, BullX and more.",
   "scripts": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "papertrench",
-  "version": "3.13.9",
+  "version": "3.13.10",
   "private": true,
   "description": "Paper-trade Solana memecoins on Axiom, Padre, Photon, GMGN, BullX and more.",
   "scripts": {

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "papertrench",
-  "version": "3.13.10",
+  "version": "3.13.11",
   "private": true,
   "description": "Paper-trade Solana memecoins on Axiom, Padre, Photon, GMGN, BullX and more.",
   "scripts": {

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -157,6 +157,12 @@ function freshState(settings) {
     version: 1,
     seq: 0,
     cashSol: settings.balanceStartSol,
+    // D-06/D-56: snapshot the birth balance the way engine.defaultState does
+    // (engine.js isn't loaded in the popup). Without it a wallet RESET FROM
+    // THE POPUP would be born as a legacy wallet — anchoring on the live
+    // setting for its whole life and re-opening the jb 100× hole on a
+    // brand-new wallet.
+    startSol: settings.balanceStartSol,
     startedAt: Date.now(),
     positions: {},
     rounds: [],
@@ -185,6 +191,61 @@ function journalFlow(journal, positions) {
   return { boughtSol, heldSol, soldSol };
 }
 
+/** D-56: the birth balance re-derived from the fill journal alone — the
+ * anchor for LEGACY wallets that predate D-06's state.startSol snapshot
+ * (created before v3.9.5). Same identity the engine's equity curve uses:
+ * equity = birth + Σ(buy fees) + Σ(sell pnl) + open P&L, so
+ * birth = equity − open P&L − Σ steps. Mirrors engine.derivedBirthSol: the
+ * popup is self-contained on purpose (no engine.js dependency), so the
+ * rule is duplicated here and the test suite pins both to the same
+ * fixture. Returns null when the journal can't support the derivation
+ * (empty or non-finite) — null defers to the setting fallback, it never
+ * overrides a real startSol. */
+function derivedAnchor(state) {
+  const journal = ((state && state.journal) || [])
+    .slice().sort((a, b) => (Number(a.ts) || 0) - (Number(b.ts) || 0));
+  if (!journal.length) return null;
+  const positions = Object.values((state && state.positions) || {});
+  let openValue = 0;
+  let openPnl = 0;
+  for (const p of positions) {
+    const qty = Number(p.qty) || 0;
+    const px = Number(p.lastPriceNative) || 0;
+    if (qty <= 0) continue;
+    openValue += qty * px;
+    openPnl += qty * px - (Number(p.costSol) || 0);
+  }
+  const equity = (Number(state.cashSol) || 0) + openValue;
+  let walked = 0;
+  for (const t of journal) {
+    if (t.side === 'buy') {
+      const feeRaw = Number(t.feeSol);
+      const fee = Number.isFinite(feeRaw) && feeRaw >= 0
+        ? feeRaw
+        : (Number.isFinite(Number(t.solNet))
+          ? Math.max(0, (Number(t.solGross) || 0) - Number(t.solNet))
+          : 0);
+      walked -= fee;
+    } else if (t.side === 'sell') {
+      walked += Number(t.pnlSol) || 0;
+    }
+  }
+  const derived = equity - openPnl - walked;
+  return Number.isFinite(derived) ? derived : null;
+}
+
+/** D-06 + D-56: the honest "% since start" denominator, in one place.
+ * Birth snapshot first (D-06), the journal-derived birth second (D-56,
+ * legacy wallets), the live setting LAST. */
+function anchorFor(state, settings) {
+  const birth = Number(state && state.startSol);
+  if (Number.isFinite(birth) && birth > 0) return birth;
+  const derived = derivedAnchor(state);
+  if (derived !== null && derived > 1e-6) return derived;
+  const setting = Number(settings && settings.balanceStartSol);
+  return Number.isFinite(setting) && setting > 0 ? setting : 0;
+}
+
 /** Equity = cash + mark-to-market value of every open position. */
 function computeStats(state, settings) {
   const positions = Object.values(state.positions || {});
@@ -209,8 +270,9 @@ function computeStats(state, settings) {
     openPositions: positions.length,
     realizedPnlSol: realized,
     rounds: rounds.length,
-    // D-06: birth anchor first; the setting is only a legacy fallback.
-    equityVsStart: equity - ((Number(state.startSol) > 0 ? Number(state.startSol) : Number(settings.balanceStartSol)) || 0),
+    // D-06 + D-56: birth snapshot → journal-derived birth (legacy wallets)
+    // → live setting, all through anchorFor.
+    equityVsStart: equity - anchorFor(state, settings),
     boughtSol: flow.boughtSol,
     heldSol: flow.heldSol,
     soldSol: flow.soldSol,
@@ -256,11 +318,10 @@ async function load() {
     $('equity').className = 'equity ' + (up ? 'green' : 'red');
 
     const deltaEl = $('delta');
-    // D-06: % change is judged against the wallet's birth balance (the
-    // state's startSol anchor), not the live setting.
-    const anchor = (state && Number(state.startSol)) > 0
-      ? Number(state.startSol)
-      : (Number(settings.balanceStartSol) > 0 ? Number(settings.balanceStartSol) : 0);
+    // D-06 + D-56: % change is judged against the wallet's birth balance —
+    // the snapshot when one exists, the journal-derived birth for legacy
+    // wallets, the live setting only as the last resort.
+    const anchor = anchorFor(state, settings);
     const pct = anchor ? (stats.equityVsStart / anchor) * 100 : 0;
     deltaEl.textContent = `${up ? '▲' : '▼'} ${up ? '+' : ''}${fmt(stats.equityVsStart, 3)} SOL (${up ? '+' : ''}${pct.toFixed(1)}%)`;
     deltaEl.className = 'delta ' + (up ? 'green' : 'red');

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3204,6 +3204,16 @@
    * itself — i.e. real content (text, stat, avatar) the chip would cover.
    * A hit outside the row entirely (page background, whitespace) is fine:
    * the anchor is in the gutter already.
+   *
+   * F-60: the chip is CLICKABLE (pointer-events:auto on .pt-rowbuy), so
+   * once it is painted at the anchor its own body tops the hit-test and
+   * elementFromPoint returns the chip — reading "clean" forever while it
+   * covers the MC a live format switch (or a late mount, or a row
+   * recycle) just moved under it. The probe therefore reads the STACK
+   * (elementsFromPoint) and skips chip-owned entries: the first element
+   * in the stack that is neither the chip, inside the chip, nor this
+   * layer's other chips, is the ground truth the chip is covering.
+   * Engines without elementsFromPoint keep the legacy top-hit read.
    */
   function rowAnchorHitsContent(anchor, rect, row, entry, pillRect) {
     const chipWidth = (entry && entry.el && entry.el.getBoundingClientRect)
@@ -3211,18 +3221,37 @@
       : 0;
     const bodyX = Math.max(1, Math.round(anchor.x - (chipWidth > 0 ? chipWidth / 2 : 14)));
     const bodyY = Math.min(Math.max(Math.round(anchor.y), 1), (window.innerHeight || 1) - 1);
-    let hit = null;
-    try { hit = document.elementFromPoint(bodyX, bodyY); } catch (_) { return false; }
-    if (!hit || hit === entry.el || entry.el.contains(hit)) return false;
-    if (hit === row) return false;
-    // Content INSIDE the row (or the pill the anchor belongs to): covered.
+    let hits = null;
     try {
-      if (row.contains(hit)) return true;
-    } catch (_) {}
-    if (pillRect && hit.getBoundingClientRect) {
-      const hr = hit.getBoundingClientRect();
-      if (hr.width > 0 && hr.right > pillRect.left && hr.left < pillRect.right
-          && hr.bottom > pillRect.top && hr.top < pillRect.bottom) return true;
+      if (typeof document.elementsFromPoint === 'function') {
+        hits = document.elementsFromPoint(bodyX, bodyY);
+      } else {
+        const one = document.elementFromPoint(bodyX, bodyY);
+        hits = one ? [one] : [];
+      }
+    } catch (_) { return false; }
+    if (!hits || !hits.length) return false;
+    for (let i = 0; i < hits.length; i += 1) {
+      const hit = hits[i];
+      if (!hit) continue;
+      // Skip everything the chip itself owns: its own body and anything
+      // inside it. The stack is painted front-to-back, so these lead.
+      if (hit === entry.el) continue;
+      try { if (entry.el && entry.el.contains(hit)) continue; } catch (_) {}
+      // Skip other chips from this same layer: a neighbouring row's chip
+      // can legitimately sit beneath this one on overlap-heavy layouts.
+      if (hit.dataset && hit.dataset.ptRowChip === '1') continue;
+      if (hit === row) return false;
+      // Content INSIDE the row (or the pill the anchor belongs to): covered.
+      try {
+        if (row.contains(hit)) return true;
+      } catch (_) {}
+      if (pillRect && hit.getBoundingClientRect) {
+        const hr = hit.getBoundingClientRect();
+        if (hr.width > 0 && hr.right > pillRect.left && hr.left < pillRect.right
+            && hr.bottom > pillRect.top && hr.top < pillRect.bottom) return true;
+      }
+      return false;
     }
     return false;
   }
@@ -3633,6 +3662,9 @@
 
       const button = document.createElement('button');
       button.className = 'pt-rowbuy';
+      // F-60: mark the chip so collision probes can recognise (and look
+      // through) their own paint in the elementsFromPoint stack.
+      try { button.dataset.ptRowChip = '1'; } catch (_) {}
       button.type = 'button';
       button.textContent = `P ${amount}`;
       button.title = `PaperTrench: paper-buy ${amount} SOL of this token right now`;

--- a/extension/quote.js
+++ b/extension/quote.js
@@ -216,7 +216,25 @@
     if (!payload || typeof payload !== 'object') return null;
     const chainId = chainIdFor(opts && opts.chain);
     const pair = payload.pair || pickBestPair(payload.pairs, fallbackAddress, chainId);
-    return normalizePair(pair, fallbackAddress, opts);
+    const token = normalizePair(pair, fallbackAddress, opts);
+    // F-61: surface EVERY pool the source lists for this base mint. A Pulse
+    // row buy can commit under a bonding-era PAIR stand-in (the row-feed
+    // fallback echoes the click address as the key); after graduation the
+    // coin resolves under its REAL mint and the bag strands. The pool list
+    // is the deterministic identity proof — graduated bonding pairs stay
+    // listed under the same base mint (verified on-chain 2026-08-20, P0-3) —
+    // so the chart page can rekey any position whose key is one of these
+    // pools. Additive: consumers that ignore it are unaffected.
+    if (token && Array.isArray(payload.pairs)) {
+      const seen = {};
+      const pools = [];
+      for (var i = 0; i < payload.pairs.length; i++) {
+        var p = payload.pairs[i] && payload.pairs[i].pairAddress;
+        if (p && !seen[p]) { seen[p] = 1; pools.push(p); }
+      }
+      if (pools.length) token.poolAddresses = pools;
+    }
+    return token;
   }
 
   /* ------------------------------------------------------------------ *

--- a/extension/test/_debug_race.js
+++ b/extension/test/_debug_race.js
@@ -1,0 +1,40 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const src = fs.readFileSync(path.join(__dirname, 'orderrace.test.js'), 'utf8');
+const harness = src.slice(0, src.indexOf('/* ---------------- the race'));
+const mod = { exports: {} };
+const fn = new Function('require', 'module', 'exports', '__harness', '__dirname',
+  harness + '\n__harness.runOrderRace = runOrderRace;');
+const h = {};
+fn(require, mod, mod.exports, h, __dirname);
+
+(async () => {
+  const ov = h.runOrderRace({});
+  await ov.settle();
+  const E = require(path.join(__dirname, '..', 'engine.js'));
+  const MINT = '3PTQpne3b7kjJEvDYDMBHSuRjTDUh6HSin2xMyW3pump';
+  const base = E.resetState(E.defaultSettings());
+  E.buy(base, E.defaultSettings(), { ts: 4000000, mint: MINT, site: 'padre', solAmount: 1, priceNative: 1e-9, priceUsd: 2e-7 });
+  E.addOrder(base, MINT, { kind: 'tp', triggerPrice: 2e-9, sizePt: 50 }, 1e-9, 4100000);
+  ov.seed(base);
+  console.log('seeded. orders in seed:', JSON.stringify(Object.keys(base.orders || {})));
+  ov.emitTick({ candidates: [{ value:  2.2e-9, unit: 'native' }] });
+  await ov.settle();
+  await ov.advance(2000);
+  const st = ov.workerState();
+  console.log('journal sells:', (st.journal || []).filter(t => t.side === 'sell').length);
+  console.log('positions:', Object.keys(st.positions || {}));
+  console.log('commits:', JSON.stringify(ov.commitLog()).slice(0, 400));
+  try {
+    console.log('token symbol:', vm.runInContext('typeof token !== "undefined" && token ? token.symbol : "none"', ov.sandbox));
+    console.log('orders in live state:', vm.runInContext('typeof state !== "undefined" && state ? JSON.stringify(Object.keys(state.orders || {})) : "no state"', ov.sandbox));
+    console.log('lastTickPrice:', vm.runInContext('typeof lastChartPrice !== "undefined" ? String(lastChartPrice) : "n/a"', ov.sandbox));
+  } catch (e) { console.log('probe err:', e.message); }
+  try {
+    console.log('resolver type:', vm.runInContext('typeof PaperTrenchResolver', ov.sandbox));
+    const r = await vm.runInContext('PaperTrenchResolver ? PaperTrenchResolver.resolve("3PTQpne3b7kjJEvDYDMBHSuRjTDUh6HSin2xMyW3pump") : null', ov.sandbox);
+    console.log('resolve result:', JSON.stringify(r).slice(0, 300));
+  } catch (e) { console.log('probe err:', e.message); }
+  process.exit(0);
+})();

--- a/extension/test/d06_backfill.test.js
+++ b/extension/test/d06_backfill.test.js
@@ -1,0 +1,236 @@
+/* D-56: legacy wallets (born before D-06's state.startSol snapshot, v3.9.5)
+ * kept anchoring every "% since start" — and every SOL-vs-start — on the
+ * LIVE "Starting paper balance" setting. Editing the form 10 → 1 SOL on a
+ * wallet that actually started at 10 turned a +0.091 SOL session into a
+ * +9.109 SOL session (jb's 8/18 report: "exactly 100×" on his numbers).
+ *
+ * The fix: engine.backfillAnchor re-derives the birth balance from the fill
+ * journal (the same identity equityCurvePoints uses:
+ *   equity = birth + Σ per-fill steps + open P&L)
+ * and freezes it onto state.startSol; anchorStartSol gains the derived
+ * middle layer (birth snapshot → derived → setting); the read-only
+ * surfaces (popup/overlay/bridge) carry local copies of the derivation.
+ *
+ * Source-contract tests on observable channels only — the same fixtures the
+ * engine's own equityCurvePoints identity was built on.
+ */
+
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const E = require('../engine.js');
+
+const read = (name) => fs.readFileSync(path.join(__dirname, '..', name), 'utf8');
+
+/* A wallet exactly as a pre-v3.9.5 content script would have written it:
+ * born at 10 SOL (the default), a few closed rounds, no startSol field.
+ * The journal is built with the engine's own buy/sell so every field the
+ * derivation reads (feeSol, solGross, solNet, pnlSol) is real. */
+function legacyWallet({ startSol = 10, feesBps = 100, price = 0.001 } = {}) {
+  const settings = E.defaultSettings();
+  settings.feeBps = feesBps;
+  const st = E.defaultState(settings);
+  delete st.startSol; // ← the legacy hole: born before the snapshot existed
+  st.cashSol = startSol;
+
+  // Round 1: buy 1 SOL gross, sell the whole bag at 2× (net +~1 SOL after fees)
+  const r1 = E.buy(st, settings, { mint: 'MINT1', symbol: 'A', solAmount: 1, priceNative: price, ts: 1000 });
+  const sell1 = E.sell(st, settings, { mint: 'MINT1', symbol: 'A', qtyFraction: 1, priceNative: price * 2, ts: 2000 });
+
+  // Round 2: buy 0.5 SOL gross, sell the whole bag at 0.98× (small net loss)
+  const r2 = E.buy(st, settings, { mint: 'MINT2', symbol: 'B', solAmount: 0.5, priceNative: price, ts: 3000 });
+  const sell2 = E.sell(st, settings, { mint: 'MINT2', symbol: 'B', qtyFraction: 1, priceNative: price * 0.98, ts: 4000 });
+
+  return { st, r1, r2, sell1, sell2, settings };
+}
+
+/* The wallet's TRUE birth, replayed from a DIFFERENT route than the fix:
+ * the CASH flow. A buy leaves the wallet by solGross + the flat tx cost;
+ * a sell enters by solNet (net proceeds). Then the open-position term:
+ * cash still holds the gross invested, and the position's cost basis
+ * (net + flat) is what the mark replaced — so birth = cashReplay + Σcost − Σmark.
+ * (With all bags closed, Σcost → 0 and Σmark → 0, and it degenerates to the
+ * plain cash replay.) Works for the base fixture AND the open-position
+ * tests without assuming stepOf is right. */
+function trueBirth(st) {
+  let cash = Number(st.cashSol) || 0;
+  for (const t of st.journal || []) {
+    if (t.side === 'buy') cash += (Number(t.solGross) || 0) + (Number(t.txCostSol) || 0);
+    else if (t.side === 'sell') cash -= (Number(t.solNet) || 0);
+  }
+  let cost = 0;
+  let mark = 0;
+  for (const p of Object.values(st.positions || {})) {
+    const qty = Number(p.qty) || 0;
+    if (qty <= 0) continue;
+    cost += Number(p.costSol) || 0;
+    mark += qty * (Number(p.lastPriceNative) || 0);
+  }
+  return cash + cost - mark;
+}
+
+test('D-56: derivedBirthSol re-derives the birth balance of a legacy wallet', () => {
+  const { st } = legacyWallet();
+  const derived = E.derivedBirthSol(st);
+  const truth = trueBirth(st);
+  assert.ok(Number.isFinite(derived), 'derivation must be finite');
+  assert.ok(Math.abs(derived - truth) < 1e-9, `derived ${derived} vs true ${truth}`);
+});
+
+test('D-56: derivedBirthSol is stable across open positions (marks move, anchor must not)', () => {
+  const { st, settings } = legacyWallet();
+  // Open a live bag and re-derive — the anchor must not budge as marks move.
+  E.buy(st, settings, { mint: 'MINT3', symbol: 'C', solAmount: 2, priceNative: 0.002, ts: 5000 });
+  const before = E.derivedBirthSol(st);
+  E.markPosition(st, 'MINT3', 0.005); // 2.5× mark
+  const after = E.derivedBirthSol(st);
+  assert.ok(Math.abs(before - after) < 1e-9, `anchor moved on a mark: ${before} → ${after}`);
+});
+
+test('D-56: derivedBirthSol is stable across new fills (the writer race)', () => {
+  const { st, settings } = legacyWallet();
+  const before = E.derivedBirthSol(st);
+  // A concurrent tab lands another round between the read and the write.
+  E.buy(st, settings, { mint: 'MINT4', symbol: 'D', solAmount: 0.2, priceNative: 0.001, ts: 6000 });
+  E.sell(st, settings, { mint: 'MINT4', symbol: 'D', qtyFraction: 1, priceNative: 0.0015, ts: 7000 });
+  const after = E.derivedBirthSol(st);
+  assert.ok(Math.abs(before - after) < 1e-9, `anchor moved on new fills: ${before} → ${after}`);
+});
+
+test('D-56: backfillAnchor freezes the derived birth onto state.startSol', () => {
+  const { st, settings } = legacyWallet();
+  const truth = trueBirth(st);
+  const wrote = E.backfillAnchor(st, settings);
+  assert.strictEqual(wrote, true, 'must write for a legacy wallet');
+  assert.ok(Math.abs(st.startSol - truth) < 1e-9, `startSol ${st.startSol} vs true ${truth}`);
+  // Idempotent: a second pass leaves the snapshot untouched.
+  assert.strictEqual(E.backfillAnchor(st, settings), false);
+  assert.ok(Math.abs(st.startSol - truth) < 1e-9, 'second pass must not re-derive');
+});
+
+test('D-56: backfillAnchor is a no-op for modern wallets (startSol already set)', () => {
+  const modern = E.defaultState(E.defaultSettings()); // born after v3.9.5
+  modern.cashSol = 42;
+  assert.strictEqual(E.backfillAnchor(modern, E.defaultSettings()), false);
+  assert.strictEqual(modern.startSol, 10, 'modern snapshot must not be touched');
+});
+
+test('D-56: backfillAnchor is conservative — empty journal or dust equity defers to the setting', () => {
+  const noFills = { cashSol: 10, positions: {}, rounds: [], journal: [] };
+  assert.strictEqual(E.backfillAnchor(noFills, { balanceStartSol: 7 }), false, 'no fills → no derived anchor');
+  assert.strictEqual(noFills.startSol, undefined, 'must not fabricate a snapshot');
+
+  // Dust: a zero-fee buy whose cost basis vanished with it — the derived
+  // birth is float dust (1e-9), not a real balance. Writing an anchor
+  // there would weld % returns to noise.
+  const dust = { cashSol: 1e-9, positions: {}, rounds: [], journal: [{ side: 'buy', ts: 1, solGross: 1, solNet: 1, feeSol: 0 }] };
+  assert.strictEqual(E.backfillAnchor(dust, { balanceStartSol: 7 }), false, 'dust → no derived anchor');
+});
+
+test('D-56: anchorStartSol — legacy wallet reads the derived birth, NOT the live setting (jb repro)', () => {
+  const { st } = legacyWallet();
+  const truth = trueBirth(st);
+  // jb's exact shape: wallet born at 10, setting later edited to 1.
+  const anchored = E.anchorStartSol(st, { balanceStartSol: 1 });
+  assert.ok(Math.abs(anchored - truth) < 1e-9,
+    `anchor ${anchored} vs birth ${truth} — the setting (1) must lose`);
+  // And the modern wallet still beats both.
+  const modern = E.defaultState({ balanceStartSol: 25 });
+  assert.strictEqual(E.anchorStartSol(modern, { balanceStartSol: 1 }), 25);
+});
+
+test('D-56: sessionStats — jb repro: +0.091 SOL stays +0.091 SOL after a 10→1 setting edit', () => {
+  // Rebuild jb's numbers from the defect card: legacy wallet, born 10 SOL,
+  // one round banked +0.091 SOL, setting edited to 1, then the full exit.
+  const settings = E.defaultSettings();
+  settings.feeBps = 0; // exact numbers, no fee noise
+  const st = E.defaultState(settings);
+  delete st.startSol;
+  st.cashSol = 10;
+  const price = 0.01;
+  E.buy(st, settings, { mint: 'JB', symbol: 'JB', solAmount: 1, priceNative: price, ts: 100 });
+  // exit at a price that banks exactly +0.091 SOL on the 1 SOL round
+  E.sell(st, settings, { mint: 'JB', symbol: 'JB', qtyFraction: 1, priceNative: price * 1.091, ts: 200 });
+  const eq = E.equitySol(st);
+  assert.ok(Math.abs((eq - 10) - 0.091) < 1e-9, `fixture sanity: equity ${eq}, expected 10.091`);
+
+  const stats = E.sessionStats(st, { balanceStartSol: 1 });
+  // The old bug: equityVsStart = 10.091 − 1 = +9.091 (jb saw +9.109 with fees).
+  // The fix: equityVsStart = 10.091 − 10 = +0.091.
+  assert.ok(Math.abs(stats.equityVsStart - 0.091) < 1e-9,
+    `jb repro: ${stats.equityVsStart} SOL — must be +0.091, not +9.091 (the 10→1 setting gap)`);
+  // And the persisted backfill makes it survive even without the derived layer.
+  E.backfillAnchor(st, settings);
+  assert.ok(Math.abs(st.startSol - 10) < 1e-9, `persisted snapshot ${st.startSol}, expected 10`);
+});
+
+/* ---------------- source contracts: the read-only surfaces ---------------- */
+
+test('D-56: popup carries the derived-anchor layer (self-contained, no engine.js)', () => {
+  const src = read('popup.js');
+  assert.match(src, /function derivedAnchor\(/, 'popup.js must define derivedAnchor');
+  assert.match(src, /function anchorFor\(/, 'popup.js must define anchorFor');
+  // Both anchor sites go through it — no raw setting fallback left in a
+  // vs-start computation.
+  assert.match(src, /equityVsStart: equity - anchorFor\(state, settings\)/);
+  assert.match(src, /const anchor = anchorFor\(state, settings\)/);
+  // The derived layer sits BETWEEN snapshot and setting.
+  assert.match(src, /function anchorFor\(state, settings\) \{[\s\S]{0,220}?Number\(state && state\.startSol\)[\s\S]{0,220}?derivedAnchor\(state\)[\s\S]{0,220}?settings && settings\.balanceStartSol/s);
+  // The derivation rule itself: buy debits its fee, sell credits its pnl.
+  assert.match(src, /t\.side === 'buy'[\s\S]{0,300}?t\.feeSol[\s\S]{0,300}?t\.solGross[\s\S]{0,300}?t\.solNet/s);
+  assert.match(src, /t\.side === 'sell'[\s\S]{0,160}?t\.pnlSol/s);
+});
+
+test('D-56: overlay carries the derived-anchor layer', () => {
+  const src = read('overlay.js');
+  assert.match(src, /function derivedAnchor\(/);
+  assert.match(src, /function anchorFor\(/);
+  assert.match(src, /equityVsStart: equity - anchorFor\(state, settings\)/);
+  assert.match(src, /const anchor = anchorFor\(state, settings\)/);
+});
+
+test('D-56: background bridge denominates the chain replay on the derived birth', () => {
+  const src = read('background.js');
+  assert.match(src, /function derivedBirthAnchor\(state\)/);
+  // bridgeRecord: snapshot → derived → setting, in that order.
+  assert.match(src, /const start = \(Number\(state\.startSol\) \|\| 0\) > 0[\s\S]{0,200}?derivedBirthAnchor\(state\) > 0[\s\S]{0,200}?derivedBirthAnchor\(state\)[\s\S]{0,200}?settings\.balanceStartSol/s);
+});
+
+test('D-56: content.js + dashboard.js persist the backfill on first load', () => {
+  const content = read('content.js');
+  // reloadState: backfill after the stored state lands.
+  assert.match(content, /if \(stored\[E\.STORAGE_KEYS\.state\]\) state = stored\[E\.STORAGE_KEYS\.state\];[\s\S]{0,400}?E\.backfillAnchor\(state, settings\)/s);
+  // adoptState: backfill the adopted state before the re-render.
+  assert.match(content, /function adoptState\(next\) \{[\s\S]{0,400}?state = next;[\s\S]{0,400}?E\.backfillAnchor\(state, settings\)/s);
+
+  const dash = read('dashboard.js');
+  assert.match(dash, /state = s\.pt_state \|\| E\.defaultState\(settings\);[\s\S]{0,800}?E\.backfillAnchor\(state, settings\)/s);
+  assert.match(dash, /mutateState\(\(fresh\) => \{ E\.backfillAnchor\(fresh, settings\); \}\)/);
+});
+
+test('D-56: engine exports the derivation + backfill for the surfaces and tests', () => {
+  for (const name of ['derivedBirthSol', 'backfillAnchor', 'stepOf']) {
+    assert.strictEqual(typeof E[name], 'function', `engine must export ${name}`);
+  }
+});
+
+test('D-56: popup freshState snapshots the birth balance (a popup-born wallet is not a legacy wallet)', () => {
+  const src = read('popup.js');
+  assert.match(src, /function freshState\(settings\) \{[\s\S]{0,300}?cashSol: settings\.balanceStartSol[,;][\s\S]{0,600}?startSol: settings\.balanceStartSol[,;]/s);
+});
+
+test('D-56: the curve and the backfill share ONE step rule (no drift)', () => {
+  const { st } = legacyWallet();
+  // The curve's anchor (derived from the SAME state, start = the true birth)
+  // and the backfill's derivation must agree to float tolerance: they walk
+  // the journal by the same stepOf, so the two anchors cannot diverge.
+  const truth = trueBirth(st);
+  const pts = E.equityCurvePoints(st, truth);
+  assert.ok(pts.length >= 2, 'curve must have points');
+  const derived = E.derivedBirthSol(st);
+  assert.ok(Math.abs(pts[0].eq - derived) < 1e-9,
+    `curve anchor ${pts[0].eq} vs derived ${derived} — two walks, two truths`);
+});

--- a/extension/test/freshlaunch.test.js
+++ b/extension/test/freshlaunch.test.js
@@ -234,6 +234,7 @@ function runFreshLaunch(opts) {
   const nodesById = {};
   const messages = [];       // postMessage traffic to the MAIN-world bridge
   let resolveCalls = 0;
+  let prewatchCalls = 0;
   let jupiterCalls = 0;
   let attempts = 0;
   let lastAttemptAt = -1;
@@ -368,6 +369,15 @@ function runFreshLaunch(opts) {
           if (msg.type === 'pt_refresh') return R.refresh(msg.token);
           if (msg.type === 'pt_sol_usd') return R.solUsd();
           if (msg.type === 'pt_batch_prices') return R.batchPrices(msg.mints);
+          if (msg.type === 'pt_onchain_prewatch') {
+            // The chain probe. Tests drive it with options.onchainPrewatch so
+            // they can model a throttled/failing RPC (D-60) as distinct from
+            // "this coin genuinely has no pool".
+            prewatchCalls += 1;
+            const h = options.onchainPrewatch;
+            if (typeof h === 'function') return Promise.resolve(h(msg, prewatchCalls));
+            return Promise.resolve(null);
+          }
           return Promise.resolve({});
         },
         onMessage: { addListener: () => {} },
@@ -419,6 +429,7 @@ function runFreshLaunch(opts) {
     // Each teardown clears the chart — this is the flashing signal.
     teardowns: () => messages.filter((m) => m === 'paper-marker-clear').length,
     resolveCalls: () => resolveCalls,
+    prewatchCalls: () => prewatchCalls,
     jupiterCalls: () => jupiterCalls,
     attempts: () => attempts,
     priceText: () => (nodesById['pt-price'] || {}).textContent,
@@ -1003,4 +1014,85 @@ test('D-39: the click acquisition leads with the board row price, and arming is 
   assert.doesNotMatch(content, /Buy armed — fires the instant the first quote lands/,
     'the arming narration toast must be gone forever');
   assert.doesNotMatch(content, /Buy armed/, 'no arming narration may exist in any form');
+});
+
+test('D-60: a failed chain probe does not permanently strand the coin', async () => {
+  // newws300, 2026-08-24: "'Fetching live price' 100% of the time ... can
+  // only buy once coin has aged like 20-30 seconds."
+  //
+  // The chain knows a launch instantly (a live probe prices an 8-second-old
+  // coin in ~150ms), so a panel still waiting 20-30s is not waiting on the
+  // chain — it is waiting on an AGGREGATOR to index the coin, which is what
+  // happens when the chain probe has been switched off. prewatchPending
+  // latched `prewatchedAddress` before the probe resolved and never cleared
+  // it on failure, so ONE throttled RPC read disabled the fast path for the
+  // whole life of that token.
+  let calls = 0;
+  const ov = runFreshLaunch({
+    // No aggregator ever answers — this coin is younger than every indexer,
+    // which is the whole point. The chain is the only source that knows it.
+    resolvePrice: null,
+    onchainPrewatch: (msg, n) => {
+      calls = n;
+      // First probe fails the way a throttled public endpoint does: no answer.
+      if (n === 1) return null;
+      // The chain was fine all along.
+      return {
+        mint: msg.mint || 'So1anaFreshMint111111111111111111111111111',
+        pool: 'Poo1Fresh1111111111111111111111111111111111',
+        poolKind: 'pump-curve',
+        priceNative: 3.2e-8,
+        decimals: 6,
+      };
+    },
+  });
+  await ov.settle();
+  // Step the clock in detect-loop increments and record WHEN the price lands.
+  let pricedAfterMs = null;
+  for (let elapsed = 0; elapsed < 8000 && pricedAfterMs === null; elapsed += 400) {
+    await ov.advance(400);
+    const shown = String(ov.priceText() || '');
+    if (shown && !/Fetching|^—$/.test(shown)) pricedAfterMs = elapsed + 400;
+  }
+
+  // The property that matters is not "the probe ran again" — the harness
+  // re-navigates and that would pass by accident. It is HOW LONG the coin
+  // sits unpriced after a transient failure.
+  //
+  // There is a slow safety-net re-probe at `pendingAttempts % 5` on the
+  // 800ms detect loop: a retry only every ~4s, first firing on the 5th
+  // attempt. That net is why a stranded coin eventually recovered at all,
+  // and its cadence is the reported "20-30 seconds". Releasing the latch on
+  // failure lets the very next detect pass re-probe instead, so the coin is
+  // priced within a pass or two rather than several seconds later.
+  assert.ok(calls >= 2, `the probe must be retried after a failure; ran ${calls}x`);
+  assert.ok(pricedAfterMs !== null,
+    'the coin must end up priced once the chain answers');
+  assert.ok(pricedAfterMs <= 800,
+    `the retry must be prompt, not the ~4s safety net; took ${pricedAfterMs}ms`);
+});
+
+test('D-60: the click asks the chain whenever no source priced it', () => {
+  // The chain probe inside acquireClickQuote was gated on `token.pending`,
+  // which means "the panel has never had a price". But the block it guards
+  // already knows the stronger fact: NO source produced a usable price for
+  // this click. A token whose pending flag was cleared without a live price
+  // could therefore never reach the chain — the one source that always knows.
+  const content = fsMod.readFileSync(pathMod.join(__dirname, '..', 'content.js'), 'utf8');
+  const fnStart = content.indexOf('async function acquireClickQuote');
+  assert.ok(fnStart !== -1, 'acquireClickQuote must exist');
+  const fnEnd = content.indexOf('\n  async function', fnStart + 10);
+  const fn = content.slice(fnStart, fnEnd === -1 ? fnStart + 4000 : fnEnd);
+
+  const probeIdx = fn.indexOf("R.onchainPrewatch({ pool: addr })");
+  assert.ok(probeIdx !== -1, 'the click must be able to probe the chain');
+
+  // The guard immediately above the probe must not require token.pending.
+  const guard = fn.slice(0, probeIdx);
+  const lastIf = guard.lastIndexOf('if (');
+  const condition = guard.slice(lastIf, guard.indexOf('{', lastIf));
+  assert.doesNotMatch(condition, /token\.pending/,
+    'the chain probe must not be gated on token.pending (D-60)');
+  assert.match(condition, /priceNative/,
+    'it stays gated on "no source produced a price", which is the real condition');
 });

--- a/extension/test/mcalerts.test.js
+++ b/extension/test/mcalerts.test.js
@@ -423,10 +423,32 @@ test('alert mints ride the batch request the positions bar already sends', () =>
 test('the chart on screen is judged too, not only the ones in the batch', () => {
   // The on-screen token is deliberately excluded from the batch poller, so
   // without this the one chart you are actually watching is the one that
-  // never pings. (N2's evaluatePendingBuys sits between them — both are
-  // tick-path judges; the order among them is not the property.)
-  assert.match(CONTENT, /evaluateChartOrders\(\);\s*\n\s*\/\/[^\n]*\n\s*evaluatePendingBuys\(\);\s*\n\s*\/\/[^\n]*\n(?:\s*\/\/[^\n]*\n)*\s*evaluateMcAlerts\(token\.mint, token\);/,
-    'the tick path must judge the on-screen token');
+  // never pings.
+  //
+  // Asserted as a PROPERTY of handlePageTick, not as source adjacency: the
+  // three tick-path judges must all be reachable on the tick that carries a
+  // price. The previous form pinned them to consecutive lines in one fixed
+  // order, which made a correct fix look like a regression — D-57 had to
+  // hoist evaluateChartOrders()/evaluatePendingBuys() ABOVE the duplicate-
+  // price early-return so a level armed between two identical prints is
+  // still judged, and the old regex failed purely on the reordering while
+  // the property it names held.
+  const tick = sliceFunction(CONTENT, 'handlePageTick');
+  for (const judge of ['evaluateChartOrders()', 'evaluatePendingBuys()', 'evaluateMcAlerts(token.mint, token)']) {
+    assert.ok(tick.includes(judge),
+      `the tick path must judge the on-screen token: ${judge} missing from handlePageTick`);
+  }
+  // The alert judge is the one that must survive the duplicate-price return,
+  // because a repeat print is not a new market-cap level. The order judges
+  // must NOT: see D-57.
+  const bail = tick.indexOf('if (token.priceNative === oldNative) return;');
+  assert.notEqual(bail, -1, 'the duplicate-tick early-return must still exist');
+  assert.ok(tick.indexOf('evaluateChartOrders()') < bail,
+    'armed levels must be judged BEFORE the duplicate-price early-return (D-57) — '
+    + 'a stop armed between two identical prints must not wait for the next distinct price');
+  assert.ok(tick.indexOf('evaluatePendingBuys()') < bail,
+    'armed limit buys ride the same rule as armed levels (D-57)');
+
   assert.match(CONTENT, /evaluateMcAlerts\(token\.mint, token\);\s*\n\s*\/\/ C-01/,
     'an adopted resolver quote must judge it too');
 });

--- a/extension/test/migratedprice.test.js
+++ b/extension/test/migratedprice.test.js
@@ -196,3 +196,23 @@ test('the deepest SOL pool wins when a coin has more than one (D-59)', async () 
   assert.equal(await feed._findGraduatedPool(MINT), POOL,
     'the pool with real depth is the one a fill would touch, not the first one listed');
 });
+
+test('one lookup never pays for two program scans (Devin review, PR #77)', async () => {
+  // getProgramAccounts is the heaviest read this module makes and the public
+  // endpoint is keyless. A pump-suffixed mint whose curve is NOT live used to
+  // run the scan in the pump branch AND again in the mint-facts branch.
+  //
+  // The case the review found: the scan comes back EMPTY (no pool indexed
+  // yet) but the mint account IS visible, so execution reaches the
+  // mint-facts branch carrying the same address.
+  const MINT_B64 = 'AQAAAAaJgY9K1B/CG8UcLbCKrDdHDVpXpDDmMBqLLnJPPRT6AICWmAsAAAAGAQEAAAAGiYGPStQfwhvFHC2wiqw3Rw1aV6Qw5jAaiy5yTz0U+g==';
+  const { pool, seen } = fakePool(
+    { [MINT]: { owner: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA', data: [MINT_B64, 'base64'] } },
+    { gpa: [] },                   // no pool on chain yet
+  );
+  const feed = loadFeedWith(pool);
+
+  await feed.prewatch({ mint: MINT });
+
+  assert.equal(seen.gpa, 1, `the program scan must run once; ran ${seen.gpa}x`);
+});

--- a/extension/test/migratedprice.test.js
+++ b/extension/test/migratedprice.test.js
@@ -1,0 +1,198 @@
+/* A graduated pump.fun coin must still get a LIVE PRICE (D-59).
+ *
+ * Community reports, 2026-08-24:
+ *   cheng.4848    "it is difficult to make purchases in time after the
+ *                  currency migration"
+ *   ark_trades13  "the "Fetching live price…" thing happens to me too, but
+ *                  only on migrated tokens"
+ *
+ * Root cause: a pump.fun bonding curve goes `complete: true` when the coin
+ * graduates and STOPS carrying a price — prewatchPool refuses it by design
+ * ("migrated: the resolver path owns it"). But the resolver path only ever
+ * read the MINT account, which yields identity and supply and no price at
+ * all. So for the minutes right after migration — the single most tradable
+ * window a memecoin has — PaperTrench had no on-chain price and sat on
+ * "Fetching live price…" until an aggregator got around to indexing the new
+ * pool.
+ *
+ * The coin is not unpriceable. It has migrated INTO a PumpSwap AMM pool
+ * (program pAMMBay6…), which is a plain constant-product pool PaperTrench
+ * already has a verified decoder for. It simply was never looked up.
+ *
+ * These fixtures are REAL mainnet bytes, captured 2026-08-25 from the
+ * migrated coin vH6HyoNG…pump ("中国石化") and its pump.fun-reported pool
+ * 7vEpDRUy…, so the production decoders run against production data.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const Feed = require('../onchain-feed.js');
+const O = require('../onchain.js');
+
+const MINT = 'vH6HyoNGaWvKHsK1ENNCqFuZhLfR1cpw46TFeGVpump';
+const POOL = '7vEpDRUy5PSiBJNdBiiuMxN7KbM7HA3fxhFvgrjRrEnV';
+const PUMP_AMM = 'pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA';
+const WSOL = 'So11111111111111111111111111111111111111112';
+
+const POOL_B64 = '8ZptBBGxbbz/AAB6Q1C2SE89KA7SMGRjsC0xmydsAww4ybhZq8eLDq91Xg2l+jGnfH5sq/B/loP1vNqbnbVXwQB7/ZrAuoz/r3cvBpuIV/6rgYT7aH9jRhjANdrEOdwa6ztVmKDwAAAAAAH7k4VEaTb9JD2KUFTUF0k578Q/o9f2Q4LOT2eALEgelXKkRFjunv3VGc7uoA8/jzdGj5PGfiHlhH+GkSetr9M/pYZCpKYOprMDyFkXXeytdgHE0HHlS41edz8YkLYNIyiAQ2tZ0AMAANtrCTeFrtufaX+xVr/2hO8KczlnuxLsd5jujBQFnuDEAADJQR4YBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==';
+const BASE_VAULT_B64 = 'DaX6Mad8fmyr8H+Wg/W82pudtVfBAHv9msC6jP+vdy9myYYmPr/nVRSFb+6zsOz3xX63sYItOsKEBbLws0QBSjUEfqYQMQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgcAAAA=';
+const QUOTE_VAULT_B64 = 'BpuIV/6rgYT7aH9jRhjANdrEOdwa6ztVmKDwAAAAAAFmyYYmPr/nVRSFb+6zsOz3xX63sYItOsKEBbLws0QBShjv2+1HAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQEAAADwHR8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+/* ---------- the decoder, against real bytes ---------- */
+
+test('the PumpSwap pool layout decodes a real mainnet pool (D-59)', () => {
+  const decoded = O.decodePumpSwapPool(O.bytesFromBase64(POOL_B64));
+  assert.ok(decoded, 'a 301-byte PumpSwap pool must decode');
+  // Every one of these is what pump.fun's own API reports for this coin.
+  assert.equal(decoded.baseMint, MINT, 'base mint sits at offset 43');
+  assert.equal(decoded.quoteMint, WSOL, 'quote mint sits at offset 75');
+  assert.equal(decoded.baseVault, '8iWkrWUntx3iRxyk59p5mcNnvF6qwER21xXHDsFTgHJn');
+  assert.equal(decoded.quoteVault, 'C991coUvgVFfHhhkaJUhPEdz6CYGk1yJrmHNPQdRp3Hh');
+});
+
+test('a graduated pool is classified by the decoder we already trust (D-59)', () => {
+  // The whole fix rests on this: PumpSwap is cp-vaults, a kind the feed
+  // already watches and prices. If this ever stops being true the pool would
+  // be discovered and then silently refused.
+  assert.equal(O.poolKindForOwner(PUMP_AMM), 'cp-vaults');
+});
+
+test('a Token-2022 base vault reads with the same decoder as a classic one (D-59)', () => {
+  // Graduated pools routinely pair a 170-byte Token-2022 base vault with a
+  // 165-byte classic SPL quote vault. Both share the prefix decodeTokenAccount
+  // reads; assuming 165 everywhere would drop the base leg and the price.
+  const base = O.decodeTokenAccount(O.bytesFromBase64(BASE_VAULT_B64));
+  const quote = O.decodeTokenAccount(O.bytesFromBase64(QUOTE_VAULT_B64));
+  assert.ok(base && quote, 'both vault legs must decode');
+  assert.equal(base.mint, MINT);
+  assert.equal(quote.mint, WSOL);
+  assert.ok(base.amount > 0 && quote.amount > 0, 'a live pool holds both legs');
+});
+
+/* ---------- the lookup, driving the real function ---------- */
+
+/**
+ * Stand in for the RPC pool. Only the reads findGraduatedPool actually makes
+ * are answered; anything else throws, so a test can never pass on a call the
+ * production path did not make.
+ */
+function fakePool(accounts, opts) {
+  const seen = { gpa: 0, reads: [] };
+  const pool = {
+    setUserEndpoint() {},
+    call(method, params) {
+      if (method === 'getProgramAccounts') {
+        seen.gpa++;
+        seen.gpaProgram = params[0];
+        seen.gpaFilters = params[1] && params[1].filters;
+        return Promise.resolve((opts && opts.gpa) || []);
+      }
+      if (method === 'getMultipleAccounts') {
+        seen.reads.push(params[0]);
+        return Promise.resolve({
+          context: { slot: 1000 },
+          value: params[0].map((a) => accounts[a] || null),
+        });
+      }
+      throw new Error('unexpected RPC call in this test: ' + method);
+    },
+  };
+  return { pool, seen };
+}
+
+const POOL_ACCOUNT = { owner: PUMP_AMM, data: [POOL_B64, 'base64'] };
+
+/**
+ * Load a FRESH copy of the feed with a fake RPC pool in place.
+ *
+ * The module binds its pool at load time (`self.PTRpcPool`), which is the
+ * right design for production and means a test must install the fake before
+ * the require rather than reaching inside afterwards. Clearing the cache
+ * entry keeps each case isolated.
+ */
+function loadFeedWith(pool) {
+  const feedPath = require.resolve('../onchain-feed.js');
+  const had = Object.prototype.hasOwnProperty.call(globalThis, 'PTRpcPool');
+  const prev = globalThis.PTRpcPool;
+  const prevSelf = globalThis.self;
+  globalThis.self = globalThis;
+  globalThis.PTRpcPool = pool;
+  delete require.cache[feedPath];
+  try {
+    return require('../onchain-feed.js');
+  } finally {
+    delete require.cache[feedPath];
+    if (had) globalThis.PTRpcPool = prev; else delete globalThis.PTRpcPool;
+    if (prevSelf === undefined) delete globalThis.self; else globalThis.self = prevSelf;
+  }
+}
+
+test('the graduated pool is found by asking the chain which pool holds the mint (D-59)', async () => {
+  const { pool, seen } = fakePool(
+    { [POOL]: POOL_ACCOUNT },
+    { gpa: [{ pubkey: POOL }] }
+  );
+  const feed = loadFeedWith(pool);
+  const found = await feed._findGraduatedPool(MINT);
+  assert.equal(found, POOL, 'the migrated coin resolves to its real pool');
+  // The filter must be an indexed memcmp on the base-mint offset — a scan of
+  // every pool on the program would be far too expensive to run on a click.
+  assert.equal(seen.gpaProgram, PUMP_AMM);
+  assert.deepEqual(seen.gpaFilters, [{ memcmp: { offset: 43, bytes: MINT } }]);
+});
+
+test('a pool quoted in something other than SOL is refused (D-59)', async () => {
+  // The feed prices in SOL end to end. A USDC-quoted pool would decode
+  // perfectly and mean a completely different number.
+  const bytes = O.bytesFromBase64(POOL_B64);
+  const usdc = O.b58decode('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v');
+  bytes.set(usdc, 75);
+  const usdcPool = { owner: PUMP_AMM, data: [Buffer.from(bytes).toString('base64'), 'base64'] };
+
+  const { pool } = fakePool({ [POOL]: usdcPool }, { gpa: [{ pubkey: POOL }] });
+  const feed = loadFeedWith(pool);
+  assert.equal(await feed._findGraduatedPool(MINT), null,
+    'a non-SOL pool must never be adopted as the price');
+});
+
+test('a pool owned by an unverified program is refused (D-59)', async () => {
+  // gPA answered, but the account is not a program we have a decoder for.
+  const impostor = { owner: 'StakeConfig11111111111111111111111111111111', data: [POOL_B64, 'base64'] };
+  const { pool } = fakePool({ [POOL]: impostor }, { gpa: [{ pubkey: POOL }] });
+  const feed = loadFeedWith(pool);
+  assert.equal(await feed._findGraduatedPool(MINT), null);
+});
+
+test('no pool on chain means no invented answer (D-59)', async () => {
+  const { pool } = fakePool({}, { gpa: [] });
+  const feed = loadFeedWith(pool);
+  assert.equal(await feed._findGraduatedPool(MINT), null);
+});
+
+test('the deepest SOL pool wins when a coin has more than one (D-59)', async () => {
+  // Dust pools exist. Quoting one would show a price nobody can trade at.
+  // The thin pool is returned FIRST by gPA, so a "take the first candidate"
+  // implementation would pick it — the depth comparison is what must decide.
+  const SECOND = '5rFQRVChhZbPvUJvLSGqTVJfLdeTFV7CxczV6NNvXbLK';
+  const THIN_VAULT = 'C991coUvgVFfHhhkaJUhPEdz6CYGk1yJrmHNPQdRp3Ha';
+
+  // A real quote-vault account, rewritten to hold dust instead of 304 SOL.
+  const dustBytes = O.bytesFromBase64(QUOTE_VAULT_B64);
+  for (let i = 0; i < 8; i++) dustBytes[64 + i] = 0;
+  dustBytes[64] = 1; // 1 lamport: non-zero, so it is a live pool, just empty
+
+  const thinPool = O.bytesFromBase64(POOL_B64);
+  thinPool.set(O.b58decode(THIN_VAULT), 171);
+
+  const SPL = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA';
+  const accounts = {
+    [POOL]: POOL_ACCOUNT,
+    [SECOND]: { owner: PUMP_AMM, data: [Buffer.from(thinPool).toString('base64'), 'base64'] },
+    C991coUvgVFfHhhkaJUhPEdz6CYGk1yJrmHNPQdRp3Hh: { owner: SPL, data: [QUOTE_VAULT_B64, 'base64'] },
+    [THIN_VAULT]: { owner: SPL, data: [Buffer.from(dustBytes).toString('base64'), 'base64'] },
+  };
+  const { pool } = fakePool(accounts, { gpa: [{ pubkey: SECOND }, { pubkey: POOL }] });
+  const feed = loadFeedWith(pool);
+  assert.equal(await feed._findGraduatedPool(MINT), POOL,
+    'the pool with real depth is the one a fill would touch, not the first one listed');
+});

--- a/extension/test/orderrace.test.js
+++ b/extension/test/orderrace.test.js
@@ -1,0 +1,313 @@
+/* Chart-order CAS race — jb's 2026-08-18 report (#bug-reports, 11:10 UTC):
+ * "took clips from a trade and fully exited but on my paper equity it shows
+ * +9.109 sol when its supposed to be +0.091".
+ *
+ * Mechanism under test: two chart tabs on the same token, one armed TP
+ * level. Both tabs' tick loops see the trigger; both call fireChartOrder.
+ * The CAS loser's remutate re-checks only the POSITION — not whether the
+ * winning context already spent the order — so it re-applies E.sell on the
+ * adopted base. The clip is booked twice: cash credited twice, the round's
+ * returnedSol double-counts, paper equity inflates by a whole extra set of
+ * clip proceeds (jb: +0.091 true + ~9.0 duplicated clips = +9.109).
+ *
+ * Asymmetric precedent: firePendingBuy's remutate re-checks the armed buy
+ * still exists ("if (!armed) return") before re-applying. The order fire
+ * must do the same. This test pins that contract.
+ *
+ * F-59 - shipped in v3.13.4
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+global.window = global.window || {};
+const Q = require('../quote.js');
+const E = require('../engine.js');
+
+const NEW_MINT = '3PTQpne3b7kjJEvDYDMBHSuRjTDUh6HSin2xMyW3pump';
+const SOL_USD = 200;
+
+function jupiterPayload() {
+  return [
+    {
+      id: NEW_MINT,
+      name: 'Bark',
+      symbol: 'BARK',
+      usdPrice: 0.0000021,
+      mcap: 2100.12,
+      liquidity: 2204.47,
+      firstPool: { id: 'PooLAddress1111111111111111111111111111111', createdAt: '2026-08-01T04:00:00Z' },
+    },
+    {
+      id: Q.WSOL_MINT,
+      name: 'Wrapped SOL',
+      symbol: 'SOL',
+      usdPrice: SOL_USD,
+      firstPool: { id: 'sol', createdAt: '2020-01-01T00:00:00Z' },
+    },
+  ];
+}
+
+/* ---------------- harness (faithful clone of freshlaunch.test.js) ---------------- */
+
+function runOrderRace(opts) {
+  const options = opts || {};
+  const timers = [];
+  let now = 5_000_000;
+  const nodesById = {};
+  const messages = [];
+  const winListeners = {};
+
+  function makeNode(tag) {
+    const node = {
+      tag, style: { setProperty() {}, removeProperty() {} }, dataset: {},
+      children: [], childNodes: [], _fields: {},
+      classList: {
+        _s: new Set(),
+        add(...c) { c.forEach((x) => this._s.add(x)); },
+        remove(...c) { c.forEach((x) => this._s.delete(x)); },
+        toggle(c, on) { if (on === undefined) { this._s.has(c) ? this._s.delete(c) : this._s.add(c); } else if (on) this._s.add(c); else this._s.delete(c); },
+        contains(c) { return this._s.has(c); },
+      },
+      set textContent(v) { this._t = v; },
+      get textContent() { return this._t || ''; },
+      set innerHTML(v) {
+        this._h = v;
+        const re = /data-f="([a-z]+)"/g; let m;
+        while ((m = re.exec(v))) { const c = makeNode('span'); c.dataset.f = m[1]; this._fields[m[1]] = c; }
+      },
+      get innerHTML() { return this._h || ''; },
+      appendChild(c) { const i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); if (c._parent && c._parent !== this) c._parent.removeChild(c); c._parent = this; this.children.push(c); this.childNodes = this.children; return c; },
+      removeChild(c) { const i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); if (c._parent === this) c._parent = null; },
+      remove() { if (this._parent) this._parent.removeChild(this); },
+      setAttribute() {}, getAttribute() { return null; },
+      addEventListener(type, fn) {
+        if (!this._listeners) this._listeners = {};
+        (this._listeners[type] = this._listeners[type] || []).push(fn);
+      },
+      click() { ((this._listeners && this._listeners.click) || []).forEach((fn) => fn()); },
+      querySelectorAll() { return []; },
+      value: '',
+      querySelector(sel) {
+        const m = /data-f="([a-z]+)"/.exec(sel);
+        if (m && this._fields[m[1]]) return this._fields[m[1]];
+        return makeNode('span');
+      },
+      getBoundingClientRect() { return { top: 0 }; },
+      attachShadow() { return shadowRoot; },
+      focus() {}, closest() { return null; },
+      get offsetWidth() { return 1; },
+    };
+    return node;
+  }
+
+  const shadowRoot = {
+    set innerHTML(v) { this._h = v; }, get innerHTML() { return this._h || ''; },
+    getElementById(id) { if (!nodesById[id]) nodesById[id] = makeNode('div'); return nodesById[id]; },
+    querySelector() { return makeNode('div'); }, querySelectorAll() { return []; }, appendChild() {},
+  };
+
+  const doc = {
+    readyState: 'complete', hidden: false, title: 'new coin',
+    body: Object.assign(makeNode('body'), { innerText: '' }),
+    documentElement: makeNode('html'), head: makeNode('head'),
+    createElement: (t) => makeNode(t),
+    getElementById: () => null, querySelector: () => null, querySelectorAll: () => [],
+    addEventListener: () => {}, createTreeWalker: () => ({ nextNode: () => null }),
+  };
+
+  const url = `https://trade.padre.gg/trade/solana/${NEW_MINT}`;
+  const parsed = new URL(url);
+  const win = {
+    addEventListener: (type, fn) => {
+      if (type === 'message') (winListeners.message = winListeners.message || []).push(fn);
+    },
+    removeEventListener: () => {},
+    postMessage: (msg) => { if (msg && msg.source === 'papertrench-content') messages.push(msg.type); },
+    location: { href: url, hostname: parsed.hostname, pathname: parsed.pathname, search: parsed.search },
+    getComputedStyle: () => ({ right: '18px', top: '84px' }),
+    confirm: () => true,
+  };
+  win.window = win;
+
+  // The single source of truth for wallet state, held by the fake worker.
+  let workerState = null;
+  let commitLog = [];
+  let staleReplies = options.staleReplies || [];
+
+  const storage = { pt_settings: E.defaultSettings() };
+
+  const sandbox = {
+    window: win, self: win, document: doc, location: win.location, console,
+    URLSearchParams, URL,
+    AbortController: function () { this.signal = {}; this.abort = () => {}; },
+    MutationObserver: function () { this.observe = () => {}; this.disconnect = () => {}; },
+    TextDecoder: function () { this.decode = () => ''; },
+    ResizeObserver: function () { this.observe = () => {}; this.disconnect = () => {}; },
+    Set, Map, WeakSet, WeakMap, Promise, JSON, Math, Number, String, Array, Object,
+    Boolean, RegExp, Error, isNaN, parseInt, parseFloat, Infinity, NaN,
+    Date: Object.assign(function () {}, { now: () => now, parse: Date.parse }),
+    setTimeout: (fn, ms) => { timers.push({ fn, at: now + (ms || 0) }); return timers.length; },
+    clearTimeout: () => {}, clearInterval: (id) => { if (timers[id - 1]) timers[id - 1].dead = true; },
+    setInterval: (fn, ms) => { timers.push({ fn, at: now + ms, every: ms }); return timers.length; },
+    fetch: (u) => {
+      const s = String(u);
+      if (s.includes('jup.ag')) return Promise.resolve({ ok: true, status: 200, json: async () => jupiterPayload() });
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ pairs: null }) });
+    },
+    chrome: {
+      runtime: {
+        id: 'papertrench-test',
+        getURL: (p) => 'x/' + p,
+        sendMessage: (msg) => {
+          if (msg.type === 'pt_attest_append') return Promise.resolve({ ok: true, seq: 0, head: 'pt-test-head' });
+          // The worker side of the CAS: compare-and-swap on seq.
+          if (msg.type === 'pt_state_commit') {
+            const expected = Number(msg.expectedSeq) || 0;
+            const currentSeq = workerState ? (Number(workerState.seq) || 0) : 0;
+            const forced = !!msg.force;
+            if (forced || currentSeq === expected) {
+              workerState = msg.state;
+              commitLog.push({ ok: true, forced, seq: msg.state.seq });
+              return Promise.resolve({ ok: true });
+            }
+            // Hostile: answer stale, with the winner's state attached. The
+            // test's staleReplies hook decides what the "other tab" did.
+            const hostile = staleReplies.length ? staleReplies.shift() : null;
+            commitLog.push({ ok: false, stale: true });
+            return Promise.resolve({ ok: false, reason: 'stale', current: hostile ? hostile(workerState) : workerState });
+          }
+          if (msg.type === 'pt_state_get') {
+            return Promise.resolve({ ok: true, state: workerState });
+          }
+          const R = win.PaperTrenchResolver;
+          if (!R) return Promise.resolve({});
+          if (msg.type === 'pt_resolve') return R.resolve(msg.address);
+          if (msg.type === 'pt_refresh') return R.refresh(msg.token);
+          if (msg.type === 'pt_sol_usd') return R.solUsd();
+          if (msg.type === 'pt_batch_prices') return R.batchPrices(msg.mints);
+          return Promise.resolve({});
+        },
+        onMessage: { addListener: () => {} },
+        openOptionsPage: () => {},
+      },
+      storage: {
+        local: {
+          get: (keys, cb) => { const out = {}; for (const k of (Array.isArray(keys) ? keys : [keys])) if (k in storage) out[k] = storage[k]; if (cb) cb(out); return Promise.resolve(out); },
+          set: (obj, cb) => { Object.assign(storage, obj); if (cb) cb(); return Promise.resolve(); },
+        },
+        onChanged: { addListener: () => {} },
+      },
+      tabs: { query: () => Promise.resolve([{ id: 1 }]), sendMessage: () => Promise.resolve() },
+    },
+    NodeFilter: { SHOW_TEXT: 4 },
+  };
+
+  const ctx = vm.createContext(sandbox);
+  const ROOT = path.join(__dirname, '..');
+  const manifest = JSON.parse(fs.readFileSync(path.join(ROOT, 'manifest.json'), 'utf8'));
+  const entry = manifest.content_scripts.find((cs) => (cs.js || []).includes('content.js'));
+  for (const f of entry.js) {
+    vm.runInContext(fs.readFileSync(path.join(ROOT, f), 'utf8'), ctx, { filename: f });
+  }
+
+  async function advance(ms, step) {
+    step = step || 100;
+    for (let e = 0; e < ms; e += step) {
+      now += step;
+      for (let i = 0; i < timers.length; i++) {
+        const t = timers[i];
+        if (t.dead || t.at > now) continue;
+        if (t.every) t.at = now + t.every; else t.dead = true;
+        try { t.fn(); } catch (err) { /* asserted below */ }
+      }
+      for (let k = 0; k < 8; k++) await Promise.resolve();
+    }
+  }
+
+  async function settle() {
+    for (let k = 0; k < 400; k++) await Promise.resolve();
+  }
+
+  return {
+    advance,
+    settle,
+    emitTick: (payload) => {
+      for (const fn of (winListeners.message || [])) {
+        fn({ source: win, origin: null, data: { source: 'papertrench-bridge', type: 'tick', payload } });
+      }
+    },
+    seed: (s) => {
+      storage[E.STORAGE_KEYS.state] = JSON.parse(JSON.stringify(s));
+      workerState = JSON.parse(JSON.stringify(s));
+    },
+    workerState: () => workerState,
+    commitLog: () => commitLog,
+    storage: () => storage,
+    sandbox,
+  };
+}
+
+/* ---------------- the race ---------------- */
+
+test('a lost CAS race must not double-book an order clip (jb 2026-08-18)', async () => {
+  const ov = runOrderRace({
+    staleReplies: [
+      // What the winning tab's state looks like when it lands: same base,
+      // order already fired and removed, clip already booked, seq bumped.
+      (winner) => {
+        const s = JSON.parse(JSON.stringify(winner || {}));
+        return s;
+      },
+    ],
+  });
+  await ov.settle();
+
+  // Seed the wallet exactly as a prior session left it: a 1 SOL position in
+  // BARK bought at 1e-9, one TP armed at 2x for 50% (a clip).
+  const base = E.resetState(E.defaultSettings());
+  const filled = E.buy(base, E.defaultSettings(), {
+    ts: 4_000_000, mint: NEW_MINT, site: 'padre',
+    solAmount: 1, priceNative: 1e-9, priceUsd: 1e-9 * SOL_USD,
+  });
+  const order = E.addOrder(base, NEW_MINT, { kind: 'tp', triggerPrice: 2e-9, sizePct: 50 }, 1e-9, 4_100_000);
+  ov.seed(base);
+
+  // The chart sees 2x - the TP trigger condition.
+  ov.emitTick({ candidates: [{ value: 2.2e-9, unit: 'native' }] });
+  await ov.settle();
+  await ov.advance(2000);
+
+  const st = ov.workerState();
+  assert.ok(st, 'state must exist after the race');
+  const sells = (st.journal || []).filter((t) => t.side === 'sell');
+  const tpSells = sells.filter((t) => t.orderKind === 'tp');
+  assert.equal(tpSells.length, 1,
+    `the clip must be booked exactly once across the CAS race; got ${tpSells.length}`);
+  const dupProceeds = tpSells.reduce((s, t) => s + t.solNet, 0);
+  assert.ok(dupProceeds > 0 && dupProceeds < 2,
+    `one honest 50% clip at ~2x on a 1 SOL position nets ~1 SOL; got ${dupProceeds}`);
+}, { timeout: 30000 });
+
+test('control: with no race the clip books once (sanity)', async () => {
+  const ov = runOrderRace({});
+  await ov.settle();
+
+  const base = E.resetState(E.defaultSettings());
+  E.buy(base, E.defaultSettings(), {
+    ts: 4_000_000, mint: NEW_MINT, site: 'padre',
+    solAmount: 1, priceNative: 1e-9, priceUsd: 1e-9 * SOL_USD,
+  });
+  E.addOrder(base, NEW_MINT, { kind: 'tp', triggerPrice: 2e-9, sizePct: 50 }, 1e-9, 4_100_000);
+  ov.seed(base);
+
+  ov.emitTick({ candidates: [{ value: 2.2e-9, unit: 'native' }] });
+  await ov.settle();
+  await ov.advance(2000);
+
+  const st = ov.workerState();
+  const tpSells = (st.journal || []).filter((t) => t.side === 'sell' && t.orderKind === 'tp');
+  assert.equal(tpSells.length, 1, `control: one fire, one clip; got ${tpSells.length}`);
+}, { timeout: 30000 });

--- a/extension/test/orderrace.test.js
+++ b/extension/test/orderrace.test.js
@@ -80,6 +80,10 @@ function runOrderRace(opts) {
       },
       get innerHTML() { return this._h || ''; },
       appendChild(c) { const i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); if (c._parent && c._parent !== this) c._parent.removeChild(c); c._parent = this; this.children.push(c); this.childNodes = this.children; return c; },
+      // renderOrderList() builds each row with the variadic ParentNode.append();
+      // a stub carrying only appendChild threw mid-render, so the order list
+      // never painted and the clip never fired under test.
+      append(...cs) { cs.forEach((c) => this.appendChild(c)); return undefined; },
       removeChild(c) { const i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); if (c._parent === this) c._parent = null; },
       remove() { if (this._parent) this._parent.removeChild(this); },
       setAttribute() {}, getAttribute() { return null; },
@@ -138,6 +142,8 @@ function runOrderRace(opts) {
   let staleReplies = options.staleReplies || [];
 
   const storage = { pt_settings: E.defaultSettings() };
+  // Listeners registered on chrome.storage.onChanged by the content script.
+  const storeListeners = [];
 
   const sandbox = {
     window: win, self: win, document: doc, location: win.location, console,
@@ -198,7 +204,11 @@ function runOrderRace(opts) {
           get: (keys, cb) => { const out = {}; for (const k of (Array.isArray(keys) ? keys : [keys])) if (k in storage) out[k] = storage[k]; if (cb) cb(out); return Promise.resolve(out); },
           set: (obj, cb) => { Object.assign(storage, obj); if (cb) cb(); return Promise.resolve(); },
         },
-        onChanged: { addListener: () => {} },
+        // Faithful to the real extension: an external write reaches the panel
+        // ONLY through this listener (content.js adoptState). A stub that
+        // registers nothing means seed() can never be observed, so a test
+        // seeding a wallet after mount silently exercises an empty wallet.
+        onChanged: { addListener: (fn) => storeListeners.push(fn), removeListener: () => {} },
       },
       tabs: { query: () => Promise.resolve([{ id: 1 }]), sendMessage: () => Promise.resolve() },
     },
@@ -240,8 +250,16 @@ function runOrderRace(opts) {
       }
     },
     seed: (s) => {
+      const oldValue = storage[E.STORAGE_KEYS.state];
       storage[E.STORAGE_KEYS.state] = JSON.parse(JSON.stringify(s));
       workerState = JSON.parse(JSON.stringify(s));
+      // Chrome delivers a STRUCTURED CLONE to onChanged (F-41) — clone here
+      // too, or the panel's identity check treats the seed as its own write
+      // and never adopts it.
+      const newValue = JSON.parse(JSON.stringify(s));
+      for (const fn of storeListeners) {
+        fn({ [E.STORAGE_KEYS.state]: { oldValue, newValue } }, 'local');
+      }
     },
     workerState: () => workerState,
     commitLog: () => commitLog,
@@ -310,4 +328,57 @@ test('control: with no race the clip books once (sanity)', async () => {
   const st = ov.workerState();
   const tpSells = (st.journal || []).filter((t) => t.side === 'sell' && t.orderKind === 'tp');
   assert.equal(tpSells.length, 1, `control: one fire, one clip; got ${tpSells.length}`);
+}, { timeout: 30000 });
+
+/* ---------------- D-57: the flat-feed stop ---------------- */
+
+/* Field class: "my stop never fired while the coin bled out" — bloodfortea
+ * 2026-08-19 ("buying low selling high doesnt count as profit, i made a
+ * minus 12% but should have been plus"), jb 2026-08-19 ("my buy just
+ * randomly disappears"), and the rug reports in #papertrench-reviews.
+ *
+ * Mechanism: evaluateChartOrders() ran ONLY from handlePageTick, and only
+ * AFTER the duplicate-price early-return. The armed SET, though, changes
+ * independently of the price — wallet state finishes loading after the
+ * first ticks land, or a level is dragged onto the chart between two
+ * identical prints. A feed repeating one number (a dead book, a rug where
+ * every tick is the same) then never produced a "new" price, so nothing
+ * ever asked whether the level had been crossed.
+ *
+ * This test seeds the wallet AFTER the crossing price is already on screen
+ * and then only ever repeats that same price. Under the old code the stop
+ * sits armed forever; the level must fire.
+ */
+test('a stop armed after the last price move still fires on a flat feed (D-57)', async () => {
+  const ov = runOrderRace({});
+  await ov.settle();
+  await ov.advance(1000);
+
+  // The panel is already holding a price: the resolver quote for this token
+  // (jupiterPayload, 0.0000021 USD at SOL=200 -> 1.05e-8 native). Nothing
+  // further will move it — this models the dead book / rug tape where every
+  // subsequent print repeats one number.
+  const SCREEN_NATIVE = 0.0000021 / SOL_USD;
+
+  const base = E.resetState(E.defaultSettings());
+  E.buy(base, E.defaultSettings(), {
+    ts: 4_000_000, mint: NEW_MINT, site: 'padre',
+    solAmount: 1, priceNative: SCREEN_NATIVE * 4, priceUsd: SCREEN_NATIVE * 4 * SOL_USD,
+  });
+  // Stop at half the entry — ALREADY crossed by the price on screen, and
+  // armed after the last price move, which is the whole defect.
+  E.addOrder(base, NEW_MINT, { kind: 'sl', triggerPrice: SCREEN_NATIVE * 2, sizePct: 100 },
+    SCREEN_NATIVE * 4, 4_100_000);
+  ov.seed(base);
+  await ov.settle();
+
+  // No new price ever arrives. Only the heartbeat runs.
+  await ov.advance(3000);
+
+  const st = ov.workerState();
+  const slSells = (st.journal || []).filter((t) => t.side === 'sell' && t.orderKind === 'sl');
+  assert.equal(slSells.length, 1,
+    `the stop must fire against the price already on screen; got ${slSells.length}`);
+  assert.ok(!st.positions[NEW_MINT],
+    'a 100% stop must close the position, not leave the bag open');
 }, { timeout: 30000 });

--- a/extension/test/quickbuy.test.js
+++ b/extension/test/quickbuy.test.js
@@ -185,11 +185,14 @@ test('row buys run the full fill pipeline and never navigate the row', () => {
   // F-56 widened it again: chip fills now run the same witness gate as
   // panel fills — an existing position anchors the check, a >2x divergent
   // candidate needs a vouching second source or the fill refuses.)
+  // F-61 widened it once more: a row-fed candidate with a missing/echoed
+  // mint gets ONE bounded prewatch probe to heal the key before commit —
+  // the stand-in stranding the 8/17 report chased (jb).
   assert.match(content, /async function fillRowBuy\(address, data, amount\)/,
     'the shared commit extractor exists (one commit path for click + armed flush)');
-  assert.match(content, /fillRowBuy[\s\S]{0,4200}E\.buy\(state, settings/,
+  assert.match(content, /fillRowBuy[\s\S]{0,5200}E\.buy\(state, settings/,
     'the extractor runs the engine buy');
-  assert.match(content, /fillRowBuy[\s\S]{0,4200}commitFill\(filled\.trade\)/,
+  assert.match(content, /fillRowBuy[\s\S]{0,5600}commitFill\(filled\.trade\)/,
     'the extractor appends the attestation chain');
   assert.match(content, /await fillRowBuy\(address, data, amount\);/,
     'the click path commits through the shared extractor');

--- a/extension/test/roundattribution.test.js
+++ b/extension/test/roundattribution.test.js
@@ -1,0 +1,116 @@
+/* Round-attribution lock for the 2026-08-18 community report (jb, Discord
+ * 11:10 UTC, #bug-reports): "took clips from a trade and fully exited but on
+ * my paper equity it shows +9.109 sol when its supposed to be +0.091".
+ *
+ * The exact-digit fit: a 1 SOL round that truly made +0.091 (9.109%) shows
+ * +9.109 — the prior round in the SAME mint had clipped out ~9.018 SOL, and
+ * closeRound() summed those clips into the new round's returnedSol.
+ *
+ * Mechanism (locked here): tradeInRound()'s same-mint fall-through matches
+ * ANY same-mint sell with ts >= pos.openedAt. Fill commits can be re-stamped
+ * ts: Date.now() when a dropped-fill CAS retry re-applies the trade late
+ * (the multi-tab race family fixed in v3.13.2) or when another context
+ * writes the fill before adopting the merged session. A prior round's clip
+ * that lands with a ts AFTER the re-entry buy's openedAt is then swallowed
+ * into the new round — its solNet counted a SECOND time, and the new round
+ * reports the prior round's winnings as its own.
+ *
+ * The fix: a fill already claimed by a CLOSED round (recorded in that
+ * round's tradeIds) can never be attributed to a newer round — claimed fills
+ * are excluded before the mint fall-through runs. The fresh-launch
+ * stand-in-mint case (F-51) is untouched: those fills belong to the OPEN
+ * position's own round and are claimed only when IT closes.
+ *
+ * Every expectation is derived from the inputs inside the test, per the
+ * engine suite's own doctrine.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+global.window = global.window || {};
+require('../engine.js');
+const E = global.window.PaperEngine;
+
+function freshSettings(over) {
+  return Object.assign(E.defaultSettings(), over || {});
+}
+
+/* jb's shape: round 1 clips out big, round 2 (same mint, re-entry) exits
+ * with a small true win. The lateLanded flag re-stamps round 1's clip sells
+ * with a ts AFTER round 2's buy — the dropped-fill retry shape. */
+function jbScenario(settings, lateLanded) {
+  const state = E.defaultState(settings);
+  const MINT = 'JbReentry';
+
+  // ROUND 1 — 1 SOL in at 1, clips at 3x / 5x / 6.5x (~9 SOL out)
+  E.buy(state, settings, {
+    ts: 1_800_000_000_000, mint: MINT, symbol: 'JB', site: 'test',
+    priceNative: 1, solAmount: 1,
+  });
+  const qty = 1; // priceNative 1 => qty 1 per SOL (fees simplify below)
+  E.sell(state, settings, { ts: 1_800_000_060_000, mint: MINT, qtyFraction: 0.3, priceNative: 3 });
+  E.sell(state, settings, { ts: 1_800_000_120_000, mint: MINT, qtyFraction: 0.3, priceNative: 5 });
+  const r1 = E.sell(state, settings, { ts: 1_800_000_180_000, mint: MINT, qtyFraction: 1, priceNative: 6.5 }).round;
+
+  // ROUND 2 — re-entry same mint; exits with a small TRUE win
+  const buyTs = 1_800_000_240_000;
+  E.buy(state, settings, {
+    ts: buyTs, mint: MINT, symbol: 'JB', site: 'test',
+    priceNative: 10, solAmount: 1,
+  });
+  const trueWin = 0.091; // jb: "supposed to be +0.091"
+  const exitPx = 10 * (1 + trueWin / 100) / (1 - settings.feeBps / 10000) / (1 + settings.slippageBps / 10000) ** 0;
+  // exact fill math is derived in the test body; here just price above entry
+  const r2 = E.sell(state, settings, {
+    ts: lateLanded ? 1_800_000_300_001 : 1_800_000_300_000,
+    mint: MINT, qtyFraction: 1, priceNative: 10 * 1.09109,
+  }).round;
+
+  return { state, r1, r2, buyTs };
+}
+
+test('round attribution: a prior round\'s late-landed clips are not re-counted into the re-entry round (jb 2026-08-18)', () => {
+  const settings = freshSettings();
+  const { state, r1, r2 } = jbScenario(settings, true);
+
+  // Sanity: round 1 was the big winner, round 2 a small win.
+  assert.ok(r1.pnlSol > 1, `round 1 should be the big winner, got ${r1.pnlSol}`);
+  assert.ok(r2.pnlSol > 0 && r2.pnlSol < 0.2, `round 2 must stay a small win near +0.09, got ${r2.pnlSol}`);
+
+  // THE LOCK: round 2 must not include round 1's fills.
+  const r1Ids = new Set(r1.tradeIds);
+  const overlap = r2.tradeIds.filter((id) => r1Ids.has(id));
+  assert.deepEqual(overlap, [], `round 2 claimed round 1's fills: ${overlap.join(', ')}`);
+
+  // Money form: returnedSol of round 2 is its own sells only.
+  const r2SellIds = new Set(r2.tradeIds);
+  const r2OwnSells = state.journal.filter(
+    (t) => t.side === 'sell' && r2SellIds.has(t.id)
+  );
+  const sumOwn = r2OwnSells.reduce((s, t) => s + t.solNet, 0);
+  assert.ok(Math.abs(r2.returnedSol - sumOwn) < 1e-9,
+    `round 2 returnedSol ${r2.returnedSol} must equal its own sells' solNet ${sumOwn}`);
+  assert.ok(r2.returnedSol < 1.2,
+    `round 2 returned ${r2.returnedSol} SOL on a 1 SOL round — prior-round clips swallowed`);
+});
+
+test('round attribution: normal back-to-back rounds stay whole (no ts inversion)', () => {
+  const settings = freshSettings();
+  const { r1, r2 } = jbScenario(settings, false);
+
+  assert.ok(r1.pnlSol > 1, `round 1 big winner, got ${r1.pnlSol}`);
+  assert.ok(r2.pnlSol > 0 && r2.pnlSol < 0.2, `round 2 small win, got ${r2.pnlSol}`);
+  const r1Ids = new Set(r1.tradeIds);
+  assert.deepEqual(r2.tradeIds.filter((id) => r1Ids.has(id)), []);
+});
+
+test('round attribution: cash identity holds across both rounds', () => {
+  const settings = freshSettings();
+  const { state, r1, r2 } = jbScenario(settings, true);
+  // cash = start − buys + sells (fees already inside solNet/solGross math)
+  const buys = state.journal.filter((t) => t.side === 'buy').reduce((s, t) => s + t.solGross, 0);
+  const sells = state.journal.filter((t) => t.side === 'sell').reduce((s, t) => s + t.solNet, 0);
+  const start = Number(settings.balanceStartSol) || 10;
+  assert.ok(Math.abs(state.cashSol - (start - buys + sells)) < 1e-6,
+    `cash identity broken: cashSol=${state.cashSol} vs ${start} - ${buys} + ${sells}`);
+});

--- a/extension/test/rowchipcollision.test.js
+++ b/extension/test/rowchipcollision.test.js
@@ -43,19 +43,22 @@ function makeNode(tag, rect) {
   };
 }
 
-function runHelper({ hit, chipWidth = 28, anchorX = 500, anchorY = 140, rowChildren = [] }) {
+function runHelper({ hit, stack, chip, chipWidth = 28, anchorX = 500, anchorY = 140, rowChildren = [] }) {
   const helper = extractHelper();
   const ctx = {
     window: { innerHeight: 900, innerWidth: 1200 },
     Math, Number, Boolean,
-    document: { elementFromPoint: () => hit },
+    document: {
+      elementFromPoint: () => hit,
+      elementsFromPoint: stack ? () => stack : undefined,
+    },
   };
   vm.createContext(ctx);
   vm.runInContext(helper, ctx);
   const row = makeNode('div', { top: 100, left: 10, right: 510, bottom: 180, width: 500, height: 80 });
   for (const c of rowChildren) row.children.push(c);
-  const chip = makeNode('span', { top: 130, left: 470, right: 498, bottom: 150, width: chipWidth, height: 20 });
-  const entry = { el: chip };
+  const ownChip = chip || makeNode('span', { top: 130, left: 470, right: 498, bottom: 150, width: chipWidth, height: 20 });
+  const entry = { el: ownChip };
   return ctx.rowAnchorHitsContent({ x: anchorX, y: anchorY }, row.getBoundingClientRect(), row, entry);
 }
 
@@ -96,6 +99,51 @@ test('F-53: a failed probe (elementFromPoint throws) never blocks placement', ()
     ctx.rowAnchorHitsContent({ x: 500, y: 140 }, row.getBoundingClientRect(), row, { el: chip }),
     false,
     'a broken probe must degrade to the old behaviour, never wedge the sweep');
+});
+
+/* ---------------- F-60: the chip must not shadow its own probe ---------------- */
+
+test('F-60: a chip painted over the MC still reads as a collision — elementsFromPoint looks THROUGH the chip', () => {
+  // The chip is already painted at the float anchor (live ultra-format
+  // switch, row recycle, late-mounting MC): the chip's own body tops the
+  // hit-test at the probe point, with the MC text directly beneath it.
+  // elementsFromPoint must be consulted and the chip skipped, so the sweep
+  // sees the MC it is covering and drops the chip to the gutter.
+  const mcText = makeNode('span', { top: 110, left: 420, right: 505, bottom: 130, width: 85, height: 20 });
+  const chip = makeNode('span', { top: 130, left: 470, right: 498, bottom: 150, width: 28, height: 20 });
+  const layer = makeNode('div', { top: 0, left: 0, right: 1200, bottom: 900, width: 1200, height: 900 });
+  assert.equal(
+    runHelper({ hit: chip, chip, stack: [chip, mcText, layer], rowChildren: [mcText] }),
+    true,
+    'the painted chip must not mask the MC underneath — that is the F-60 recurrence of the F-53 defect');
+});
+
+test('F-60: a chip over clean gutter stays clean — the stack below the chip is page background', () => {
+  const chip = makeNode('span', { top: 130, left: 470, right: 498, bottom: 150, width: 28, height: 20 });
+  const layer = makeNode('div', { top: 0, left: 0, right: 1200, bottom: 900, width: 1200, height: 900 });
+  const foreign = makeNode('div', { top: 0, left: 0, right: 1200, bottom: 900, width: 1200, height: 900 });
+  assert.equal(
+    runHelper({ hit: chip, chip, stack: [chip, foreign, layer] }),
+    false,
+    'skipping the chip must not invent a collision where the page background sits');
+});
+
+test('F-60: no elementsFromPoint (older engines) — elementFromPoint hit on the chip degrades to clean', () => {
+  // The legacy fallback keeps the pre-F-60 behaviour when the stack API is
+  // missing: never wedge the sweep on an engine without elementsFromPoint.
+  const chip = makeNode('span', { top: 130, left: 470, right: 498, bottom: 150, width: 28, height: 20 });
+  assert.equal(runHelper({ hit: chip }), false,
+    'without the stack API the chip self-hit still reads clean — the documented degradation');
+});
+
+test('F-60 source contract: the probe reads the stack and never writes styles', () => {
+  const helper = extractHelper();
+  assert.match(helper, /elementsFromPoint/,
+    'the probe must read the hit-test stack so a painted chip cannot shadow it');
+  assert.doesNotMatch(helper, /\.style\./,
+    'READ-phase only: the probe must never write styles');
+  assert.match(helper, /elementsFromPoint\(bodyX, bodyY\)/,
+    'the stack read uses the same body-midpoint point as the top-hit read');
 });
 
 /* ---------------- the anchor drop is actually applied ---------------- */

--- a/extension/test/strandedbag.test.js
+++ b/extension/test/strandedbag.test.js
@@ -1,0 +1,445 @@
+/* F-61 — the stranded stand-in bag at the graduation boundary (jb, 8/17).
+ *
+ * Report: "buy via final stretch, hold until bond, then open from the bonding
+ * section: the buy does not show." The Pulse row buy runs on a LIST page; the
+ * resolver cascade can miss a pre-graduation bonding coin entirely, so the
+ * row-feed fallback commits the fill under the CLICK address — on Axiom that
+ * is the pair/curve STAND-IN, not the mint. The coin then graduates (new AMM
+ * pool, new pair address) off-page. Reopening it later from the bonded
+ * listing resolves the REAL mint: a key the wallet never held. The card
+ * renders empty, the bar chip goes dead, and unlike P0-3's in-context stash
+ * bridge nothing links the two sessions — the page was closed between.
+ *
+ * Fix 1 (commit-time heal, content.js fillRowBuy): a row-fed candidate whose
+ * mint is missing or the echoed click address gets ONE bounded prewatch
+ * probe; a discovered real mint re-keys the candidate before commit.
+ * Fix 2 (migration backstop, content.js detectLoop/requote + quote.js
+ * tokenFromPayload): the resolver record now carries poolAddresses — every
+ * pool Dexscreener lists for the base mint, including the graduated
+ * bonding-era pair. Any OPEN position keyed by one of those pools is the
+ * same coin under its stand-in; it rekeys onto the real mint.
+ *
+ * This file drives the SHIPPED content.js in the migration.test.js harness
+ * shape.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+
+global.window = global.window || {};
+require('../engine.js');
+const E = global.window.PaperEngine;
+
+const REAL_MINT  = 'R' + '1'.repeat(42);
+const CURVE      = 'C' + '2'.repeat(42);
+const NEW_POOL   = 'P' + '3'.repeat(42);
+const OTHER_MINT = 'D' + '4'.repeat(42);
+const WSOL = 'So11111111111111111111111111111111111111112';
+
+function dexPayload(mint, pair) {
+  return {
+    pairs: [{
+      chainId: 'solana',
+      dexId: 'pumpswap',
+      pairAddress: pair,
+      baseToken: { address: mint, symbol: 'GRAD', name: 'Graduated' },
+      quoteToken: { address: WSOL, symbol: 'SOL' },
+      priceNative: '0.0000021',
+      priceUsd: '0.00042',
+      liquidity: { usd: 60000 },
+      marketCap: 42000,
+    }],
+  };
+}
+
+/** The /tokens/<mint> answer AFTER graduation: BOTH pools listed under the
+ * same base mint — the migrated AMM pool AND the (dead) bonding-era curve.
+ * This is what Dexscreener keeps forever for graduated pump coins. */
+function migratedTokenPayload() {
+  return {
+    pairs: [{
+      chainId: 'solana',
+      dexId: 'pumpswap',
+      pairAddress: NEW_POOL,
+      baseToken: { address: REAL_MINT, symbol: 'GRAD', name: 'Graduated' },
+      quoteToken: { address: WSOL, symbol: 'SOL' },
+      priceNative: '0.0000042',
+      priceUsd: '0.00084',
+      liquidity: { usd: 120000 },
+      marketCap: 84000,
+    }, {
+      chainId: 'solana',
+      dexId: 'pumpfun',
+      pairAddress: CURVE,
+      baseToken: { address: REAL_MINT, symbol: 'GRAD', name: 'Graduated' },
+      quoteToken: { address: WSOL, symbol: 'SOL' },
+      priceNative: '0.0000039',
+      priceUsd: '0.00078',
+      liquidity: { usd: 100 },
+      marketCap: 78000,
+    }],
+  };
+}
+
+/**
+ * Boot the shipped content.js on an Axiom Pulse list page (final stretch).
+ */
+function runStrandedBag(opts) {
+  const options = opts || {};
+  const timers = [];
+  let now = 5_000_000;
+  const nodesById = {};
+  const messages = [];
+  const winListeners = {};
+  const bridgeEvents = [];
+
+  function makeNode(tag) {
+    const node = {
+      tag, style: { setProperty() {}, removeProperty() {} }, dataset: {}, value: '',
+      children: [], childNodes: [], _fields: {},
+      classList: {
+        _s: new Set(),
+        add(...c) { c.forEach((x) => this._s.add(x)); },
+        remove(...c) { c.forEach((x) => this._s.delete(x)); },
+        toggle(c, on) { if (on === undefined) { this._s.has(c) ? this._s.delete(c) : this._s.add(c); } else if (on) this._s.add(c); else this._s.delete(c); },
+        contains(c) { return this._s.has(c); },
+      },
+      set textContent(v) { this._t = v; },
+      get textContent() { return this._t || ''; },
+      set innerHTML(v) {
+        this._h = v;
+        const re = /data-f="([a-z]+)"/g; let m;
+        while ((m = re.exec(v))) { const c = makeNode('span'); c.dataset.f = m[1]; this._fields[m[1]] = c; }
+      },
+      get innerHTML() { return this._h || ''; },
+      appendChild(c) { const i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); if (c._parent && c._parent !== this) c._parent.removeChild(c); c._parent = this; this.children.push(c); this.childNodes = this.children; return c; },
+      removeChild(c) { const i = this.children.indexOf(c); if (i >= 0) this.children.splice(i, 1); },
+      remove() { if (this._parent) this._parent.removeChild(this); },
+      setAttribute() {}, getAttribute() { return null; },
+      addEventListener(type, fn) {
+        if (!this._listeners) this._listeners = {};
+        if (!this._listeners[type]) this._listeners[type] = [];
+        this._listeners[type].push(fn);
+      },
+      click() { ((this._listeners && this._listeners.click) || []).forEach((fn) => fn()); },
+      querySelectorAll() { return []; },
+      querySelector(sel) {
+        const m = /data-f="([a-z]+)"/.exec(sel);
+        if (m && this._fields[m[1]]) return this._fields[m[1]];
+        return makeNode('span');
+      },
+      getBoundingClientRect() { return { top: 0 }; },
+      attachShadow() { return shadowRoot; },
+      focus() {}, closest() { return null; },
+      get offsetWidth() { return 1; },
+    };
+    return node;
+  }
+
+  const shadowRoot = {
+    set innerHTML(v) { this._h = v; }, get innerHTML() { return this._h || ''; },
+    getElementById(id) { if (!nodesById[id]) nodesById[id] = makeNode('div'); return nodesById[id]; },
+    querySelector() { return makeNode('div'); }, querySelectorAll() { return []; }, appendChild() {},
+  };
+
+  const startUrl = 'https://axiom.trade/pulse';
+  const parsedStart = new URL(startUrl);
+  const location = {
+    href: startUrl, hostname: parsedStart.hostname,
+    pathname: parsedStart.pathname, search: parsedStart.search,
+  };
+
+  const doc = {
+    readyState: 'complete', hidden: false, title: 'pulse',
+    body: Object.assign(makeNode('body'), { innerText: '' }),
+    documentElement: makeNode('html'), head: makeNode('head'),
+    createElement: (t) => makeNode(t),
+    getElementById: () => null, querySelector: () => null, querySelectorAll: () => [],
+    addEventListener: () => {}, createTreeWalker: () => ({ nextNode: () => null }),
+  };
+
+  const win = {
+    addEventListener(type, fn) { (winListeners[type] = winListeners[type] || []).push(fn); },
+    removeEventListener() {},
+    postMessage: (msg) => { if (msg && msg.source === 'papertrench-content') messages.push(msg.type); },
+    location,
+    getComputedStyle: () => ({ right: '18px', top: '84px' }),
+    confirm: () => false,
+  };
+  win.window = win;
+
+  // Seeded wallet: the exact state the reported bug leaves behind — a bag
+  // committed under the stand-in curve address by a row buy that never
+  // resolved. (Rows on a list page have no loaded token; no swapStash.)
+  const seeded = E.defaultState();
+  seeded.positions[CURVE] = {
+    mint: CURVE, qty: 2_000_000, costSol: 0.4, investedSol: 0.4,
+    netInvestedSol: 0.4, openedAt: 12345, sessionId: 'pt-test',
+  };
+  const storage = { pt_settings: E.defaultSettings(), pt_state: seeded };
+
+  const sandbox = {
+    window: win, self: win, document: doc, location, console,
+    URLSearchParams, URL,
+    AbortController: function () { this.signal = {}; this.abort = () => {}; },
+    MutationObserver: function () { this.observe = () => {}; this.disconnect = () => {}; },
+    TextDecoder: function () { this.decode = () => ''; },
+    ResizeObserver: function () { this.observe = () => {}; this.disconnect = () => {}; },
+    Set, Map, WeakSet, WeakMap, Promise, JSON, Math, Number, String, Array, Object,
+    Boolean, RegExp, Error, isNaN, parseInt, parseFloat, Infinity, NaN,
+    Date: Object.assign(function () {}, { now: () => now, parse: Date.parse }),
+    setTimeout: (fn, ms) => { timers.push({ fn, at: now + (ms || 0) }); return timers.length; },
+    clearTimeout: () => {}, clearInterval: (id) => { if (timers[id - 1]) timers[id - 1].dead = true; },
+    setInterval: (fn, ms) => { timers.push({ fn, at: now + ms, every: ms }); return timers.length; },
+    fetch: (u) => {
+      const s = String(u);
+      // Jupiter: the SOL/USD reference query; tokens stay unknown there.
+      if (s.includes('lite-api.jup.ag')) {
+        const q = decodeURIComponent(s.split('query=')[1] || '');
+        if (q.includes(WSOL)) {
+          return Promise.resolve({ ok: true, status: 200, json: async () => [{ id: WSOL, usdPrice: 200 }] });
+        }
+        return Promise.resolve({ ok: true, status: 200, json: async () => [] });
+      }
+      // Dexscreener resolve endpoints, routed by the test's stage().
+      const m = /\/latest\/dex\/(?:pairs\/solana|tokens)\/([A-Za-z0-9]+)/.exec(s);
+      if (m) {
+        const r = options.stage(m[1]);
+        if (!r || r === 'blind') return Promise.resolve({ ok: true, status: 200, json: async () => ({ pairs: null }) });
+        return Promise.resolve({ ok: true, status: 200, json: async () => r.payload || dexPayload(r.mint, r.pair) });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ pairs: null }) });
+    },
+    chrome: {
+      runtime: {
+        id: 'papertrench-test',
+        getURL: (p) => 'x/' + p,
+        sendMessage: (msg) => {
+          if (msg && msg.type === 'pt_attest_append') return Promise.resolve({ ok: true, seq: 0, head: 'pt-test-head' });
+          if (msg && msg.type === 'pt_state_commit') return Promise.resolve({}); // worker absent: forces the direct-write fallback
+          const R = win.PaperTrenchResolver;
+          if (!R) return Promise.resolve({});
+          if (msg.type === 'pt_resolve') return R.resolve(msg.address);
+          if (msg.type === 'pt_refresh') return R.refresh(msg.token);
+          if (msg.type === 'pt_sol_usd') return R.solUsd();
+          if (msg.type === 'pt_batch_prices') return R.batchPrices(msg.mints);
+          if (msg.type === 'pt_onchain_prewatch') {
+            // F-61 Fix 1 path: the background's prewatch probe. The test's
+            // stage() decides whether the chain can identify the click
+            // address (a bonding curve -> its mint; a pool -> its base).
+            const answer = options.prewatch && options.prewatch(msg.pool, msg.mint);
+            return Promise.resolve(answer || null);
+          }
+          return Promise.resolve({});
+        },
+        onMessage: { addListener: () => {} },
+        openOptionsPage: () => {},
+      },
+      storage: {
+        local: {
+          get: (keys, cb) => { const out = {}; for (const k of (Array.isArray(keys) ? keys : [keys])) if (k in storage) out[k] = storage[k]; if (cb) cb(out); return Promise.resolve(out); },
+          set: (obj, cb) => { Object.assign(storage, obj); if (cb) cb(); return Promise.resolve(); },
+        },
+        onChanged: { addListener: () => {} },
+      },
+      tabs: { query: () => Promise.resolve([{ id: 1 }]), sendMessage: () => Promise.resolve() },
+    },
+    NodeFilter: { SHOW_TEXT: 4 },
+  };
+
+  const ctx = vm.createContext(sandbox);
+  const manifest = JSON.parse(fs.readFileSync(path.join(ROOT, 'manifest.json'), 'utf8'));
+  const entry = manifest.content_scripts.find((cs) => (cs.js || []).includes('content.js'));
+  for (const f of entry.js) {
+    vm.runInContext(fs.readFileSync(path.join(ROOT, f), 'utf8'), ctx, { filename: f });
+  }
+
+  async function advance(ms, step) {
+    step = step || 100;
+    for (let e = 0; e < ms; e += step) {
+      now += step;
+      for (let i = 0; i < timers.length; i++) {
+        const t = timers[i];
+        if (t.dead || t.at > now) continue;
+        if (t.every) t.at = now + t.every; else t.dead = true;
+        try { t.fn(); } catch (err) { /* asserted via outcomes */ }
+      }
+      for (let k = 0; k < 8; k++) await Promise.resolve();
+    }
+  }
+
+  async function settle() {
+    for (let k = 0; k < 400; k++) await Promise.resolve();
+  }
+
+  /** Simulate the OS gesture the chip tap itself constitutes. */
+  function gesture() {
+    for (const fn of winListeners.pointerdown || []) fn({ isTrusted: true });
+  }
+
+  /** A MAIN-world bridge 'row-buy' message, as the injected chip posts it. */
+  function tapChip(address) {
+    gesture();
+    for (const fn of winListeners.message || []) {
+      fn({
+        source: win, origin: location.origin,
+        data: { source: 'papertrench-bridge', type: 'row-buy', payload: { address } },
+      });
+    }
+  }
+
+  /** A MAIN-world bridge row tick — the Pulse row's own price print. */
+  function rowTick(address, usd) {
+    for (const fn of winListeners.message || []) {
+      fn({
+        source: win, origin: location.origin,
+        data: {
+          source: 'papertrench-bridge', type: 'tick',
+          payload: { mint: address, symbol: 'GRAD', name: 'Graduated', candidates: [{ unit: 'usd', value: usd }] },
+        },
+      });
+    }
+  }
+
+  return {
+    advance, settle, gesture, tapChip, rowTick,
+    navigate(url) {
+      const p = new URL(url);
+      location.href = url; location.pathname = p.pathname;
+      location.hostname = p.hostname; location.search = p.search;
+    },
+    shadowNode: (id) => shadowRoot.getElementById(id),
+    clickShadow: (id) => shadowRoot.getElementById(id).click(),
+    setInput: (id, v) => { shadowRoot.getElementById(id).value = String(v); },
+    buyButtonText: () => (nodesById['pt-buy'] || {}).textContent || '',
+    buyButtonArmed: () => {
+      const el = nodesById['pt-buy'];
+      return !!(el && el.classList.contains('pt-buy-armed'));
+    },
+    storage: () => storage,
+    CURVE, REAL_MINT, NEW_POOL, OTHER_MINT,
+  };
+}
+
+test('F-61 report: Pulse row buy under the stand-in heals at the migrated pool', async () => {
+  // Phase 1 — the Pulse list page, world pre-graduation: the coin is a
+  // bonding curve that NO source can identify or price (the resolver's
+  // exact blind window at the final stretch). The row's own tick prints.
+  const world = { stage: 'bonding' };
+  const ov = runStrandedBag({
+    stage: (addr) => {
+      if (world.stage === 'bonding') return 'blind';
+      // Post-graduation: the NEW pool answers with BOTH pools listed under
+      // the real mint — Dexscreener's forever-listing of graduated coins.
+      if (addr === REAL_MINT) return { payload: migratedTokenPayload() };
+      // The old curve still resolves to the same base mint (it stays listed).
+      if (addr === CURVE) return { mint: REAL_MINT, pair: CURVE };
+      return 'blind';
+    },
+    prewatch: (pool, mint) => {
+      // Pre-graduation the chain CAN classify the curve: it knows the curve
+      // account and its mint — the identity heal Fix 1 relies on.
+      if (world.stage === 'bonding' && (pool === CURVE || mint === CURVE)) {
+        return { mint: REAL_MINT, pool: CURVE, poolKind: 'pump-curve', priceNative: 0.000002 };
+      }
+      return null;
+    },
+  });
+
+  await ov.advance(3000);
+  // The Pulse row prints its own live price (USD) for the curve address.
+  ov.rowTick(CURVE, 0.0004);
+  await ov.settle();
+  // The chip tap: a real gesture + bridge row-buy for the curve address.
+  ov.tapChip(CURVE);
+  await ov.settle();
+
+  // FIX 1 ASSERT — the fill must commit under the REAL mint already at buy
+  // time: the prewatch probe discovered the identity. The seeded stand-in
+  // bag is a LEGACY stranding (pre-fix wallet state) — merging it is the
+  // backstop's job at reopen, not the candidate heal's.
+  let positions = ov.storage().pt_state.positions || {};
+  assert.ok(positions[REAL_MINT],
+    'Fix 1: the row buy must commit under the REAL mint (prewatch identity heal)');
+  assert.ok(positions[REAL_MINT].qty > 0 && positions[REAL_MINT].qty < 2_000_000,
+    'Fix 1: the fill opened a FRESH real-mint bag (the 0.1 SOL fill, ~50k tokens)');
+  assert.ok(positions[CURVE] && positions[CURVE].qty === 2_000_000,
+    'the legacy stand-in bag stays put until the backstop heals it');
+
+  // Phase 2 — graduation. The page was closed; the world moves on. The
+  // bonded listing now opens the coin by its REAL mint.
+  world.stage = 'graduated';
+  ov.navigate(`https://axiom.trade/meme/${REAL_MINT}?chain=sol`);
+  await ov.advance(4000);
+
+  // FIX 2 ASSERT — the backstop healed the stranded legacy bag: the stand-in
+  // key is vacated and everything lives under the real mint, ONE bag.
+  positions = ov.storage().pt_state.positions || {};
+  assert.ok(positions[REAL_MINT], 'the real-mint bag survives the reopen');
+  assert.ok(!positions[CURVE],
+    'Fix 2: the stand-in key must be vacated by the poolAddresses backstop');
+  assert.ok(positions[REAL_MINT].qty > 2_000_000,
+    'one merged bag under the real mint (legacy seed + fresh fill)');
+});
+
+test('F-61 negative: a different coin never inherits the stand-in bag', async () => {
+  const world = { stage: 'bonding' };
+  const ov = runStrandedBag({
+    stage: (addr) => {
+      if (world.stage === 'bonding') return 'blind';
+      // The reopened page is a DIFFERENT coin entirely.
+      if (addr === OTHER_MINT) return { mint: OTHER_MINT, pair: NEW_POOL };
+      return 'blind';
+    },
+    prewatch: (pool, mint) => {
+      if (world.stage === 'bonding' && (pool === CURVE || mint === CURVE)) {
+        return { mint: REAL_MINT, pool: CURVE, poolKind: 'pump-curve', priceNative: 0.000002 };
+      }
+      return null;
+    },
+  });
+
+  await ov.advance(3000);
+  ov.rowTick(CURVE, 0.0004);
+  await ov.settle();
+  ov.tapChip(CURVE);
+  await ov.settle();
+
+  world.stage = 'graduated';
+  ov.navigate(`https://axiom.trade/meme/${OTHER_MINT}?chain=sol`);
+  await ov.advance(4000);
+
+  const positions = ov.storage().pt_state.positions || {};
+  assert.ok(positions[CURVE],
+    'an unrelated coin page must never eat the stand-in bag');
+  assert.ok(!positions[OTHER_MINT] || positions[OTHER_MINT].qty <= 0,
+    'nothing may be created for the unrelated coin');
+  assert.ok(!positions[REAL_MINT] || positions[REAL_MINT].qty <= 2_000_000 + 1e9,
+    'the healed bag must not leak onto the other coin');
+});
+
+test('F-61 legacy path: prewatch silent, fill keys the stand-in honestly', async () => {
+  // The chain probe misses (RPC blind, foreign shape, whatever): Fix 1 keeps
+  // the legacy behavior — the fill commits under the row's own address. The
+  // seeded stand-in bag grows; no crash, no refusal.
+  const ov = runStrandedBag({
+    stage: () => 'blind',
+    prewatch: () => null,
+  });
+
+  await ov.advance(3000);
+  ov.rowTick(CURVE, 0.0004);
+  await ov.settle();
+  ov.tapChip(CURVE);
+  await ov.settle();
+
+  const positions = ov.storage().pt_state.positions || {};
+  assert.ok(positions[CURVE],
+    'a silent probe keeps the honest legacy keying (the row address)');
+  assert.ok(positions[CURVE].qty > 2_000_000,
+    'the seeded bag grew by the fill');
+});

--- a/extension/whatsnew.json
+++ b/extension/whatsnew.json
@@ -1,26 +1,22 @@
 {
-  "version": "3.13.9",
+  "version": "3.13.10",
   "date": "2026-08-25",
   "entries": [
     {
-      "title": "Your stop fires now.",
-      "text": "Two separate bugs behind the same family of reports — \"my stop never went off while it rugged\", \"I made a minus 12% but should have been plus\", \"my paper equity shows +9.109 when it should be +0.091\"."
+      "title": "Migrated coins have a live price again.",
+      "text": "When a pump.fun coin graduates, its bonding curve stops carrying a price — and PaperTrench never looked for the pool it had just migrated *into*. So for the minutes right after migration, the window where the coin is most tradable, the panel sat on \"Fetching live price…\" waiting for an aggregator to catch up."
     },
     {
       "title": null,
-      "text": "- **An armed stop or take-profit was only judged when the price   CHANGED.** The level check lived in one place: the tick path, below the   \"this price is the same as the last one, nothing to redraw\" shortcut.   That shortcut is right about redrawing and wrong about levels — because   a level can be armed *after* the last price move. Reload a chart and   your wallet loads a beat after the first ticks land; drag a stop on   while the tape is quiet; arm one from another tab. In every case the   level was already crossed by the price on screen, and PaperTrench was   waiting for a *different* number before it would look."
+      "text": "It now asks the chain which PumpSwap pool holds the coin and prices it directly. Against live mainnet, 4/4 freshly migrated coins price in about two seconds where all 4 previously showed nothing."
     },
     {
       "title": null,
-      "text": "The books where a different number never comes are exactly the ones a   stop exists for: a dead market, or a rug printing the same number all   the way down. So the stop sat there while the position bled out.   Levels are now judged before that shortcut, and the 100 ms heartbeat   re-asks the question every beat — the same watchdog armed buys have   had since F-16. It cannot double-fire: one function decides every   fill, and asking it twice about a level it already spent is a no-op.   (D-57)"
+      "text": "- Only a SOL-quoted pool from a program we have a verified decoder for is ever   adopted, and where a coin has several, the deepest one wins — a dust pool   quotes a price nobody could fill against. No pool on chain still means no   price shown, never a guessed one. - Covers non-pump.fun launchpads too (Bags, Believe, moonshot), which reach   the same code path."
     },
     {
       "title": null,
-      "text": "- **A take-profit clip could be booked twice.** With two chart tabs open   on the same coin — routine, since every quick-buy chip tap opens one —   both tabs see the trigger. The one that loses the write race re-applies   its fill onto the winner's wallet, and it only checked that the   position was still open. A 50% clip doesn't close the position, so the   loser sold again: proceeds credited twice, and paper equity inflated by   a whole extra set of clips. It now re-checks that the order itself is   still live, exactly as armed buys already did. (D-58)"
-    },
-    {
-      "title": null,
-      "text": "This is the *second* mechanism behind jb's \"+9.109 vs +0.091\" report —   v3.13.8 fixed the starting-balance half. Both were live at once."
+      "text": "Thanks to **cheng.4848** and **ark_trades13**, who reported this independently and pinned it to migrated tokens specifically — that detail is what made it findable."
     }
   ]
 }

--- a/extension/whatsnew.json
+++ b/extension/whatsnew.json
@@ -1,22 +1,26 @@
 {
-  "version": "3.13.8",
-  "date": "2026-08-24",
+  "version": "3.13.9",
+  "date": "2026-08-25",
   "entries": [
     {
-      "title": "\"Paper equity showed +9.109 SOL, should be +0.091 — exactly 100×.\"",
-      "text": "jb's 8/18 report, after a full exit: the wallet's session return was welded to the \"Starting paper balance\" setting. Change the form 10 → 1 SOL and a wallet that really started at 10 re-denominates its whole history overnight."
+      "title": "Your stop fires now.",
+      "text": "Two separate bugs behind the same family of reports — \"my stop never went off while it rugged\", \"I made a minus 12% but should have been plus\", \"my paper equity shows +9.109 when it should be +0.091\"."
     },
     {
       "title": null,
-      "text": "- **Who was hit:** every wallet created before v3.9.5 (the D-06 birth   snapshot). Newer wallets froze their starting balance at reset; older ones   never got the field, so every \"vs start\" number — popup, overlay,   dashboard, even the leaderboard bridge — read the *live* form value."
+      "text": "- **An armed stop or take-profit was only judged when the price   CHANGED.** The level check lived in one place: the tick path, below the   \"this price is the same as the last one, nothing to redraw\" shortcut.   That shortcut is right about redrawing and wrong about levels — because   a level can be armed *after* the last price move. Reload a chart and   your wallet loads a beat after the first ticks land; drag a stop on   while the tape is quiet; arm one from another tab. In every case the   level was already crossed by the price on screen, and PaperTrench was   waiting for a *different* number before it would look."
     },
     {
       "title": null,
-      "text": "- **The fix:** the wallet's own fill history now re-derives its birth   balance (equity − open P&L − the sum of every fill's effect), and the   first load after this update freezes that number onto the wallet. Marks   moving or another tab trading in between can't shift it — it's the same   arithmetic the equity curve already uses. Until the frozen number lands,   every surface falls back to the derived value before the form, so the   right number shows on the very first paint. jb's wallet: +0.091 SOL stays   +0.091 SOL, whatever the form says. (D-56)"
+      "text": "The books where a different number never comes are exactly the ones a   stop exists for: a dead market, or a rug printing the same number all   the way down. So the stop sat there while the position bled out.   Levels are now judged before that shortcut, and the 100 ms heartbeat   re-asks the question every beat — the same watchdog armed buys have   had since F-16. It cannot double-fire: one function decides every   fill, and asking it twice about a level it already spent is a no-op.   (D-57)"
     },
     {
       "title": null,
-      "text": "- **Also closed:** a wallet reset from the popup now snapshots its starting   balance too — previously a popup-born wallet would have lived its whole   life as a \"legacy\" wallet with the same hole."
+      "text": "- **A take-profit clip could be booked twice.** With two chart tabs open   on the same coin — routine, since every quick-buy chip tap opens one —   both tabs see the trigger. The one that loses the write race re-applies   its fill onto the winner's wallet, and it only checked that the   position was still open. A 50% clip doesn't close the position, so the   loser sold again: proceeds credited twice, and paper equity inflated by   a whole extra set of clips. It now re-checks that the order itself is   still live, exactly as armed buys already did. (D-58)"
+    },
+    {
+      "title": null,
+      "text": "This is the *second* mechanism behind jb's \"+9.109 vs +0.091\" report —   v3.13.8 fixed the starting-balance half. Both were live at once."
     }
   ]
 }

--- a/extension/whatsnew.json
+++ b/extension/whatsnew.json
@@ -1,14 +1,18 @@
 {
-  "version": "3.13.5",
+  "version": "3.13.6",
   "date": "2026-08-24",
   "entries": [
     {
-      "title": "Pulse-page instant buys fill at the price the row printed — not a lagging aggregator snapshot.",
-      "text": "Field report 8/16 (Ski + sedna): quick research on the pulse page, instant buy, entry market cap flat wrong — the row showed a real 20k while the fill booked 6k. Three holes, one defect (F-59):"
+      "title": "Bags bought from a Pulse final-stretch row no longer vanish when the coin bonds.",
+      "text": "jb's 8/17 report: buy via final stretch, hold until the coin graduates, reopen it from the bonding section — the position card renders empty."
     },
     {
       "title": null,
-      "text": "- **What broke (identity):** Axiom pulse frames key their price records by   pair address, but the row-tick override looked up `recentRowPrices` by the   resolver's mint — so the live print the trader just looked at was invisible   to the fill and a stale aggregator price won by default. - **What broke (the cap):** even when the override fired, `data.mcap` kept   the resolver's stale value — price corrected, cap never rode it. - **What broke (the witness):** a FIRST buy had no witness at all under   F-56 (which anchors on an existing position). Quick research → instant   buy → blind fill. - **The fix:** the override now tries every identity the token answers to   (mint, pair, chip address), the cap is rescaled to the corrected price,   and a first buy must be vouched by the row's own fresh print (or a   same-block chain quote) — otherwise it refuses with **“Price unvouched”**   instead of silently filling wrong."
+      "text": "- **What broke:** on an unresolved final-stretch row the fill committed   under the row's CLICK address — on Pulse that is the pair/curve   stand-in, not the mint. Right while the page lived, dead after   graduation: the bonded reopen resolves the real mint, a key the wallet   never held. Closing the page between buy and graduation also skipped the   graduation stash entirely — a list page has no loaded token to stash."
+    },
+    {
+      "title": null,
+      "text": "- **The fix:** the commit core now probes the click address on-chain (one   bounded read) whenever the fill's identity is missing or an echo, and   books under the discovered real mint. Wallets already carrying stranded   bags heal on reopen: every pool the mint lists — including its graduated   bonding-era curve — now carries its orphaned position onto the real key.   An unrelated coin can never inherit the bag; a silent probe keeps the   honest legacy keying and the fill still books. (F-61)"
     }
   ]
 }

--- a/extension/whatsnew.json
+++ b/extension/whatsnew.json
@@ -1,14 +1,18 @@
 {
-  "version": "3.13.5",
+  "version": "3.13.7",
   "date": "2026-08-24",
   "entries": [
     {
-      "title": "Pulse-page instant buys fill at the price the row printed — not a lagging aggregator snapshot.",
-      "text": "Field report 8/16 (Ski + sedna): quick research on the pulse page, instant buy, entry market cap flat wrong — the row showed a real 20k while the fill booked 6k. Three holes, one defect (F-59):"
+      "title": "Bags bought from a Pulse final-stretch row no longer vanish when the coin bonds.",
+      "text": "jb's 8/17 report: buy via final stretch, hold until the coin graduates, reopen it from the bonding section — the position card renders empty."
     },
     {
       "title": null,
-      "text": "- **What broke (identity):** Axiom pulse frames key their price records by   pair address, but the row-tick override looked up `recentRowPrices` by the   resolver's mint — so the live print the trader just looked at was invisible   to the fill and a stale aggregator price won by default. - **What broke (the cap):** even when the override fired, `data.mcap` kept   the resolver's stale value — price corrected, cap never rode it. - **What broke (the witness):** a FIRST buy had no witness at all under   F-56 (which anchors on an existing position). Quick research → instant   buy → blind fill. - **The fix:** the override now tries every identity the token answers to   (mint, pair, chip address), the cap is rescaled to the corrected price,   and a first buy must be vouched by the row's own fresh print (or a   same-block chain quote) — otherwise it refuses with **“Price unvouched”**   instead of silently filling wrong."
+      "text": "- **What broke:** on an unresolved final-stretch row the fill committed   under the row's CLICK address — on Pulse that is the pair/curve   stand-in, not the mint. Right while the page lived, dead after   graduation: the bonded reopen resolves the real mint, a key the wallet   never held. Closing the page between buy and graduation also skipped the   graduation stash entirely — a list page has no loaded token to stash."
+    },
+    {
+      "title": null,
+      "text": "- **The fix:** the commit core now probes the click address on-chain (one   bounded read) whenever the fill's identity is missing or an echo, and   books under the discovered real mint. Wallets already carrying stranded   bags heal on reopen: every pool the mint lists — including its graduated   bonding-era curve — now carries its orphaned position onto the real key.   An unrelated coin can never inherit the bag; a silent probe keeps the   honest legacy keying and the fill still books. (F-61)"
     }
   ]
 }

--- a/extension/whatsnew.json
+++ b/extension/whatsnew.json
@@ -1,22 +1,18 @@
 {
-  "version": "3.13.10",
+  "version": "3.13.11",
   "date": "2026-08-25",
   "entries": [
     {
-      "title": "Migrated coins have a live price again.",
-      "text": "When a pump.fun coin graduates, its bonding curve stops carrying a price — and PaperTrench never looked for the pool it had just migrated *into*. So for the minutes right after migration, the window where the coin is most tradable, the panel sat on \"Fetching live price…\" waiting for an aggregator to catch up."
+      "title": "Brand-new coins are buyable immediately.",
+      "text": "If you installed the extension and every coin sat on \"Fetching live price…\" — only becoming buyable once it had aged 20-30 seconds — that was one throttled RPC read poisoning the whole token."
     },
     {
       "title": null,
-      "text": "It now asks the chain which PumpSwap pool holds the coin and prices it directly. Against live mainnet, 4/4 freshly migrated coins price in about two seconds where all 4 previously showed nothing."
+      "text": "The extension probes the chain directly for coins too new for any aggregator to know. That probe marked the address as \"already probed\" *before* the read came back, and never un-marked it if the read failed. A single blip — a rate-limited public endpoint, a dropped socket — therefore switched off the only source that can price a fresh launch, leaving the coin waiting on an indexer to catch up."
     },
     {
       "title": null,
-      "text": "- Only a SOL-quoted pool from a program we have a verified decoder for is ever   adopted, and where a coin has several, the deepest one wins — a dust pool   quotes a price nobody could fill against. No pool on chain still means no   price shown, never a guessed one. - Covers non-pump.fun launchpads too (Bags, Believe, moonshot), which reach   the same code path."
-    },
-    {
-      "title": null,
-      "text": "Thanks to **cheng.4848** and **ark_trades13**, who reported this independently and pinned it to migrated tokens specifically — that detail is what made it findable."
+      "text": "A failed read is never evidence about the coin. Now a failed probe retries on the very next pass (~400ms) instead of waiting on a ~4-second safety net, and clicking Buy asks the chain whenever nothing else produced a price, rather than only when the panel had never had one."
     }
   ]
 }

--- a/extension/whatsnew.json
+++ b/extension/whatsnew.json
@@ -1,18 +1,22 @@
 {
-  "version": "3.13.7",
+  "version": "3.13.8",
   "date": "2026-08-24",
   "entries": [
     {
-      "title": "Bags bought from a Pulse final-stretch row no longer vanish when the coin bonds.",
-      "text": "jb's 8/17 report: buy via final stretch, hold until the coin graduates, reopen it from the bonding section — the position card renders empty."
+      "title": "\"Paper equity showed +9.109 SOL, should be +0.091 — exactly 100×.\"",
+      "text": "jb's 8/18 report, after a full exit: the wallet's session return was welded to the \"Starting paper balance\" setting. Change the form 10 → 1 SOL and a wallet that really started at 10 re-denominates its whole history overnight."
     },
     {
       "title": null,
-      "text": "- **What broke:** on an unresolved final-stretch row the fill committed   under the row's CLICK address — on Pulse that is the pair/curve   stand-in, not the mint. Right while the page lived, dead after   graduation: the bonded reopen resolves the real mint, a key the wallet   never held. Closing the page between buy and graduation also skipped the   graduation stash entirely — a list page has no loaded token to stash."
+      "text": "- **Who was hit:** every wallet created before v3.9.5 (the D-06 birth   snapshot). Newer wallets froze their starting balance at reset; older ones   never got the field, so every \"vs start\" number — popup, overlay,   dashboard, even the leaderboard bridge — read the *live* form value."
     },
     {
       "title": null,
-      "text": "- **The fix:** the commit core now probes the click address on-chain (one   bounded read) whenever the fill's identity is missing or an echo, and   books under the discovered real mint. Wallets already carrying stranded   bags heal on reopen: every pool the mint lists — including its graduated   bonding-era curve — now carries its orphaned position onto the real key.   An unrelated coin can never inherit the bag; a silent probe keeps the   honest legacy keying and the fill still books. (F-61)"
+      "text": "- **The fix:** the wallet's own fill history now re-derives its birth   balance (equity − open P&L − the sum of every fill's effect), and the   first load after this update freezes that number onto the wallet. Marks   moving or another tab trading in between can't shift it — it's the same   arithmetic the equity curve already uses. Until the frozen number lands,   every surface falls back to the derived value before the form, so the   right number shows on the very first paint. jb's wallet: +0.091 SOL stays   +0.091 SOL, whatever the form says. (D-56)"
+    },
+    {
+      "title": null,
+      "text": "- **Also closed:** a wallet reset from the popup now snapshots its starting   balance too — previously a popup-born wallet would have lived its whole   life as a \"legacy\" wallet with the same hole."
     }
   ]
 }

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -11,6 +11,19 @@ fail() { echo "PREFLIGHT FAIL: $*" >&2; exit 1; }
 # ("-P supports only unibyte and UTF-8 locales"). A release check that only
 # runs on one machine is a release check nobody runs.
 version_of() { sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([0-9.]*\)".*/\1/p' "$1" | head -1; }
+
+# Same portability rule, for the interpreter itself: Windows (git-bash / MSYS)
+# ships `python` with no `python3` on PATH, and the Microsoft Store alias stub
+# that answers `python3` there PRINTS AN ADVERT AND EXITS 0 — so a bare
+# `python3 - <<PY` silently ran nothing and the gate below it passed without
+# ever executing a check. Resolve once, fail loudly if neither exists.
+if command -v python3 >/dev/null 2>&1 && python3 -c 'import sys' >/dev/null 2>&1; then
+  PY=python3
+elif command -v python >/dev/null 2>&1 && python -c 'import sys' >/dev/null 2>&1; then
+  PY=python
+else
+  fail "no working python3/python on PATH — preflight needs one for the manifest-scope and site-count gates"
+fi
 MANIFEST_V=$(version_of extension/manifest.json)
 PACKAGE_V=$(version_of extension/package.json)
 
@@ -160,7 +173,7 @@ echo "sitemap OK ($(grep -c '<loc>' site/sitemap.xml) urls, all resolve to a pag
 if grep -q '"<all_urls>"' extension/manifest.json; then
   # host_permissions may legitimately stay broad (user-configured AI/RPC
   # endpoints are fetched by the service worker) — content_scripts must not.
-  python3 - <<'PY' || exit 1
+  "$PY" - <<'PY' || exit 1
 import json, sys
 m = json.load(open('extension/manifest.json'))
 for cs in m.get('content_scripts', []):
@@ -238,7 +251,7 @@ done
 # actually supports — over-claiming advertises a capability the user does not
 # have. Under-claiming is tolerated on purpose: between a commit and its tag,
 # the manifest legitimately runs ahead of what anyone can install.
-SITES_REAL=$(python3 - <<'PY'
+SITES_REAL=$("$PY" - <<'PY'
 import json
 m = json.load(open('extension/manifest.json'))
 hosts = set()

--- a/server/test/streamsroster.test.js
+++ b/server/test/streamsroster.test.js
@@ -1,0 +1,150 @@
+/* site/streams.js — the roster actually renders what it claims.
+ *
+ * There was no coverage on this file at all, which is how issue #64 could
+ * describe a Kick creator being "accepted by a moderator and then silently
+ * never appearing anywhere". The roster is also the one page where a wrong
+ * answer is a dead embed: `login` means "mountable Twitch player", and
+ * inventing one for a Kick channel puts a broken player on the page.
+ *
+ * These tests BOOT THE REAL SCRIPT in a DOM stub and read the resulting
+ * markup. A string assertion against the source ("is 'ark1317' in the file?")
+ * would pass just as happily with the card never rendering.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const SRC = fs.readFileSync(path.join(__dirname, '..', '..', 'site', 'streams.js'), 'utf8');
+
+/** The smallest DOM the page actually touches. */
+function makeElement(id) {
+  const el = {
+    id,
+    innerHTML: '',
+    className: '',
+    style: {},
+    children: [],
+    dataset: {},
+    textContent: '',
+    classList: { add() {}, remove() {}, toggle() {}, contains: () => false },
+    addEventListener() {},
+    removeEventListener() {},
+    appendChild(c) { this.children.push(c); return c; },
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    setAttribute() {},
+    getAttribute: () => null,
+  };
+  return el;
+}
+
+/**
+ * Boot the page with no network (both remote roster sources fail, which is
+ * the documented "hand-maintained list stands alone" path) and hand back the
+ * elements it rendered into.
+ */
+async function bootPage() {
+  const els = new Map();
+  const getEl = (id) => {
+    if (!els.has(id)) els.set(id, makeElement(id));
+    return els.get(id);
+  };
+
+  const sandbox = {
+    console,
+    // Both remote sources refused: the page must still render the manual list.
+    fetch: () => Promise.reject(new Error('offline in test')),
+    setTimeout: (fn) => { void fn; return 0; },      // never run timers
+    clearTimeout() {},
+    setInterval: () => 0,                            // no live-poll loop
+    clearInterval() {},
+    Image: function () { this.addEventListener = () => {}; },
+    // The page lazy-reveals cards; nothing here scrolls, so the observer is
+    // inert and every card is treated as already visible.
+    IntersectionObserver: function () {
+      this.observe = () => {};
+      this.unobserve = () => {};
+      this.disconnect = () => {};
+    },
+    encodeURIComponent,
+    document: {
+      getElementById: getEl,
+      // Selector-addressed elements resolve to their own stub, keyed by the
+      // selector text — enough for the page's classList/style toggles.
+      querySelector: (sel) => getEl('sel:' + sel),
+      querySelectorAll: () => [],
+      createElement: () => makeElement('created'),
+      addEventListener() {},
+      readyState: 'complete',
+      body: makeElement('body'),
+    },
+    localStorage: {
+      _v: {},
+      getItem(k) { return Object.prototype.hasOwnProperty.call(this._v, k) ? this._v[k] : null; },
+      setItem(k, v) { this._v[k] = String(v); },
+      removeItem(k) { delete this._v[k]; },
+    },
+    matchMedia: () => ({ matches: false, addEventListener() {}, removeEventListener() {} }),
+    URLSearchParams,
+    URL,
+    location: { href: 'https://papertrench.com/streams', search: '' },
+    navigator: { userAgent: 'node' },
+  };
+  sandbox.window = sandbox;
+  sandbox.globalThis = sandbox;
+  vm.createContext(sandbox);
+  vm.runInContext(SRC, sandbox, { filename: 'streams.js' });
+
+  // boot() is async (it awaits the two optional remote rosters). Let the
+  // rejected fetches settle so the final render has happened.
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+
+  return { grid: getEl('streamerGrid'), els };
+}
+
+test('every roster entry becomes a card on the page (issue #64)', async () => {
+  const { grid } = await bootPage();
+  const html = grid.innerHTML;
+  assert.ok(html.length > 0, 'the grid must render even with both remote rosters down');
+
+  for (const name of ['OnlyTerp', 'ProfitableDegen', 'Chillygmi', 'plahstickk', 'Zurp52', 'Ark1317']) {
+    assert.ok(html.includes(name), `${name} must appear on the page`);
+  }
+});
+
+test('a Kick creator renders as a link-out card, not a dead player (issue #64)', async () => {
+  const { grid } = await bootPage();
+  const html = grid.innerHTML;
+
+  // The card must point at the real channel...
+  assert.ok(html.includes('https://kick.com/ark1317'),
+    'the Kick card must link to the channel it names');
+  // ...and must NOT have been given an invented Twitch login, which is
+  // exactly what would mount a player for a channel that does not exist.
+  assert.ok(!html.includes('twitch.tv/ark1317'),
+    'a Kick channel must never be linked as a Twitch one');
+  assert.ok(!/ark1317[^"]*\.jpg/i.test(html),
+    'a Kick channel has no Twitch preview thumbnail to show');
+});
+
+test('a Twitch entry keeps its embeddable login (issue #64)', async () => {
+  const { grid } = await bootPage();
+  assert.ok(grid.innerHTML.includes('twitch.tv/zurp52'),
+    'a Twitch streamer must link to their Twitch channel');
+});
+
+test('the roster carries no duplicate identities', async () => {
+  // Two cards for one channel is the visible symptom of a manual entry
+  // colliding with an approved application. Count CARDS, not mentions — a
+  // single card legitimately names its channel several times (href, preview
+  // image, alt text).
+  const { grid } = await bootPage();
+  const hrefs = [...grid.innerHTML.matchAll(/href="([^"]+)"/g)].map((m) => m[1]);
+  const channels = hrefs.filter((h) => /twitch\.tv\/|kick\.com\//.test(h));
+  assert.ok(channels.length >= 6, 'every roster entry links somewhere');
+  assert.equal(new Set(channels).size, channels.length,
+    'each channel gets exactly one card');
+});

--- a/site/index.html
+++ b/site/index.html
@@ -77,11 +77,11 @@
          you can INSTALL today, so it tracks the released tag, not the working
          tree — an unreleased window under-claims on purpose. The marquee below
          must name the same sites the count claims: 15 chips for 15 hosts, or
-         the hero counts a site the page never names. 2097 = 1886 extension +
-         187 server + 16 bot. -->
+         the hero counts a site the page never names. 2101 = 1886 extension +
+         191 server + 16 bot. -->
     <div class="hero-stats reveal d3">
       <div class="hero-stat"><div class="num o" data-check="sites">15</div><div class="lbl">TRADING SITES</div></div>
-      <div class="hero-stat"><div class="num g" data-check="tests">2097</div><div class="lbl">TESTS PASSING</div></div>
+      <div class="hero-stat"><div class="num g" data-check="tests">2101</div><div class="lbl">TESTS PASSING</div></div>
       <div class="hero-stat"><div class="num b">0</div><div class="lbl">PRICES INVENTED</div></div>
       <div class="hero-stat"><div class="num o">100%</div><div class="lbl">LOCAL &amp; PRIVATE</div></div>
     </div>

--- a/site/index.html
+++ b/site/index.html
@@ -77,11 +77,11 @@
          you can INSTALL today, so it tracks the released tag, not the working
          tree — an unreleased window under-claims on purpose. The marquee below
          must name the same sites the count claims: 15 chips for 15 hosts, or
-         the hero counts a site the page never names. 2089 = 1886 extension +
+         the hero counts a site the page never names. 2097 = 1886 extension +
          187 server + 16 bot. -->
     <div class="hero-stats reveal d3">
       <div class="hero-stat"><div class="num o" data-check="sites">15</div><div class="lbl">TRADING SITES</div></div>
-      <div class="hero-stat"><div class="num g" data-check="tests">2089</div><div class="lbl">TESTS PASSING</div></div>
+      <div class="hero-stat"><div class="num g" data-check="tests">2097</div><div class="lbl">TESTS PASSING</div></div>
       <div class="hero-stat"><div class="num b">0</div><div class="lbl">PRICES INVENTED</div></div>
       <div class="hero-stat"><div class="num o">100%</div><div class="lbl">LOCAL &amp; PRIVATE</div></div>
     </div>

--- a/site/index.html
+++ b/site/index.html
@@ -77,11 +77,11 @@
          you can INSTALL today, so it tracks the released tag, not the working
          tree — an unreleased window under-claims on purpose. The marquee below
          must name the same sites the count claims: 15 chips for 15 hosts, or
-         the hero counts a site the page never names. 2101 = 1886 extension +
+         the hero counts a site the page never names. 2103 = 1886 extension +
          191 server + 16 bot. -->
     <div class="hero-stats reveal d3">
       <div class="hero-stat"><div class="num o" data-check="sites">15</div><div class="lbl">TRADING SITES</div></div>
-      <div class="hero-stat"><div class="num g" data-check="tests">2101</div><div class="lbl">TESTS PASSING</div></div>
+      <div class="hero-stat"><div class="num g" data-check="tests">2103</div><div class="lbl">TESTS PASSING</div></div>
       <div class="hero-stat"><div class="num b">0</div><div class="lbl">PRICES INVENTED</div></div>
       <div class="hero-stat"><div class="num o">100%</div><div class="lbl">LOCAL &amp; PRIVATE</div></div>
     </div>

--- a/site/index.html
+++ b/site/index.html
@@ -77,11 +77,11 @@
          you can INSTALL today, so it tracks the released tag, not the working
          tree — an unreleased window under-claims on purpose. The marquee below
          must name the same sites the count claims: 15 chips for 15 hosts, or
-         the hero counts a site the page never names. 2103 = 1886 extension +
+         the hero counts a site the page never names. 2104 = 1886 extension +
          191 server + 16 bot. -->
     <div class="hero-stats reveal d3">
       <div class="hero-stat"><div class="num o" data-check="sites">15</div><div class="lbl">TRADING SITES</div></div>
-      <div class="hero-stat"><div class="num g" data-check="tests">2103</div><div class="lbl">TESTS PASSING</div></div>
+      <div class="hero-stat"><div class="num g" data-check="tests">2104</div><div class="lbl">TESTS PASSING</div></div>
       <div class="hero-stat"><div class="num b">0</div><div class="lbl">PRICES INVENTED</div></div>
       <div class="hero-stat"><div class="num o">100%</div><div class="lbl">LOCAL &amp; PRIVATE</div></div>
     </div>

--- a/site/index.html
+++ b/site/index.html
@@ -77,11 +77,11 @@
          you can INSTALL today, so it tracks the released tag, not the working
          tree — an unreleased window under-claims on purpose. The marquee below
          must name the same sites the count claims: 15 chips for 15 hosts, or
-         the hero counts a site the page never names. 2034 = 1832 extension +
-         186 server + 16 bot. -->
+         the hero counts a site the page never names. 2089 = 1886 extension +
+         187 server + 16 bot. -->
     <div class="hero-stats reveal d3">
       <div class="hero-stat"><div class="num o" data-check="sites">15</div><div class="lbl">TRADING SITES</div></div>
-      <div class="hero-stat"><div class="num g" data-check="tests">2034</div><div class="lbl">TESTS PASSING</div></div>
+      <div class="hero-stat"><div class="num g" data-check="tests">2089</div><div class="lbl">TESTS PASSING</div></div>
       <div class="hero-stat"><div class="num b">0</div><div class="lbl">PRICES INVENTED</div></div>
       <div class="hero-stat"><div class="num o">100%</div><div class="lbl">LOCAL &amp; PRIVATE</div></div>
     </div>

--- a/site/news.html
+++ b/site/news.html
@@ -73,9 +73,9 @@
            reads "0 NUMBERS INVENTED" cannot carry a stale one, so
            scripts/preflight.sh now recomputes both and fails the release if
            either disagrees. Update them together with that check, never alone.
-           2089 = 1886 extension + 187 server + 16 bot. -->
-      <div><div class="num g" style="color:var(--green)" data-check="tests">2089</div><div class="lbl">TESTS PASSING</div></div>
-      <div><div class="num b" style="color:var(--blue)" data-check="defects">178</div><div class="lbl">AUDITED DEFECTS CLOSED</div></div>
+           2097 = 1894 extension + 187 server + 16 bot. -->
+      <div><div class="num g" style="color:var(--green)" data-check="tests">2097</div><div class="lbl">TESTS PASSING</div></div>
+      <div><div class="num b" style="color:var(--blue)" data-check="defects">179</div><div class="lbl">AUDITED DEFECTS CLOSED</div></div>
       <div><div class="num o" style="color:var(--violet)">0</div><div class="lbl">NUMBERS INVENTED</div></div>
     </div>
   </div>

--- a/site/news.html
+++ b/site/news.html
@@ -73,8 +73,8 @@
            reads "0 NUMBERS INVENTED" cannot carry a stale one, so
            scripts/preflight.sh now recomputes both and fails the release if
            either disagrees. Update them together with that check, never alone.
-           2103 = 1896 extension + 191 server + 16 bot. -->
-      <div><div class="num g" style="color:var(--green)" data-check="tests">2103</div><div class="lbl">TESTS PASSING</div></div>
+           2104 = 1897 extension + 191 server + 16 bot. -->
+      <div><div class="num g" style="color:var(--green)" data-check="tests">2104</div><div class="lbl">TESTS PASSING</div></div>
       <div><div class="num b" style="color:var(--blue)" data-check="defects">180</div><div class="lbl">AUDITED DEFECTS CLOSED</div></div>
       <div><div class="num o" style="color:var(--violet)">0</div><div class="lbl">NUMBERS INVENTED</div></div>
     </div>

--- a/site/news.html
+++ b/site/news.html
@@ -73,9 +73,9 @@
            reads "0 NUMBERS INVENTED" cannot carry a stale one, so
            scripts/preflight.sh now recomputes both and fails the release if
            either disagrees. Update them together with that check, never alone.
-           2101 = 1894 extension + 191 server + 16 bot. -->
-      <div><div class="num g" style="color:var(--green)" data-check="tests">2101</div><div class="lbl">TESTS PASSING</div></div>
-      <div><div class="num b" style="color:var(--blue)" data-check="defects">179</div><div class="lbl">AUDITED DEFECTS CLOSED</div></div>
+           2103 = 1896 extension + 191 server + 16 bot. -->
+      <div><div class="num g" style="color:var(--green)" data-check="tests">2103</div><div class="lbl">TESTS PASSING</div></div>
+      <div><div class="num b" style="color:var(--blue)" data-check="defects">180</div><div class="lbl">AUDITED DEFECTS CLOSED</div></div>
       <div><div class="num o" style="color:var(--violet)">0</div><div class="lbl">NUMBERS INVENTED</div></div>
     </div>
   </div>

--- a/site/news.html
+++ b/site/news.html
@@ -73,8 +73,8 @@
            reads "0 NUMBERS INVENTED" cannot carry a stale one, so
            scripts/preflight.sh now recomputes both and fails the release if
            either disagrees. Update them together with that check, never alone.
-           2097 = 1894 extension + 187 server + 16 bot. -->
-      <div><div class="num g" style="color:var(--green)" data-check="tests">2097</div><div class="lbl">TESTS PASSING</div></div>
+           2101 = 1894 extension + 191 server + 16 bot. -->
+      <div><div class="num g" style="color:var(--green)" data-check="tests">2101</div><div class="lbl">TESTS PASSING</div></div>
       <div><div class="num b" style="color:var(--blue)" data-check="defects">179</div><div class="lbl">AUDITED DEFECTS CLOSED</div></div>
       <div><div class="num o" style="color:var(--violet)">0</div><div class="lbl">NUMBERS INVENTED</div></div>
     </div>

--- a/site/news.html
+++ b/site/news.html
@@ -73,9 +73,9 @@
            reads "0 NUMBERS INVENTED" cannot carry a stale one, so
            scripts/preflight.sh now recomputes both and fails the release if
            either disagrees. Update them together with that check, never alone.
-           2034 = 1832 extension + 186 server + 16 bot. -->
-      <div><div class="num g" style="color:var(--green)" data-check="tests">2034</div><div class="lbl">TESTS PASSING</div></div>
-      <div><div class="num b" style="color:var(--blue)" data-check="defects">172</div><div class="lbl">AUDITED DEFECTS CLOSED</div></div>
+           2089 = 1886 extension + 187 server + 16 bot. -->
+      <div><div class="num g" style="color:var(--green)" data-check="tests">2089</div><div class="lbl">TESTS PASSING</div></div>
+      <div><div class="num b" style="color:var(--blue)" data-check="defects">178</div><div class="lbl">AUDITED DEFECTS CLOSED</div></div>
       <div><div class="num o" style="color:var(--violet)">0</div><div class="lbl">NUMBERS INVENTED</div></div>
     </div>
   </div>

--- a/site/streams.js
+++ b/site/streams.js
@@ -40,6 +40,20 @@
       name: 'plahstickk',                // display name on the card
       blurb: 'Weekend challenge runs — fresh eyes on the trenches.',
     },
+    {
+      login: 'zurp52',                   // twitch.tv/<login> — lowercase
+      name: 'Zurp52',                    // display name on the card
+      blurb: 'Streaming PaperTrench on a regular schedule.',
+    },
+    {
+      // Kick: no embeddable player, so this renders as a link-out card.
+      // `login` stays absent on purpose — inventing one would mount a dead
+      // Twitch player for a channel that does not exist there.
+      name: 'Ark1317',
+      platform: 'kick',
+      channelUrl: 'https://kick.com/ark1317',
+      blurb: 'PaperTrench streamer on Kick.',
+    },
   ];
 
   // Where "Sign up as a streamer" points — the on-site form, which posts to


### PR DESCRIPTION
Three defects from community reports, each with a regression test that was verified to fail when the fix is removed.

## D-57 · S1 — an armed stop only fired on a price *change*

`handlePageTick` returned early on a duplicate price **before** it evaluated armed orders. So a stop or take-profit armed after the last price move was never judged while the feed printed a flat price — and a rugging or thinly-traded tape is exactly where a stop matters and exactly where prices repeat.

The price loop had a watchdog for armed *buys* but none for armed *orders*; the fix makes it symmetric.

## D-58 · S1 — a lost CAS race double-booked an order clip

The remutate on a lost compare-and-swap re-checked that the position still existed, but never that the order was still live. Two tabs (or a tick racing a retry) could each book the same clip.

The test for this shipped already-failing at `7d8e9d8` — it never passed. It passes now.

Both surfaced from the same family of reports: *"my stop never went off while it rugged"*, *"I made a minus 12% but should have been plus"*.

## D-59 · S1 — migrated coins had no on-chain price at all

Reported independently, both pinning it to migrated tokens:

> **cheng.4848** — "it is difficult to make purchases in time after the currency migration"
> **ark_trades13** — "the 'Fetching live price…' thing happens to me too, but only on migrated tokens"

A pump.fun bonding curve sets `complete: true` at graduation and stops carrying a price. `prewatchPool` correctly refuses it — *"migrated: the resolver path owns it"* — but that resolver path only ever read the **mint account**, which yields identity and supply and **no price**. Nothing ever looked for the pool the coin had just migrated *into*. On-chain pricing was silently unavailable for the minutes right after migration: the window where the coin is most tradable.

The coin was never unpriceable. It migrates into a PumpSwap AMM pool (`pAMMBay6…`), which `poolKindForOwner` **already** classifies as `cp-vaults` — a kind we already watch, decode and price. The lookup simply did not exist.

`findGraduatedPool()` asks the chain which pool holds the mint via `getProgramAccounts` + an indexed memcmp on the base-mint offset, rather than guessing a PDA whose seeds (creator, index) we don't know. Wired into both dead-end paths — the `pump`-suffixed branch and the mint-facts branch (how Bags/Believe/moonshot arrive).

**Honesty guards**, one test each, each verified to fail when its check is removed:
- only a **WSOL-quoted** pool is adopted — a USDC-quoted pool decodes perfectly and means a different number
- only a pool owned by a **verified** program
- where several qualify, the **deepest** wins — a dust pool quotes a price nobody could fill against
- no pool on chain still means **no price**, never an invented one

**Layout verified against live mainnet, not a spec** (301 bytes; base mint @43, quote mint @75, base vault @139, quote vault @171). The base vault is frequently Token-2022 (170 bytes) where the quote vault is classic SPL (165) — assuming 165 everywhere would drop the base leg and the price with it. Transcript in `docs/POOL-LAYOUTS.md`.

**Live proof** — driving the real `FEED.prewatch()`:

| | result |
|---|---|
| freshly migrated coins priced | **4/4**, ~2s each |
| discovered pool vs pump.fun's own `pump_swap_pool` | **exact match** |
| negative control (both hooks removed) | **0/4** — the reported bug |
| separate discovery run | **9/9** matched before the public RPC throttled |

Test fixtures are real captured mainnet bytes, so the production decoders run against production data.

## Closes #64 — Zurp52 and Ark1317 on the roster

Zurp52 (Twitch) plays inline. Ark1317 (Kick) renders as a link-out card with **no `login`** — `login` means "mountable Twitch player", and inventing one puts a dead player on the page.

The issue flagged `handleStreamerRoster` filtering on `twitch_login IS NOT NULL` as a possible blocker; that's already resolved server-side, so both entries work today with no server change.

This also adds **the first tests `site/streams.js` has ever had** — no coverage is precisely how the issue could describe a Kick creator being *"accepted by a moderator and then silently never appearing anywhere"*. They boot the real page script in a DOM stub with both remote roster sources failing and read the markup actually produced; a string assertion against the source would pass just as happily with the card never rendering.

## Also

`scripts/preflight.sh` called `python3`, which on Windows is the Microsoft Store alias stub — it **prints an advert and exits 0**, so the manifest-scope gate (content scripts must never match `<all_urls>`, DEFECT O-09) silently ran nothing and passed. It now resolves a working interpreter and fails loudly if there isn't one. That gate is real again.

Public counters synced: 2101 tests, 179 defects closed.

---

**2101 tests green** (1894 extension + 191 server + 16 bot) · `PREFLIGHT OK for v3.13.10`

Remaining manual step before release: `docs/QA-MATRIX.md` pass on the built zip.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/papertrench/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->