### PR TITLE
fix(popup): the "holding" figure read a field positions never carry — every wallet showed 0.00

### DIFF
--- a/extension/popup.js
+++ b/extension/popup.js
@@ -171,6 +171,29 @@ function freshState(settings) {
   };
 }
 
+/** The gross cost basis still open on one position — engine.grossOpenCostSol's
+ * rule, duplicated here for the same reason derivedAnchor duplicates the birth
+ * rule: the popup is self-contained on purpose (no engine.js dependency).
+ *
+ * It is a DERIVED quantity, never a stored field. Reading it as `pos.
+ * grossOpenCostSol` yields undefined on every real position — the engine
+ * stores costSol / investedSol / netInvestedSol and computes the rest.
+ *
+ * costSol shrinks proportionally on partial sells while netInvestedSol (total
+ * net ever invested) does not, so costSol / netInvestedSol is the surviving
+ * fraction of the stack and invested × that fraction is its gross cost.
+ * Legacy positions predate netInvestedSol: without partial sells costSol ===
+ * net invested and the full investedSol is exact, so it is the fallback.
+ */
+function grossOpenCostSol(pos) {
+  if (!pos) return 0;
+  const invested = Number(pos.investedSol) || 0;
+  const cost = Number(pos.costSol) || 0;
+  const netInvested = Number(pos.netInvestedSol) || 0;
+  if (netInvested > 0) return invested * (cost / netInvested);
+  return invested;
+}
+
 /** jb (ideas): lifetime bought / held / sold SOL from the journal alone,
  * so historical wallets get correct numbers with no migration. Held is the
  * surviving cost basis of open positions (what actually went in and is
@@ -186,7 +209,7 @@ function journalFlow(journal, positions) {
   }
   let heldSol = 0;
   for (const p of Object.values(positions || {})) {
-    heldSol += Number(p.grossOpenCostSol) || 0;
+    heldSol += grossOpenCostSol(p);
   }
   return { boughtSol, heldSol, soldSol };
 }

--- a/extension/test/flowstats.test.js
+++ b/extension/test/flowstats.test.js
@@ -110,29 +110,66 @@ test('flow stats: two tokens hold independently', () => {
 
 /* ---------------- popup helper ---------------- */
 
-test('popup journalFlow derives bought/held/sold from a legacy state alone', () => {
-  // A wallet from BEFORE the feature: journal rows + positions, nothing else.
+/** Load the popup's journal-derived helpers into a bare context. The slice
+ * starts at the cost-basis helper because journalFlow depends on it. */
+function loadPopupFlow() {
   const popupSrc = fs.readFileSync(path.join(ROOT, 'popup.js'), 'utf8');
   const ctx = { console, Math, Number, Object, parseFloat };
   vm.createContext(ctx);
-  const start = popupSrc.indexOf('function journalFlow(');
+  const start = popupSrc.indexOf('function grossOpenCostSol(');
   const end = popupSrc.indexOf('/** Equity = cash');
-  assert.ok(start !== -1 && end > start, 'journalFlow must exist in popup.js');
+  assert.ok(start !== -1 && end > start,
+    'journalFlow and its cost-basis helper must exist in popup.js');
   vm.runInContext(popupSrc.slice(start, end), ctx);
+  return ctx;
+}
 
+test('popup journalFlow agrees with the engine on a REAL engine state', () => {
+  // The fixture is a state the ENGINE built, never a hand-written shape.
+  // A position's open cost basis is DERIVED (from costSol / investedSol /
+  // netInvestedSol), never stored as a `grossOpenCostSol` field — so a
+  // fabricated `{ grossOpenCostSol: n }` fixture proves nothing about the
+  // popup that ships. It passed for exactly that reason while the real popup
+  // rendered "holding 0.00" for every user with an open position.
+  const settings = freshSettings({ balanceStartSol: 10 });
+  const state = E.defaultState(settings);
+  buyAt(state, settings, MINT_A, 2, 0.001);
+  buyAt(state, settings, MINT_B, 1, 0.002);
+  sellPct(state, settings, MINT_A, 50, 0.0012);   // partial exit: cost basis shrinks
+
+  const ctx = loadPopupFlow();
+  const flow = ctx.journalFlow(state.journal, state.positions);
+  const engine = E.sessionStats(state, settings);
+
+  // Expectations come from the engine, which owns these definitions — the
+  // popup duplicates the rule and must not drift from it.
+  assert.ok(engine.heldSol > 0, 'the scenario must leave something held');
+  assert.ok(Math.abs(flow.heldSol - engine.heldSol) < 1e-9,
+    `held must match the engine (${flow.heldSol} vs ${engine.heldSol})`);
+  assert.ok(Math.abs(flow.boughtSol - engine.boughtSol) < 1e-9,
+    `bought must match the engine (${flow.boughtSol} vs ${engine.boughtSol})`);
+  assert.ok(Math.abs(flow.soldSol - engine.soldSol) < 1e-9,
+    `sold must match the engine (${flow.soldSol} vs ${engine.soldSol})`);
+});
+
+test('popup journalFlow reads a legacy position that predates netInvestedSol', () => {
+  // Real historical shape: positions written before netInvestedSol existed
+  // carry investedSol + costSol only. Without partial sells costSol === net
+  // invested, so the full investedSol is the exact gross basis.
+  const ctx = loadPopupFlow();
   const journal = [
     { side: 'buy', solGross: 1.0, solNet: -0.99 },
     { side: 'buy', solGross: 2.0, solNet: -1.98 },
     { side: 'sell', solGross: 1.25, solNet: 1.2375 },
   ];
   const positions = {
-    M1: { grossOpenCostSol: 1.5 },
-    M2: { grossOpenCostSol: 0.25 },
+    M1: { investedSol: 1.5, costSol: 1.485 },
+    M2: { investedSol: 0.25, costSol: 0.2475 },
   };
   const flow = ctx.journalFlow(journal, positions);
   assert.equal(flow.boughtSol, 3, 'bought = sum of buy solGross (order size)');
   assert.equal(flow.soldSol, 1.25, 'sold = sum of sell solGross (order size)');
-  assert.equal(flow.heldSol, 1.75, 'held = surviving open cost basis');
+  assert.equal(flow.heldSol, 1.75, 'held = gross invested for legacy positions');
 });
 
 test('dashboard surfaces the flow KPI', () => {


### PR DESCRIPTION
## The defect

The popup's lifetime flow line renders `In X · holding Y · out Z SOL`. The
`holding` number was **0.00 for every user with an open position**, while the
bought and sold figures beside it were both correct.

`journalFlow` summed `Number(p.grossOpenCostSol) || 0` over open positions. But
`grossOpenCostSol` is a **derived** quantity, not a stored field — engine
positions carry `costSol` / `investedSol` / `netInvestedSol`, and the engine
computes the rest in `grossOpenCostSol(pos)`. The property read yielded
`undefined` on every real position, so the sum was always zero.

Driving the real engine and the shipped popup helper together, before the fix:

```
position keys: mint, symbol, name, site, pairAddress, sessionId, thesis, qty,
               costSol, investedSol, netInvestedSol, peakPnlSol, troughPnlSol,
               openedAt, lastPriceNative, lastPriceUsd, chain
has grossOpenCostSol property? false

popup journalFlow on a REAL state: {"boughtSol":0.25,"heldSol":0,"soldSol":0}
engine sessionStats heldSol       = 0.25
```

A displayed number that is wrong, which is the one hard rule in CONTRIBUTING.md.

## The fix

The popup is engine-free on purpose (see its header — it avoids a whole class of
"PaperEngine is undefined" load-order failures), so the rule is duplicated here
the way `derivedAnchor` already duplicates the birth-balance rule, rather than
importing `engine.js`. The logic mirrors `engine.grossOpenCostSol` exactly,
including the legacy fallback for positions that predate `netInvestedSol`.

## Why the test did not catch it

The existing test hand-wrote its fixture as `{ M1: { grossOpenCostSol: 1.5 } }`
— a shape the engine never produces — so it blessed the property read instead of
testing it. This is the pattern CONTRIBUTING.md warns about: a fixture that
encodes what the code does rather than what the inputs imply.

It now drives real buys and a partial sell through the engine and pins the popup
to `engine.sessionStats`, the component that owns these definitions, so the two
cannot drift. A second case keeps the legacy path honest using the real
pre-`netInvestedSol` shape (`investedSol` + `costSol` only).

Both new tests were confirmed to **fail against the unfixed popup** and pass
after:

```
not ok - popup journalFlow agrees with the engine on a REAL engine state
  error: 'held must match the engine (0 vs 2)'
```

## Tests

```
extension: 2073 pass, 0 fail
server:     201 tests, 191 pass, 0 fail, 10 skipped (offline live-API)
```

Scope is `popup.js` + its test only; no behaviour change outside the popup's
flow line.