### PR TITLE
streams: play Kick and YouTube inline, and colour the whole card by platform

### DIFF
--- a/docs/STREAMS.md
+++ b/docs/STREAMS.md
@@ -5,7 +5,7 @@ touches lives in the CONFIG block at the top of `streams.js`:
 
 | Constant | What it does |
 | --- | --- |
-| `STREAMERS` | Hand-maintained roster. Always shown; wins over an approved application with the same login. |
+| `STREAMERS` | Hand-maintained roster. Always shown; wins over an approved application with the same login. Twitch entries carry `login`; Kick and YouTube carry `platform` + `channelUrl` (plus `channelId` for a YouTube channel that should play inline). |
 | `SIGNUP_URL` | Where "Sign up as a streamer" points — the on-site form, `streamer-signup.html`. |
 | `API` | Worker origin the approved roster is read from. Same value as `arena.js`. |
 | `ROSTER_CSV_URL` | Legacy Google-Sheet CSV roster. Empty = disabled, and it should stay empty on a new deploy. |
@@ -59,8 +59,10 @@ the card within ~60 s (the edge cache window).
 
 Rules the pipeline applies:
 
-- **Every platform can be approved.** Twitch channels are embedded and play
-  inline; Kick, YouTube and anything else get a roster card that links out.
+- **Every platform can be approved.** Twitch and Kick channels embed and play
+  inline. YouTube plays inline too, but only when the entry carries the UC…
+  channel id (see *Which platforms play inline* below); without one it is a
+  link-out card. Anything else links out.
   This used to be Twitch-only — `handleStreamerRoster` filtered on
   `twitch_login IS NOT NULL`, so an approved Kick creator became a row nobody
   could see, and the queue admitted it by disabling Approve for them.
@@ -99,17 +101,57 @@ deployment keeps its roster on upgrade. To finish the move: re-enter any
 approved streamers via the form (or add them to `STREAMERS`), confirm they
 show, then set `ROSTER_CSV_URL` back to `''` and unpublish the sheet.
 
+## Which platforms play inline
+
+`PLATFORMS` in `streams.js` tracks two separate capabilities, because the
+platforms disagree about them:
+
+| Platform | Embeds a player | Reports live/offline | Needs |
+| --- | --- | --- | --- |
+| Twitch | yes | yes — preview CDN | `login` |
+| Kick | yes | yes — `kick.com/api/v2/channels/<slug>` | slug, read from `channelUrl` |
+| YouTube | yes | **no** | the UC… channel id |
+| other | no | no | — |
+
+They were one flag until multi-platform embeds landed, which forced an
+all-or-nothing call on YouTube: either claim a status nothing can back, or
+refuse to play a stream that embeds perfectly well.
+
+**YouTube needs the channel id.** `/embed/live_stream?channel=<UC…>` mounts
+whatever the channel is currently broadcasting, with no key — but it keys off
+the `UC…` id, and a `/@handle` URL cannot be resolved to one client-side. Put
+the id in the entry's `channelId` (YouTube: *Share channel → Copy channel ID*)
+or use the `/channel/UC…` form of the URL, and the card plays. Neither, and it
+stays a link-out card, which is the honest fallback rather than a player keyed
+on a guess.
+
 ## How the page decides who's "LIVE"
 
-No Twitch API key: the page checks Twitch's public preview CDN. A live
-channel's `live_user_<login>` thumbnail resolves; an offline one redirects to
-the `404_preview` image. Checked every 60 s. If Twitch ever changes this, the
-page degrades to showing no badges — never wrong ones.
+No API keys, so each platform is asked in whatever public way it answers, and
+every probe returns live / offline / **unknown** — a failed probe renders as no
+badge, never as OFFLINE, because OFFLINE is a claim.
 
-**This is a Twitch-only signal**, so non-Twitch cards show their platform name
-where the badge would be rather than a guessed status, and `refreshLive` does
-not query the CDN for them at all — a Kick login asked of Twitch's CDN answers
-about a Twitch channel that happens to share the name.
+- **Twitch** — the public preview CDN. A live channel's `live_user_<login>`
+  thumbnail resolves; an offline one redirects to the `404_preview` image.
+- **Kick** — `kick.com/api/v2/channels/<slug>` answers a cross-origin fetch
+  with CORS headers. `livestream` is `null` when the channel is off and an
+  object when it is on, and it carries a real preview frame, so a live Kick
+  card gets a thumbnail exactly like a Twitch one.
+- **YouTube** — nothing. The channel `/live` page and the RSS feed are both
+  CORS-blocked, and oEmbed 404s on the `live_stream` URL. Real status needs a
+  Data API key this static site has nowhere to keep, so a YouTube card shows
+  its platform name where the badge would be, forever.
+
+Checked every 60 s. If a platform changes its endpoint the page degrades to
+showing no badge for it — never a wrong one.
+
+Each platform is asked its own way and never another's: a Kick slug put to
+Twitch's CDN answers about a Twitch channel that happens to share the name.
+
+**A platform with no live signal is never auto-promoted into the featured
+player.** It would sit there autoplaying "video unavailable" for every visitor
+whenever the channel is off. Clicking its card still plays it — that is the
+visitor asking, and the embed then reports its own truth.
 
 ### Card order
 

--- a/site/streams.html
+++ b/site/streams.html
@@ -115,12 +115,22 @@
   @media (max-width: 980px) { .streamer-grid { grid-template-columns: repeat(2, 1fr); } }
   @media (max-width: 640px) { .streamer-grid { grid-template-columns: 1fr; } }
 
+  /* One accent pair per card, set by the platform class streams.js puts on it.
+     The badge always spoke the platform's colour; everything else on the card
+     was hardcoded Twitch purple, so a Kick card and a Twitch card were
+     identical below the badge. --accent carries it through the handle, the
+     hover border, the hover glow and the placeholder. The rgb triple exists
+     because rgba() cannot take a hex var. */
   .s-card {
+    --accent: var(--twitch2); --accent-rgb: 191,148,255;
     position: relative; text-align: left; cursor: pointer; overflow: hidden; padding: 0;
     background: var(--panel); border: 1px solid var(--line); border-radius: 14px;
     font: inherit; color: inherit; display: block; width: 100%;
     transition: transform .22s cubic-bezier(.2,.8,.2,1), border-color .22s, box-shadow .22s;
   }
+  .s-card.plat-kick    { --accent: var(--kick);  --accent-rgb: 83,252,24; }
+  .s-card.plat-youtube { --accent: var(--yt);    --accent-rgb: 255,78,69; }
+  .s-card.plat-other   { --accent: var(--muted); --accent-rgb: 141,151,169; }
   .s-card:hover { border-color: rgba(255,157,69,0.42); }
   .s-card:hover .s-play { opacity: 1; transform: scale(1); }
 
@@ -130,14 +140,14 @@
     position: absolute; inset: 0; display: grid; place-items: center;
     font-family: var(--mono);
     font-size: 30px; font-weight: 800; color: rgba(255,255,255,0.18); letter-spacing: 2px;
-    background: linear-gradient(145deg, rgba(145,70,255,0.15), rgba(145,70,255,0.02));
+    background: linear-gradient(145deg, rgba(var(--accent-rgb),0.15), rgba(var(--accent-rgb),0.02));
   }
   /* A play affordance on hover — the card is a button, so it should look
      like one the moment a pointer is on it. */
   .s-play {
     position: absolute; inset: 0; margin: auto; width: 52px; height: 52px;
     display: grid; place-items: center; pointer-events: none;
-    border-radius: 50%; background: rgba(10,6,20,0.72); border: 1px solid rgba(191,148,255,0.5);
+    border-radius: 50%; background: rgba(10,6,20,0.72); border: 1px solid rgba(var(--accent-rgb),0.5);
     color: #fff; opacity: 0; transform: scale(.86);
     transition: opacity .22s, transform .22s;
     backdrop-filter: blur(3px);
@@ -170,12 +180,10 @@
   .s-name { font-size: 15px; font-weight: 800; letter-spacing: -0.2px; }
   .s-handle {
     display: inline-block; font-family: var(--mono); font-size: 11.5px;
-    color: var(--twitch2); font-weight: 500; margin-top: 3px;
+    color: var(--accent); font-weight: 500; margin-top: 3px;
     border-bottom: 1px solid transparent; word-break: break-all;
   }
   a.s-handle:hover { border-bottom-color: currentColor; }
-  .s-card.link .s-handle { color: var(--muted); }
-  .s-card[data-login] .s-handle { color: var(--twitch2); }
   .s-blurb { margin-top: 9px; font-size: 13px; color: var(--muted); line-height: 1.55; }
 
   /* The open slot is an invitation, not a fake streamer — it never borrows
@@ -183,7 +191,7 @@
   .s-card.open { border-style: dashed; border-color: rgba(145,70,255,0.3); background: rgba(145,70,255,0.02); }
   .s-card.open:hover { border-color: rgba(145,70,255,0.55); }
   .s-card.open .s-thumb { background: transparent; }
-  .s-card.open .ph { background: linear-gradient(145deg, rgba(145,70,255,0.09), transparent); color: rgba(191,148,255,0.3); }
+  .s-card.open .ph { background: linear-gradient(145deg, rgba(var(--accent-rgb),0.09), transparent); color: rgba(var(--accent-rgb),0.3); }
 
   .signup-rail {
     margin-top: 2.25rem; padding: 1.25rem 0 0;
@@ -236,6 +244,22 @@
   .obs-sec { padding: 28px 0 8px; }
   .obs-lead { margin-bottom: 8px; }
   .obs-lead h2 { margin: 0 0 0.4rem; }
+
+  /* ---------- platform accent on hover ----------
+     Last, because .s-card:hover above sets one flat brand colour for every
+     card and this has to win over it.
+
+     No lift and no drop shadow: the card hover was deliberately flattened —
+     the translate and the black box-shadow were removed — so the platform is
+     carried by the border and a soft tint of its own colour instead. A
+     link-out card tints more quietly than a playable one rather than
+     promising a player it does not have. */
+  .s-card:hover      { border-color: rgba(var(--accent-rgb),0.5); }
+  .s-card.link:hover { border-color: rgba(var(--accent-rgb),0.34); }
+  .s-card[data-key]:hover { box-shadow: 0 0 24px -10px rgba(var(--accent-rgb),0.55); }
+  /* The open slot is an invitation, not a platform — it keeps the brand. */
+  .s-card.open { --accent: var(--orange2); --accent-rgb: 255,192,129; }
+  .s-card.open:hover { border-color: rgba(255,157,69,0.55); }
 </style>
 </head>
 <body>
@@ -353,8 +377,11 @@
         for the minute a fill claims. Newest launches often have none. Those
         fills come back <i>unpriced</i> rather than passing, and a record
         carrying too many of them is labelled instead of ranked. Live/offline
-        badges on this page are inferred from Twitch's public preview images,
-        not an official Twitch API. Treat them as a hint. The full protocol,
+        badges come from each platform's own public endpoint — Twitch's preview
+        images, Kick's channel API — not from official partner APIs, so treat
+        them as a hint. A YouTube card never shows one at all: nothing public
+        reports that channel's status without a key, and a guess is worse than
+        a blank. The full protocol,
         including what it refuses to claim, is in
         <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener">LEADERBOARD.md</a>.
       </p>

--- a/site/streams.js
+++ b/site/streams.js
@@ -16,9 +16,15 @@
 
   // Hand-maintained roster. Entries here always show, and they win over a
   // sheet row with the same login — useful for pinning or fixing a blurb.
-  // `login` is the Twitch login and means "embeddable inline". Kick and
-  // YouTube entries carry `platform` + `channelUrl` instead and render as
-  // link-out cards — there is no login to invent for a player we cannot mount.
+  // `login` is the Twitch login. Kick and YouTube entries carry `platform` +
+  // `channelUrl`; what can be mounted from that is decided per platform in
+  // PLATFORMS below, not by the presence of a Twitch login.
+  //
+  // YouTube is the one platform that needs more than a channel URL: the embed
+  // keys off the UC… channel id, which cannot be derived from a /@handle URL
+  // without the Data API. Give such an entry an explicit `channelId` (copy it
+  // from the channel's "Share channel → Copy channel ID"), or leave it off and
+  // accept a link-out card.
   const STREAMERS = [
     {
       login: 'onlyterp',                 // twitch.tv/<login> — lowercase
@@ -46,9 +52,9 @@
       blurb: 'Streaming PaperTrench on a regular schedule.',
     },
     {
-      // Kick: no embeddable player, so this renders as a link-out card.
-      // `login` stays absent on purpose — inventing one would mount a dead
-      // Twitch player for a channel that does not exist there.
+      // Kick: plays inline. `login` stays absent on purpose — it is the Twitch
+      // login, and inventing one would mount a dead Twitch player. The Kick
+      // slug is read from channelUrl.
       name: 'Ark1317',
       platform: 'kick',
       channelUrl: 'https://kick.com/ark1317',
@@ -118,38 +124,110 @@
 
   /* ---------- platforms ----------
    *
-   * Only Twitch can be embedded, so only Twitch cards act as a player button.
-   * The rest are links, and are drawn as links — a card that looks identical
-   * to a playable one but silently opens a new tab teaches the visitor that
-   * the whole grid is unpredictable. Live/offline is a Twitch-only signal too
-   * (it comes from Twitch's preview CDN), so the other platforms show their
-   * platform name where the badge would be rather than a guessed status.
+   * Two capabilities, deliberately separate, because they are not the same
+   * question and the platforms disagree about them:
+   *
+   *   embeddable — can a player be mounted on this page at all?
+   *   liveSignal — can live/offline be OBSERVED without a server-side key?
+   *
+   * They used to be one flag, which forced an all-or-nothing call on YouTube:
+   * either claim a live status nothing can back, or refuse to play a stream
+   * that embeds perfectly well. Splitting them lets each platform be handled
+   * for what it actually supports (verified live from this origin, 2026-08-26):
+   *
+   *   Twitch  embed + live. Live comes from the public preview CDN.
+   *   Kick    embed + live. player.kick.com mounts, and kick.com/api/v2 answers
+   *           a cross-origin fetch with CORS headers — livestream:null offline,
+   *           a livestream object (with a real thumbnail) when live.
+   *   YouTube embed only. /embed/live_stream?channel=<UC id> always mounts the
+   *           channel's current broadcast without a key, but NOTHING key-free
+   *           reports whether that broadcast exists: the channel /live page and
+   *           the RSS feed are both CORS-blocked, and oEmbed 404s on the
+   *           live_stream URL. Real status needs a Data API key this static
+   *           site has nowhere to keep.
+   *
+   * A platform with no live signal never claims one and is never auto-promoted
+   * into the featured player — an autoplaying "video unavailable" shown to
+   * every visitor is exactly the confident-wrong-answer this project refuses.
+   * Its card plays on a click, which is the visitor asking, and the embed
+   * itself then reports the truth.
    */
   const PLATFORMS = {
     twitch: {
-      label: 'Twitch', host: 'twitch.tv/', embeddable: true,
+      label: 'Twitch', host: 'twitch.tv/', embeddable: true, liveSignal: true, chat: true,
+      // The Twitch login IS the embed handle.
+      handle: (s) => s.login || null,
       url: (s) => 'https://twitch.tv/' + encodeURIComponent(s.login),
+      player: (h) => 'https://player.twitch.tv/?channel=' + encodeURIComponent(h) +
+        '&parent=' + encodeURIComponent(PARENT) + '&muted=true&autoplay=true',
+      chatUrl: (h) => 'https://www.twitch.tv/embed/' + encodeURIComponent(h) +
+        '/chat?parent=' + encodeURIComponent(PARENT) + '&darkpopout',
     },
     kick: {
-      label: 'Kick', host: 'kick.com/', embeddable: false,
-      url: (s) => s.channelUrl,
+      label: 'Kick', host: 'kick.com/', embeddable: true, liveSignal: true, chat: false,
+      // kick.com/<slug> — the slug is the embed handle and the API key alike.
+      handle: (s) => s.channel || slugFromUrl(s.channelUrl, 'kick.com'),
+      url: (s) => s.channelUrl || ('https://kick.com/' + encodeURIComponent(s.channel || '')),
+      player: (h) => 'https://player.kick.com/' + encodeURIComponent(h) + '?muted=true&autoplay=true',
     },
     youtube: {
-      label: 'YouTube', host: 'youtube.com/', embeddable: false,
+      label: 'YouTube', host: 'youtube.com/', embeddable: true, liveSignal: false, chat: false,
+      // Only a UC… id can be embedded. A /@handle URL has no client-side route
+      // to one, so such an entry stays a link-out rather than mounting a player
+      // keyed on a guess.
+      handle: (s) => ytChannelId(s),
       url: (s) => s.channelUrl,
+      player: (h) => 'https://www.youtube.com/embed/live_stream?channel=' +
+        encodeURIComponent(h) + '&autoplay=1&mute=1',
     },
     other: {
-      label: 'Stream', host: '', embeddable: false,
+      label: 'Stream', host: '', embeddable: false, liveSignal: false, chat: false,
+      handle: () => null,
       url: (s) => s.channelUrl,
     },
   };
 
   const platformOf = (s) => PLATFORMS[s && s.platform] || PLATFORMS.twitch;
 
+  /** First path segment of a URL on `host` — "kick.com/Ark1317?x=1" -> "ark1317". */
+  function slugFromUrl(raw, host) {
+    try {
+      const url = new URL(String(raw || ''));
+      if (!url.hostname.replace(/^www\./i, '').toLowerCase().endsWith(host)) return null;
+      const seg = url.pathname.split('/').filter(Boolean)[0] || '';
+      const slug = seg.toLowerCase();
+      return /^[a-z0-9_-]{1,60}$/.test(slug) ? slug : null;
+    } catch { return null; }
+  }
+
+  /** The UC… channel id for a YouTube entry, from `channelId` or a /channel/ URL. */
+  function ytChannelId(s) {
+    const explicit = String((s && s.channelId) || '').trim();
+    if (/^UC[A-Za-z0-9_-]{22}$/.test(explicit)) return explicit;
+    try {
+      const url = new URL(String((s && s.channelUrl) || ''));
+      const parts = url.pathname.split('/').filter(Boolean);
+      const i = parts.indexOf('channel');
+      const id = i >= 0 ? parts[i + 1] : '';
+      return /^UC[A-Za-z0-9_-]{22}$/.test(id || '') ? id : null;
+    } catch { return null; }
+  }
+
+  /** The handle this entry plays under, or null when it cannot be mounted. */
+  const embedHandle = (s) => {
+    const spec = platformOf(s);
+    return spec.embeddable ? (spec.handle(s) || null) : null;
+  };
+
+  /** Can this entry mount a player on the page? */
+  const canEmbed = (s) => embedHandle(s) !== null;
+
+  /** Can live/offline be observed for this entry? */
+  const hasLiveSignal = (s) => platformOf(s).liveSignal && canEmbed(s);
+
   /** The href a card points at, or null when there is nothing safe to link. */
   function channelHref(s) {
     const spec = platformOf(s);
-    if (spec.embeddable) return s.login ? spec.url(s) : null;
     const raw = spec.url(s);
     if (!raw) return null;
     // The roster is server-normalized, but this is the point where a string
@@ -164,7 +242,7 @@
   /** What to print under the name: "twitch.tv/name", or the bare host+path. */
   function channelLabel(s) {
     const spec = platformOf(s);
-    if (spec.embeddable && s.login) return spec.host + s.login;
+    if (spec === PLATFORMS.twitch && s.login) return spec.host + s.login;
     const href = channelHref(s);
     if (!href) return spec.label;
     return href.replace(/^https?:\/\//i, '').replace(/^www\./i, '').replace(/\/$/, '');
@@ -178,14 +256,19 @@
   }, { threshold: 0.12 });
   document.querySelectorAll('.reveal').forEach((el) => io.observe(el));
 
-  /* ---------- state ---------- */
-  const live = new Map();       // login -> true | false | null (unknown)
+  /* ---------- state ----------
+   * Keyed by keyOf(), not by Twitch login: a Kick entry has no login, and two
+   * platforms can carry the same name. */
+  const live = new Map();       // key -> true | false | null (unknown)
+  const preview = new Map();    // key -> live thumbnail URL, when the platform gives one
   let roster = [...STREAMERS];  // manual entries + approved sheet rows
 
   /** Identity for dedupe: a Twitch login, else the channel it points at. */
   const keyOf = (s) => (s.login ? 'twitch:' + s.login : 'url:' + String(s.channelUrl || '').toLowerCase());
-  let featured = null;          // login currently in the big player
+  let featured = null;          // key currently in the big player
   let userPinned = false;       // stop auto-promotion once the viewer chose
+
+  const entryFor = (key) => roster.find((s) => keyOf(s) === key) || null;
 
   $('signupBtn').href = SIGNUP_URL;
 
@@ -273,12 +356,16 @@
           login: login || null,
           platform,
           channelUrl: String(row.channelUrl || '').trim() || null,
+          // Optional and YouTube-only: the UC… id that makes an entry
+          // playable. Absent, a YouTube row is still a perfectly good
+          // link-out card.
+          channelId: String(row.channelId || '').trim() || null,
           name: String(row.name || '').trim() || login || '',
           blurb: String(row.blurb || '').trim(),
         };
         // An entry we can neither embed nor link is not a card, it is a
         // name with nowhere to go — drop it rather than render a dead tile.
-        if (!entry.login && !channelHref(entry)) continue;
+        if (!canEmbed(entry) && !channelHref(entry)) continue;
         if (!entry.name) continue;
         const key = keyOf(entry);
         if (seen.has(key)) continue;
@@ -324,11 +411,15 @@
   }
 
   /* ---------- live detection ----------
-   * No Twitch API key on a static page, so we lean on the public preview CDN:
+   * Per platform, and only where a status can actually be observed without a
+   * key. Every probe returns true / false / null, and null means "unknown" —
+   * a failed probe must never render as OFFLINE, which is a claim.
+   *
+   * Twitch: no API key on a static page, so we lean on the public preview CDN:
    * a live channel's thumbnail resolves normally, an offline one redirects to
    * Twitch's 404_preview image. If the CDN ever stops sending CORS headers
    * this degrades to "unknown" and the page simply shows no live badges. */
-  async function isLive(login) {
+  async function isLiveTwitch(login) {
     try {
       const r = await fetch(
         `https://static-cdn.jtvnw.net/previews-ttv/live_user_${encodeURIComponent(login)}-80x45.jpg?t=${Date.now()}`,
@@ -339,8 +430,47 @@
     } catch (_) { return null; }
   }
 
-  function thumbUrl(login) {
-    return `https://static-cdn.jtvnw.net/previews-ttv/live_user_${encodeURIComponent(login)}-440x248.jpg?t=${Math.floor(Date.now() / LIVE_POLL_MS)}`;
+  /* Kick answers a cross-origin GET with CORS headers, so the status is a
+   * plain read rather than an inference: `livestream` is null when the channel
+   * is off and an object (carrying a real preview frame) when it is on. A 404
+   * is a channel that does not exist — false, not unknown. Anything else, and
+   * any thrown fetch, stays unknown. */
+  async function isLiveKick(slug, key) {
+    try {
+      const r = await fetch('https://kick.com/api/v2/channels/' + encodeURIComponent(slug), {
+        mode: 'cors', cache: 'no-store',
+      });
+      if (r.status === 404) return false;
+      if (!r.ok) return null;
+      const body = await r.json();
+      const stream = body && body.livestream;
+      if (!stream || stream.is_live !== true) return false;
+      const thumb = stream.thumbnail && (stream.thumbnail.url || stream.thumbnail);
+      if (typeof thumb === 'string' && /^https:\/\//i.test(thumb)) preview.set(key, thumb);
+      return true;
+    } catch (_) { return null; }
+  }
+
+  /** Dispatch to the probe for `s`'s platform. Unknown when there is none. */
+  async function probeLive(s) {
+    const spec = platformOf(s);
+    const handle = embedHandle(s);
+    if (!spec.liveSignal || !handle) return null;
+    if (spec === PLATFORMS.twitch) return isLiveTwitch(handle);
+    if (spec === PLATFORMS.kick) return isLiveKick(handle, keyOf(s));
+    return null;
+  }
+
+  /** The live preview frame for a card, or null when the platform gives none. */
+  function thumbUrl(s) {
+    const spec = platformOf(s);
+    if (spec === PLATFORMS.twitch) {
+      const login = embedHandle(s);
+      return login
+        ? `https://static-cdn.jtvnw.net/previews-ttv/live_user_${encodeURIComponent(login)}-440x248.jpg?t=${Math.floor(Date.now() / LIVE_POLL_MS)}`
+        : null;
+    }
+    return preview.get(keyOf(s)) || null;
   }
 
   function initials(name) {
@@ -369,42 +499,72 @@
       return;
     }
 
-    const s = roster.find((x) => x.login === featured);
-    const login = esc(featured);
-    $('playerWho').textContent = s ? s.name : featured;
-    $('playerHandle').textContent = 'twitch.tv/' + featured;
-    $('playerOut').href = 'https://twitch.tv/' + encodeURIComponent(featured);
+    const s = entryFor(featured);
+    if (!s) { featured = null; renderFeatured(); return; }
+
+    const spec = platformOf(s);
+    const handle = embedHandle(s);
+    const href = channelHref(s);
+    const label = esc(channelLabel(s));
+    const who = esc(s.name);
+
+    $('playerWho').textContent = s.name;
+    $('playerHandle').textContent = channelLabel(s);
+    $('playerOut').textContent = `Watch on ${spec.label} ↗`;
+    if (href) { $('playerOut').href = href; $('playerOut').style.display = ''; }
+    else { $('playerOut').removeAttribute('href'); $('playerOut').style.display = 'none'; }
     bar.style.display = '';
 
-    if (!PARENT) {
-      // Opened from disk — Twitch refuses embeds without a parent domain.
-      chatShell.style.display = 'none';
+    // Twitch is the only platform whose chat embeds, and its chat — like its
+    // player — needs the parent domain.
+    const wantChat = spec.chat && !!PARENT;
+    chatShell.style.display = wantChat ? '' : 'none';
+    if (!wantChat) $('chatFrame').innerHTML = '';
+
+    // Twitch refuses embeds without a parent domain, which file:// has no way
+    // to supply. Kick and YouTube do not take a parent, so they still play.
+    if (spec === PLATFORMS.twitch && !PARENT) {
       frame.innerHTML = `
         <div class="player-empty">
           <div class="inner">
             ${MARK_EXTERNAL}
             <h3>Embeds need a web origin</h3>
             <p>Open this page from papertrench.com (or localhost) to watch inline,
-            or head straight to <a href="https://twitch.tv/${login}" target="_blank" rel="noopener">twitch.tv/${login}</a>.</p>
+            ${href ? `or head straight to <a href="${esc(href)}" target="_blank" rel="noopener">${label}</a>.` : 'or open the channel directly.'}</p>
+          </div>
+        </div>`;
+      return;
+    }
+
+    if (!handle || !spec.player) {
+      frame.innerHTML = `
+        <div class="player-empty">
+          <div class="inner">
+            ${MARK_EXTERNAL}
+            <h3>${who} streams on ${esc(spec.label)}</h3>
+            <p>This channel cannot be played here.
+            ${href ? `Watch it at <a href="${esc(href)}" target="_blank" rel="noopener">${label}</a>.` : ''}</p>
           </div>
         </div>`;
       return;
     }
 
     frame.innerHTML = `<iframe
-      src="https://player.twitch.tv/?channel=${encodeURIComponent(featured)}&parent=${encodeURIComponent(PARENT)}&muted=true&autoplay=true"
+      src="${esc(spec.player(handle))}"
       allowfullscreen allow="autoplay; fullscreen"
-      title="Twitch stream: ${login}"></iframe>`;
-    chatShell.style.display = '';
-    $('chatFrame').innerHTML = `<iframe
-      src="https://www.twitch.tv/embed/${encodeURIComponent(featured)}/chat?parent=${encodeURIComponent(PARENT)}&darkpopout"
-      title="Twitch chat: ${login}"></iframe>`;
+      title="${esc(spec.label)} stream: ${who}"></iframe>`;
+
+    if (wantChat) {
+      $('chatFrame').innerHTML = `<iframe
+        src="${esc(spec.chatUrl(handle))}"
+        title="${esc(spec.label)} chat: ${who}"></iframe>`;
+    }
   }
 
-  function setFeatured(login, { pinned = false, scroll = false } = {}) {
+  function setFeatured(key, { pinned = false, scroll = false } = {}) {
     if (pinned) userPinned = true;
-    if (featured === login) return;
-    featured = login;
+    if (featured === key) return;
+    featured = key;
     renderFeatured();
     if (scroll) $('watch').scrollIntoView({ behavior: 'smooth', block: 'start' });
   }
@@ -441,8 +601,8 @@
    */
   function orderedRoster() {
     const rank = (s) => {
-      if (live.get(s.login) === true) return 0;     // live now
-      if (platformOf(s).embeddable) return 1;       // playable, currently off
+      if (live.get(keyOf(s)) === true) return 0;    // live now
+      if (canEmbed(s)) return 1;                    // playable, status off or unknown
       return 2;                                     // link-out
     };
     return [...roster].sort((a, b) =>
@@ -455,19 +615,22 @@
     const cards = orderedRoster().map((s) => {
       const spec = platformOf(s);
       const href = channelHref(s);
-      const status = spec.embeddable ? live.get(s.login) : undefined;
+      const key = keyOf(s);
+      const plat = PLATFORMS[s.platform] ? s.platform : 'twitch';
+      const status = hasLiveSignal(s) ? live.get(key) : undefined;
       const isUp = status === true;
+      const frame = isUp ? thumbUrl(s) : null;
 
-      // Live/offline is a Twitch-only fact. Off Twitch the slot names the
-      // platform instead of guessing a status we cannot observe.
+      // A status is only ever printed where one can be observed. Everywhere
+      // else the slot names the platform rather than guessing.
       const badge = isUp
         ? '<span class="s-live on"><span class="dot"></span>LIVE</span>'
         : status === false
           ? '<span class="s-live off">OFFLINE</span>'
-          : `<span class="s-live plat ${esc(s.platform || 'twitch')}">${esc(spec.label)}</span>`;
+          : `<span class="s-live plat ${esc(plat)}">${esc(spec.label)}</span>`;
 
-      const thumb = isUp
-        ? `<img src="${thumbUrl(s.login)}" alt="Live preview of ${esc(s.name)}" loading="lazy">`
+      const thumb = frame
+        ? `<img src="${esc(frame)}" alt="Live preview of ${esc(s.name)}" loading="lazy">`
         : `<div class="ph">${esc(initials(s.name))}</div>`;
 
       const body = (handleLine) => `
@@ -481,13 +644,13 @@
       // its own link so reaching someone's actual channel does not mean
       // promoting them into the player first (two clicks and a scroll for
       // what is just a URL). stopPropagation keeps it from doing both.
-      if (spec.embeddable && s.login) {
+      if (canEmbed(s)) {
         const handleLine = href
           ? `<a class="s-handle" href="${esc(href)}" target="_blank" rel="noopener"
                data-out title="Open ${esc(channelLabel(s))}">${esc(channelLabel(s))} ↗</a>`
           : `<span class="s-handle">${esc(channelLabel(s))}</span>`;
         return `
-        <div class="s-card" data-login="${esc(s.login)}" role="button" tabindex="0"
+        <div class="s-card plat-${esc(plat)}" data-key="${esc(key)}" role="button" tabindex="0"
              title="Watch ${esc(s.name)} here">
           <div class="s-thumb">${thumb}${badge}${MARK_PLAY}</div>
           ${body(handleLine)}
@@ -498,7 +661,7 @@
       // a span. An <a> inside an <a> is not nestable markup: the parser closes
       // the outer one early and splits a single card into two broken tiles.
       return `
-        <a class="s-card link" href="${esc(href)}" target="_blank" rel="noopener"
+        <a class="s-card link plat-${esc(plat)}" href="${esc(href)}" target="_blank" rel="noopener"
            title="Open ${esc(s.name)} on ${esc(spec.label)}">
           <div class="s-thumb">${thumb}${badge}${MARK_OUT}</div>
           ${body(`<span class="s-handle">${esc(channelLabel(s))} ↗</span>`)}
@@ -513,8 +676,8 @@
       a.addEventListener('click', (e) => e.stopPropagation());
     });
 
-    grid.querySelectorAll('.s-card[data-login]').forEach((card) => {
-      const open = () => setFeatured(card.dataset.login, { pinned: true, scroll: true });
+    grid.querySelectorAll('.s-card[data-key]').forEach((card) => {
+      const open = () => setFeatured(card.dataset.key, { pinned: true, scroll: true });
       card.addEventListener('click', open);
       card.addEventListener('keydown', (e) => {
         if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open(); }
@@ -525,12 +688,13 @@
   /* ---------- live badge refresh loop ---------- */
   async function refreshLive() {
     if (!roster.length) return;
-    // Only Twitch has a live signal; asking the preview CDN about a Kick
-    // login would answer about a Twitch channel of the same name.
-    const checkable = roster.filter((s) => platformOf(s).embeddable && s.login);
-    await Promise.all(checkable.map(async (s) => live.set(s.login, await isLive(s.login))));
+    // Only platforms with a real signal are probed, and each is asked its own
+    // way — putting a Kick slug to Twitch's preview CDN would answer about a
+    // Twitch channel that happens to share the name.
+    const checkable = roster.filter(hasLiveSignal);
+    await Promise.all(checkable.map(async (s) => live.set(keyOf(s), await probeLive(s))));
 
-    const liveCount = checkable.filter((s) => live.get(s.login) === true).length;
+    const liveCount = checkable.filter((s) => live.get(keyOf(s)) === true).length;
     $('liveCountLabel').textContent = liveCount > 0
       ? `${liveCount} streamer${liveCount === 1 ? '' : 's'} live right now`
       : 'The PaperTrench Challenge';
@@ -543,8 +707,8 @@
     // the one to feature — and when exactly one channel is live, that is the
     // channel, which is the behaviour a single streamer should get for free.
     if (!userPinned) {
-      const firstLive = orderedRoster().find((s) => live.get(s.login) === true);
-      if (firstLive && live.get(featured) !== true) setFeatured(firstLive.login);
+      const firstLive = orderedRoster().find((s) => live.get(keyOf(s)) === true);
+      if (firstLive && live.get(featured) !== true) setFeatured(keyOf(firstLive));
     }
     renderGrid();
   }
@@ -554,14 +718,25 @@
     const requested = normalizeLogin(new URLSearchParams(location.search).get('channel'));
 
     const pickFeatured = () => {
-      if (requested && roster.some((s) => s.login === requested)) {
+      // ?channel=<login> stays a Twitch deep link — it shipped that way and
+      // the links are in the wild.
+      const asked = requested && roster.find((s) => s.login === requested);
+      if (asked) {
         userPinned = true;
-        featured = requested;
+        featured = keyOf(asked);
       } else if (!featured) {
-        // Only an embeddable entry can go in the player; a Kick card at the
-        // top of the order must not blank the player out.
-        const first = orderedRoster().find((s) => platformOf(s).embeddable && s.login);
-        if (first) featured = first.login;
+        // The opening pick happens before any probe has answered, so prefer a
+        // platform that can eventually report one. A signal-less platform in
+        // the player autoplays "video unavailable" whenever the channel is off,
+        // which is a bad thing to hand every visitor unasked.
+        //
+        // It is still the fallback when the roster has nothing better, because
+        // the alternative is the "roster is forming" empty state sitting above
+        // a grid full of streamers — and that is a plainly false statement,
+        // where YouTube's own player at least reports its real status.
+        const order = orderedRoster();
+        const first = order.find(hasLiveSignal) || order.find(canEmbed);
+        if (first) featured = keyOf(first);
       }
     };
 


### PR DESCRIPTION
Two asks from the project owner on `/streams`: let Kick and YouTube streams be **watched on the site** the way the featured Twitch streamer already is, and **colour-code each card by platform** (Kick green, Twitch purple, YouTube red).

## Why the existing `embeddable: false` was overridden

Kick and YouTube were deliberately non-embeddable, with a comment explaining why: no reliable embeddable player, and no live-status signal without guessing. **That reasoning was correct when written and is now partly out of date.** I re-probed both from `papertrench.com` on 2026-08-26 rather than trusting the write-ups (several of which are wrong about Kick):

| Platform | Player embed | Live status without a key |
|---|---|---|
| Twitch | `player.twitch.tv` | yes — preview CDN (unchanged) |
| Kick | `player.kick.com/<slug>` ✅ | **yes** — `kick.com/api/v2/channels/<slug>` answers a cross-origin fetch **with CORS headers** ✅ |
| YouTube | `/embed/live_stream?channel=<UC id>` ✅ | **no** ❌ |

Kick turns out to be full parity with Twitch — `livestream: null` when off, an object when on, carrying a real preview frame, so live Kick cards get a thumbnail exactly like Twitch cards. Public scraping guides claim this endpoint is Cloudflare-locked to browsers; that is not true for a plain cross-origin `GET` today, and it is verified live in the commit.

**YouTube live-detection genuinely cannot work client-side**, and I want to be explicit about that rather than ship something that silently never fires: the channel `/live` page and the RSS feed are both CORS-blocked, and oEmbed 404s on the `live_stream` URL. Real status needs a Data API key this static site has nowhere to keep.

## The design change

`embeddable` was conflating two different questions, which is what forced the all-or-nothing call on YouTube. Split into:

- `embeddable` — can a player be mounted?
- `liveSignal` — can live/offline be **observed** without a server-side key?

That lets YouTube play inline **without** ever claiming a status. The honesty rule is kept exactly where it matters:

- A platform with no live signal is **never auto-promoted into the featured player** — that would autoplay "video unavailable" for every visitor whenever the channel is off. Clicking its card still plays it; that is the visitor asking, and the embed then reports its own truth.
- A failed probe stays **unknown** and renders no badge. It never renders `OFFLINE`, which is a claim.

**YouTube needs the `UC…` channel id** (a `/@handle` URL can't be resolved to one client-side). Entries carry `channelId`, or use the `/channel/UC…` URL form. Without one the card stays a link-out rather than mounting a player keyed on a guess.

Because live/featured state is no longer Twitch-shaped, `live` and `featured` are keyed by `keyOf()` instead of Twitch login (a Kick entry has no login). `?channel=<login>` stays a Twitch deep link — those URLs are in the wild.

## Card accent

The badge already spoke each platform's colour; everything below it was hardcoded Twitch purple, so a Kick card and a Twitch card were identical below the badge. One `--accent` pair per card, set by a `plat-*` class, now carries the platform through the **handle, hover border, hover glow and placeholder**. The open "your stream here" slot is an invitation rather than a platform, so it keeps the brand orange.

**One PR rather than two:** the accent keys off the `plat-*` class the embed change emits, and both land in the same two files — splitting them would have made the second PR a conflict against the first.

## Also included

- Drops a dead selector still pointing at the old `data-login` attribute.
- Updates two lines of page copy the change made false: the limits callout still said live badges were Twitch preview images, and the signup strip still said "Any Twitch streamer".
- `docs/STREAMS.md` updated with the capability table and the per-platform live-detection rules.

## Testing

Ran the real page against the live roster and against temporary Kick/YouTube fixtures:

- live Kick card → `LIVE` + Kick's own thumbnail; offline Kick → `OFFLINE` (previously it could only show the platform name)
- YouTube with a UC id → plays on click, chat shell correctly torn down; YouTube with only a handle → stays a link-out anchor
- per-platform accents resolve to the right colours, and the open slot keeps brand orange
- Twitch path unchanged end-to-end (player, chat, deep link)

Suites green: **2072 extension, 201 server**.

> Note: `scripts/preflight.sh` could not run locally (no working Python on this machine — only the Windows Store alias stubs). I ran its site-relevant gates by hand instead: the extensionless-URL rule, nav destinations, and the a11y landmarks all pass. CI runs the full script.

## One judgment call left for you

The page `<title>`, `og:` tags and `<h1>` still say **"Live on Twitch"**, which is now inaccurate. I left them alone deliberately — retitling the page affects SEO and social previews, so it reads as your call rather than a side effect of this PR. Happy to follow up if you want it changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
