### PR TITLE
admin: /admin-mod only ever showed the first 100 accounts and 200 clans

### DIFF
--- a/docs/STREAMS.md
+++ b/docs/STREAMS.md
@@ -168,6 +168,15 @@ on the page:
 Ban and disqualify are separate deliberately: collapsed into one flag, taking a
 duplicate chain off the board would require banning its owner.
 
+Both lists **page**, 100 rows at a time, and print what they are showing out of
+what exists ("Showing 100 of 347 accounts"). They used to take a flat
+`LIMIT 100` / `LIMIT 200` with no paging and no total, so past the cap the rows
+were simply absent with nothing on the page saying so — and since the clans view
+has no search box, a clan past the first 200 could not be reached from the
+console at all. `server/core/admin.js` owns the queries; note that every
+ORDER BY there ends in a unique id, because paging over a non-unique sort key
+drops and repeats rows across page boundaries.
+
 Enforcement is in SQL on the leaderboard and Sprint queries, not in the page —
 there is no board, cache or export that can still be showing a banned account.
 

--- a/server/core/admin.js
+++ b/server/core/admin.js
@@ -1,0 +1,150 @@
+/* PaperTrench server — moderation console list reads.
+ *
+ * The console shows accounts and clans a moderator acts on, so what it does
+ * NOT show is a correctness problem rather than a cosmetic one. Both lists
+ * shipped as a bare `LIMIT` — 100 accounts, 200 clans — with no paging and no
+ * total, which produced the failure this file exists to fix:
+ *
+ *   - Past the cap the rows simply were not there. The accounts view has a
+ *     search box, so a moderator who knew a handle could still reach it; the
+ *     clans view has no search at all, so clan 201 was unreachable from the
+ *     console entirely.
+ *   - Nothing said the list was cut. A hundred rows and a hundred-and-first
+ *     account look identical from the page, so "no such account" and "beyond
+ *     the limit" were the same screen. That is exactly the confidently-wrong
+ *     answer the rest of this project refuses to give.
+ *
+ * So the queries page, and they report `total` — the console can then say what
+ * it is showing out of what exists, rather than implying it is showing all.
+ *
+ * THE ORDERING TIEBREAK IS LOAD-BEARING. `last_login_at` and `created_at` are
+ * not unique, and SQLite gives no stable order among equal keys. Paging on a
+ * non-deterministic ORDER BY silently drops rows and repeats others across
+ * page boundaries — the same class of bug as the missing rows above, and the
+ * reason every ORDER BY here ends in a unique id.
+ */
+'use strict';
+
+/** Rows per page when the caller does not say. */
+const DEFAULT_PAGE = 100;
+
+/** Ceiling on a caller-supplied page size, so one request cannot ask for the
+ *  whole table and bill D1 for it. Paging past this is free; asking for it in
+ *  one shot is not. */
+const MAX_PAGE = 200;
+
+/** A page size: a positive integer, clamped to MAX_PAGE, else the default. */
+function pageSize(raw) {
+  const n = Math.floor(Number(raw));
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_PAGE;
+  return Math.min(n, MAX_PAGE);
+}
+
+/** An offset: a non-negative integer, else 0. Garbage must not become SQL. */
+function pageOffset(raw) {
+  const n = Math.floor(Number(raw));
+  if (!Number.isFinite(n) || n <= 0) return 0;
+  return n;
+}
+
+/** LIKE pattern for a search term, with the wildcards the user typed removed
+ *  so a bare `%` cannot match every account. */
+function likeTerm(term) {
+  return '%' + String(term == null ? '' : term).replace(/[%_]/g, '') + '%';
+}
+
+/**
+ * The accounts list, paged.
+ *
+ * The joins are all 1:1 — `records.user_id` and `clan_members.user_id` are
+ * both PRIMARY KEY — so LIMIT counts accounts rather than joined rows. Adding
+ * a one-to-many join here without a GROUP BY would quietly turn the page size
+ * back into a lie.
+ */
+function adminUsersQuery(options) {
+  const opts = options || {};
+  const term = String(opts.term == null ? '' : opts.term).trim().toLowerCase();
+  const limit = pageSize(opts.limit);
+  const offset = pageOffset(opts.offset);
+  const like = likeTerm(term);
+
+  const where = `WHERE (?1 = '' OR LOWER(u.handle) LIKE ?2
+                     OR LOWER(COALESCE(u.display_name, '')) LIKE ?2
+                     OR u.x_id LIKE ?2)`;
+
+  return {
+    limit,
+    offset,
+    sql: `
+    SELECT u.id, u.handle, u.display_name, u.x_id, u.avatar_url,
+           u.created_at, u.last_login_at, u.banned_at, u.banned_reason,
+           r.status AS record_status, r.chain_len, r.stats_json, r.dq_at, r.dq_reason,
+           cl.tag AS clan_tag
+      FROM users u
+      LEFT JOIN records r ON r.user_id = u.id
+      LEFT JOIN clan_members cm ON cm.user_id = u.id
+      LEFT JOIN clans cl ON cl.id = cm.clan_id
+     ${where}
+     ORDER BY u.last_login_at DESC, u.id DESC
+     LIMIT ?3 OFFSET ?4`,
+    binds: [term, like, limit, offset],
+    countSql: `SELECT COUNT(*) AS n FROM users u ${where}`,
+    countBinds: [term, like],
+  };
+}
+
+/**
+ * The clans list, paged.
+ *
+ * No search box exists for clans, which is what made the old cap absolute
+ * rather than merely inconvenient — paging is the whole route to a clan past
+ * the first page.
+ */
+function adminClansQuery(options) {
+  const opts = options || {};
+  const limit = pageSize(opts.limit);
+  const offset = pageOffset(opts.offset);
+
+  return {
+    limit,
+    offset,
+    sql: `
+    SELECT c.id, c.tag, c.name, c.motto, c.open, c.created_at,
+           c.disbanded_at, c.disbanded_reason,
+           f.handle AS founder,
+           (SELECT COUNT(*) FROM clan_members m WHERE m.clan_id = c.id) AS members
+      FROM clans c LEFT JOIN users f ON f.id = c.founder_id
+     ORDER BY c.created_at DESC, c.id DESC
+     LIMIT ?1 OFFSET ?2`,
+    binds: [limit, offset],
+    countSql: `SELECT COUNT(*) AS n FROM clans`,
+    countBinds: [],
+  };
+}
+
+/**
+ * What the page needs to know about where it sits in the list.
+ *
+ * `total` is the honest denominator; `hasMore` is derived from the offset and
+ * the rows actually returned rather than from the requested limit, so a short
+ * final page ends the walk instead of offering a "Load more" that fetches
+ * nothing.
+ */
+function pageInfo(total, offset, returned) {
+  const n = Math.max(0, Math.floor(Number(total)) || 0);
+  const from = Math.max(0, Math.floor(Number(offset)) || 0);
+  const got = Math.max(0, Math.floor(Number(returned)) || 0);
+  const next = from + got;
+  return { total: n, offset: from, returned: got, hasMore: got > 0 && next < n, nextOffset: next };
+}
+
+module.exports = {
+  DEFAULT_PAGE,
+  MAX_PAGE,
+  pageSize,
+  pageOffset,
+  likeTerm,
+  adminUsersQuery,
+  adminClansQuery,
+  pageInfo,
+};

--- a/server/test/admin.test.js
+++ b/server/test/admin.test.js
@@ -1,0 +1,180 @@
+/* The moderation console's list reads.
+ *
+ * The bug these exist for: both lists shipped as a bare LIMIT (100 accounts,
+ * 200 clans) with no paging and no total, so past the cap the rows were simply
+ * absent and nothing on the page said so. The clans view has no search box, so
+ * clan 201 was unreachable from the console at all.
+ *
+ * Two things are asserted here, and the second is the subtle one:
+ *
+ *  1. Every row is REACHABLE by walking the pages — the count is derived from
+ *     a simulated table rather than pasted, so it cannot bless an off-by-one.
+ *  2. The walk is EXHAUSTIVE AND DISJOINT. Paging over a non-unique ORDER BY
+ *     silently drops rows and repeats others across page boundaries, which
+ *     looks exactly like the bug it was meant to fix. The ORDER BY therefore
+ *     ends in a unique id, and the walk below is checked for both loss and
+ *     duplication, not merely for total count.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const A = require('../core/admin.js');
+
+/* ---------- page-size and offset clamping ---------- */
+
+test('page size falls back to the default and is capped', () => {
+  assert.equal(A.pageSize(undefined), A.DEFAULT_PAGE);
+  assert.equal(A.pageSize(null), A.DEFAULT_PAGE);
+  assert.equal(A.pageSize(''), A.DEFAULT_PAGE);
+  assert.equal(A.pageSize('not a number'), A.DEFAULT_PAGE);
+  assert.equal(A.pageSize(0), A.DEFAULT_PAGE);
+  assert.equal(A.pageSize(-5), A.DEFAULT_PAGE);
+  assert.equal(A.pageSize(25), 25);
+  assert.equal(A.pageSize('25'), 25);
+  // One request must not be able to ask for the whole table.
+  assert.equal(A.pageSize(1e9), A.MAX_PAGE);
+  assert.equal(A.pageSize(A.MAX_PAGE + 1), A.MAX_PAGE);
+});
+
+test('offset refuses garbage rather than passing it to SQL', () => {
+  assert.equal(A.pageOffset(undefined), 0);
+  assert.equal(A.pageOffset('abc'), 0);
+  assert.equal(A.pageOffset(-10), 0);
+  assert.equal(A.pageOffset('40'), 40);
+  assert.equal(A.pageOffset(40.9), 40);
+});
+
+test('a search term cannot smuggle in LIKE wildcards', () => {
+  // A bare % would otherwise match every account, which is the opposite of
+  // what a moderator typing it means.
+  assert.equal(A.likeTerm('%'), '%%');
+  assert.equal(A.likeTerm('a_b%c'), '%abc%');
+  assert.equal(A.likeTerm(''), '%%');
+  assert.equal(A.likeTerm(null), '%%');
+});
+
+/* ---------- the ordering tiebreak ---------- */
+
+test('both list queries order by a unique id last', () => {
+  // Without this, equal last_login_at / created_at values have no defined
+  // order, and a paged walk over them loses and repeats rows.
+  assert.match(A.adminUsersQuery({}).sql, /ORDER BY u\.last_login_at DESC, u\.id DESC/);
+  assert.match(A.adminClansQuery({}).sql, /ORDER BY c\.created_at DESC, c\.id DESC/);
+});
+
+test('both list queries page rather than truncating', () => {
+  const users = A.adminUsersQuery({ limit: 10, offset: 30 });
+  assert.match(users.sql, /LIMIT \?3 OFFSET \?4/);
+  assert.deepEqual(users.binds.slice(2), [10, 30]);
+
+  const clans = A.adminClansQuery({ limit: 10, offset: 30 });
+  assert.match(clans.sql, /LIMIT \?1 OFFSET \?2/);
+  assert.deepEqual(clans.binds, [10, 30]);
+});
+
+test('the accounts search also matches a display name', () => {
+  // A moderator handed a display name had no way to find the account before.
+  const { sql } = A.adminUsersQuery({ term: 'x' });
+  assert.match(sql, /LOWER\(COALESCE\(u\.display_name, ''\)\) LIKE \?2/);
+});
+
+test('the count query counts the same set the page selects', () => {
+  // A total taken from a different WHERE would be a confidently wrong
+  // denominator — worse than no denominator.
+  const { sql, countSql, binds, countBinds } = A.adminUsersQuery({ term: 'ab' });
+  const whereOf = (s) => s.slice(s.indexOf('WHERE')).replace(/\s+/g, ' ').split('ORDER BY')[0].trim();
+  assert.equal(whereOf(countSql), whereOf(sql));
+  assert.deepEqual(countBinds, binds.slice(0, 2));
+});
+
+/* ---------- pageInfo ---------- */
+
+test('pageInfo reports more only while rows remain', () => {
+  assert.deepEqual(A.pageInfo(250, 0, 100), { total: 250, offset: 0, returned: 100, hasMore: true, nextOffset: 100 });
+  assert.deepEqual(A.pageInfo(250, 100, 100), { total: 250, offset: 100, returned: 100, hasMore: true, nextOffset: 200 });
+  // The last page is short: the walk ends here rather than offering a
+  // "Load more" that would fetch nothing.
+  assert.deepEqual(A.pageInfo(250, 200, 50), { total: 250, offset: 200, returned: 50, hasMore: false, nextOffset: 250 });
+});
+
+test('pageInfo never promises more after an empty page', () => {
+  assert.equal(A.pageInfo(250, 250, 0).hasMore, false);
+  assert.equal(A.pageInfo(0, 0, 0).hasMore, false);
+});
+
+/* ---------- the walk: every row reachable, exactly once ---------- */
+
+/**
+ * A stand-in table ordered exactly as the SQL orders it, then served through
+ * the same limit/offset the handler computes. This is what proves the paging
+ * contract without needing D1 — node:sqlite is unavailable on Node 20, which
+ * is what CI runs.
+ */
+function walk(total, { pageLimit, ties = 1 }) {
+  // `ties` collapses the sort key so many rows share one — the condition that
+  // breaks a paged walk when the ORDER BY has no unique tiebreak.
+  const rows = Array.from({ length: total }, (_, i) => ({
+    id: i + 1,
+    sortKey: Math.floor(i / ties),
+  }));
+
+  const seen = [];
+  let offset = 0;
+  for (let guard = 0; guard <= total + 2; guard++) {
+    const q = A.adminUsersQuery({ limit: pageLimit, offset });
+
+    // Order the way the QUERY says to, not the way this test would like. If
+    // the SQL carries the unique tiebreak the order is total and stable; if it
+    // does not, ties have no defined order and SQLite is free to return them
+    // differently per statement. `spin` models exactly that freedom — it is
+    // what turns a missing tiebreak into observable row loss below, instead of
+    // a bug this helper quietly papers over.
+    const stable = /ORDER BY[^]*?u\.id\b/.test(q.sql);
+    // Alternate the tie order page to page: the mildest possible instability,
+    // and enough to lose rows if the query relies on ties landing the same way
+    // twice. A stable query is unaffected by it.
+    const flip = !stable && Math.floor(q.offset / Math.max(1, q.limit)) % 2 === 1;
+    const ordered = [...rows].sort((a, b) =>
+      b.sortKey - a.sortKey || (flip ? a.id - b.id : b.id - a.id));
+
+    const page = ordered.slice(q.offset, q.offset + q.limit);
+    seen.push(...page.map((r) => r.id));
+    const info = A.pageInfo(total, q.offset, page.length);
+    if (!info.hasMore) return seen;
+    offset = info.nextOffset;
+  }
+  throw new Error('page walk did not terminate');
+}
+
+test('a walk reaches every account past the old 100-row cap', () => {
+  const total = 347;                       // more than the old LIMIT 100
+  const seen = walk(total, { pageLimit: 100 });
+  assert.equal(seen.length, total, 'walk did not return every row');
+  assert.equal(new Set(seen).size, total, 'walk returned a row twice');
+  // Derived from the input, not pasted: every id 1..total exactly once.
+  assert.deepEqual([...seen].sort((a, b) => a - b), Array.from({ length: total }, (_, i) => i + 1));
+});
+
+test('a walk stays exhaustive when tied sort keys straddle a page edge', () => {
+  // 150 rows per distinct sort-key value against a 100-row page, so a tie
+  // group deliberately spans a page boundary — the only place a missing
+  // ORDER BY tiebreak can actually lose a row. (Ties that align exactly with
+  // the page size cannot show the bug, which is why this is 150 and not 100.)
+  const total = 400;
+  const seen = walk(total, { pageLimit: 100, ties: 150 });
+  assert.equal(seen.length, total, 'tied sort keys returned the wrong row count');
+  assert.equal(new Set(seen).size, total, 'tied sort keys lost or duplicated rows');
+});
+
+test('a walk terminates when the total is an exact multiple of the page', () => {
+  // The off-by-one case: the final full page must not promise another one.
+  const total = 200;
+  const seen = walk(total, { pageLimit: 100 });
+  assert.equal(seen.length, total);
+  assert.equal(new Set(seen).size, total);
+});
+
+test('a single short page is the whole list', () => {
+  const seen = walk(7, { pageLimit: 100 });
+  assert.deepEqual(seen.sort((a, b) => a - b), [1, 2, 3, 4, 5, 6, 7]);
+});

--- a/server/worker/index.js
+++ b/server/worker/index.js
@@ -16,6 +16,7 @@ import { windowOf, sprintEntry } from '../core/sprint.js';
 import { windowEntry } from '../core/window.js';
 import { awarded } from '../core/achievements.js';
 import * as duel from '../core/duel.js';
+import * as adminCore from '../core/admin.js';
 import * as clan from '../core/clan.js';
 import * as streamer from '../core/streamer.js';
 // Default-imported, not named: core/chain.js re-exports attest.js by property
@@ -1654,24 +1655,23 @@ async function handleAdminUsers(request, env) {
   const mod = await moderator(request, env);
   if (!mod) return json({ ok: false, reason: 'not-a-moderator' }, 403);
 
-  const term = (new URL(request.url).searchParams.get('q') || '').trim().toLowerCase();
-  const like = '%' + term.replace(/[%_]/g, '') + '%';
-  const rows = await env.DB.prepare(`
-    SELECT u.id, u.handle, u.display_name, u.x_id, u.avatar_url,
-           u.created_at, u.last_login_at, u.banned_at, u.banned_reason,
-           r.status AS record_status, r.chain_len, r.stats_json, r.dq_at, r.dq_reason,
-           cl.tag AS clan_tag
-      FROM users u
-      LEFT JOIN records r ON r.user_id = u.id
-      LEFT JOIN clan_members cm ON cm.user_id = u.id
-      LEFT JOIN clans cl ON cl.id = cm.clan_id
-     WHERE (?1 = '' OR LOWER(u.handle) LIKE ?2 OR u.x_id LIKE ?2)
-     ORDER BY u.last_login_at DESC
-     LIMIT 100`).bind(term, like).all();
+  const params = new URL(request.url).searchParams;
+  const q = adminCore.adminUsersQuery({
+    term: params.get('q') || '',
+    limit: params.get('limit'),
+    offset: params.get('offset'),
+  });
+
+  const [rows, counted] = await Promise.all([
+    env.DB.prepare(q.sql).bind(...q.binds).all(),
+    env.DB.prepare(q.countSql).bind(...q.countBinds).first(),
+  ]);
+  const results = rows.results || [];
 
   return json({
     ok: true,
-    users: (rows.results || []).map((r) => {
+    page: adminCore.pageInfo(counted ? counted.n : 0, q.offset, results.length),
+    users: results.map((r) => {
       const stats = r.stats_json ? JSON.parse(r.stats_json) : null;
       return {
         id: r.id, handle: r.handle, displayName: r.display_name, xId: r.x_id,
@@ -1802,17 +1802,22 @@ async function handleAdminClans(request, env) {
   const mod = await moderator(request, env);
   if (!mod) return json({ ok: false, reason: 'not-a-moderator' }, 403);
 
-  const rows = await env.DB.prepare(`
-    SELECT c.id, c.tag, c.name, c.motto, c.open, c.created_at,
-           c.disbanded_at, c.disbanded_reason,
-           f.handle AS founder,
-           (SELECT COUNT(*) FROM clan_members m WHERE m.clan_id = c.id) AS members
-      FROM clans c LEFT JOIN users f ON f.id = c.founder_id
-     ORDER BY c.created_at DESC LIMIT 200`).all();
+  const params = new URL(request.url).searchParams;
+  const q = adminCore.adminClansQuery({
+    limit: params.get('limit'),
+    offset: params.get('offset'),
+  });
+
+  const [rows, counted] = await Promise.all([
+    env.DB.prepare(q.sql).bind(...q.binds).all(),
+    env.DB.prepare(q.countSql).bind(...q.countBinds).first(),
+  ]);
+  const results = rows.results || [];
 
   return json({
     ok: true,
-    clans: (rows.results || []).map((c) => ({
+    page: adminCore.pageInfo(counted ? counted.n : 0, q.offset, results.length),
+    clans: results.map((c) => ({
       id: c.id, tag: c.tag, name: c.name, motto: c.motto || '',
       open: Boolean(c.open), createdAt: c.created_at, founder: c.founder || null,
       members: c.members || 0,

--- a/site/admin-mod.html
+++ b/site/admin-mod.html
@@ -149,6 +149,11 @@
 
   .state { text-align: center; padding: 54px 20px; color: var(--muted); font-size: 14px; }
   .state .big { font-size: 34px; margin-bottom: 12px; opacity: 0.8; }
+
+  .pager { display: flex; align-items: center; gap: 14px; justify-content: center;
+    flex-wrap: wrap; padding: 18px 4px 4px; }
+  .pager-count { font-family: var(--mono); font-size: 11.5px; letter-spacing: 0.4px;
+    color: var(--dim); }
 </style>
 </head>
 <body>
@@ -222,10 +227,17 @@
       </div>
 
       <div class="searchbar" id="searchbar">
-        <input class="ar-input" type="search" id="q" placeholder="Search by handle or X user id…" autocomplete="off">
+        <input class="ar-input" type="search" id="q" placeholder="Search by handle, display name or X user id…" autocomplete="off">
       </div>
 
       <div class="rowset" id="rows"></div>
+
+      <!-- What is on screen out of what exists. A truncated list that looks
+           complete is the bug this replaced, so the count is always shown. -->
+      <div class="pager" id="pager" hidden>
+        <span class="pager-count" id="pagerCount"></span>
+        <button class="ar-btn" type="button" id="moreBtn" hidden>Load more</button>
+      </div>
 
       <div class="ledger">
         <h2>Moderation ledger</h2>

--- a/site/admin-mod.js
+++ b/site/admin-mod.js
@@ -244,35 +244,76 @@
 
   let view = 'accounts';
   let term = '';
+  let shown = 0;        // rows already on screen, and the offset of the next page
 
-  async function loadRows() {
+  function setPager(page) {
+    const pager = $('pager');
+    const more = $('moreBtn');
+    // No page block from the server means an older Worker: say nothing rather
+    // than invent a total.
+    if (!page) { pager.hidden = true; more.hidden = true; return; }
+    const noun = view === 'accounts' ? 'account' : 'clan';
+    pager.hidden = false;
+    $('pagerCount').textContent = page.total === shown
+      ? `${shown} ${noun}${shown === 1 ? '' : 's'}`
+      : `Showing ${shown} of ${page.total} ${noun}${page.total === 1 ? '' : 's'}`;
+    more.hidden = !page.hasMore;
+    more.disabled = false;
+    more.textContent = 'Load more';
+  }
+
+  /**
+   * Load a page of rows.
+   *
+   * `append` continues the current list; without it this is a fresh read and
+   * the offset goes back to zero. Both views paginate, because the cap used to
+   * be silent — and for clans, which have no search box, paging is the only
+   * route to a row past the first page.
+   */
+  async function loadRows({ append = false } = {}) {
     const box = $('rows');
-    box.innerHTML = '<div class="state"><div class="big">⏳</div>Loading…</div>';
+    if (!append) {
+      shown = 0;
+      box.innerHTML = '<div class="state"><div class="big">⏳</div>Loading…</div>';
+      $('pager').hidden = true;
+    }
     $('searchbar').hidden = (view !== 'accounts');
 
-    const path = view === 'accounts'
-      ? '/api/admin/users?q=' + encodeURIComponent(term)
-      : '/api/admin/clans';
+    const query = new URLSearchParams({ offset: String(append ? shown : 0) });
+    if (view === 'accounts') query.set('q', term);
+    const path = (view === 'accounts' ? '/api/admin/users?' : '/api/admin/clans?') + query;
     const { status, body } = await api(path);
 
     if (status === 403) { await boot(); return; }
     if (status < 200 || status >= 300 || !body || !body.ok) {
       // Say the read failed. "No accounts" would be a claim about the data,
       // made while we cannot see it.
+      if (append) {
+        const more = $('moreBtn');
+        more.disabled = false;
+        more.textContent = 'Couldn’t load more — retry';
+        return;
+      }
       box.innerHTML = '<div class="state"><div class="big">⚠️</div>'
         + 'Couldn’t load that. Refresh to try again.</div>';
       return;
     }
 
     const list = view === 'accounts' ? (body.users || []) : (body.clans || []);
-    if (!list.length) {
+    if (!append && !list.length) {
       box.innerHTML = `<div class="state"><div class="big">🗂️</div>${
         view === 'accounts'
           ? (term ? 'No account matches that.' : 'No accounts yet.')
           : 'No clans yet.'}</div>`;
+      $('pager').hidden = true;
       return;
     }
-    box.innerHTML = list.map(view === 'accounts' ? accountRow : clanRow).join('');
+
+    const html = list.map(view === 'accounts' ? accountRow : clanRow).join('');
+    if (append) box.insertAdjacentHTML('beforeend', html);
+    else box.innerHTML = html;
+    shown += list.length;
+    setPager(body.page);
   }
 
   async function loadLog() {
@@ -349,6 +390,13 @@
     box.querySelectorAll('button[data-do]').forEach((b) => { b.disabled = false; });
     msg.textContent = REASONS[body && body.reason] || 'That didn’t save — try again.';
     msg.className = 'act-msg err';
+  });
+
+  $('moreBtn').addEventListener('click', async () => {
+    const more = $('moreBtn');
+    more.disabled = true;
+    more.textContent = 'Loading…';
+    await loadRows({ append: true });
   });
 
   $('tabs').addEventListener('click', (event) => {


### PR DESCRIPTION
Reported by the project owner: **the moderation console isn't loading all the clan and player data — records are missing.**

## Root cause

Not a filter and not a join. `handleAdminUsers` and `handleAdminClans` each took a flat cap, with no paging and no total:

```sql
users  ORDER BY u.last_login_at DESC LIMIT 100
clans  ORDER BY c.created_at   DESC LIMIT 200
```

Past the cap the rows were simply **absent, and nothing on the page said so**. A hundred accounts and a hundred-and-first look identical from the console, so "no such account" and "beyond the limit" were the same screen.

The two views failed differently, which matches the report on both counts:

- **Accounts** — a moderator who already knew a handle could still find one via the search box, so this looked intermittent.
- **Clans** — there is no clan search box at all, so **clan 201 was unreachable from the console entirely**.

> Ruled out first: the `LEFT JOIN`s onto `records` / `clan_members` cannot fan out and inflate the row count — both tables have `user_id` as `PRIMARY KEY`, so `LIMIT` was counting accounts and not joined rows. Worth stating because that would have been the other obvious suspect.

## The fix

Queries move into **`server/core/admin.js`** as pure builders (the repo's push-I/O-to-the-edges rule, and it makes them testable without D1). They now page with `limit`/`offset` and return a `total`. The console loads 100 at a time behind a **Load more**, and always prints what it is showing out of what exists — *"Showing 100 of 347 accounts"*. Page size is clamped to 200 so one request cannot ask for the whole table and bill D1 for it.

### The ORDER BY tiebreak is part of the fix, not tidying

`last_login_at` and `created_at` are **not unique**, and SQLite gives no defined order among equal keys. Paging over a non-deterministic sort silently drops rows and repeats others across page boundaries — which would have reintroduced the reported bug in a form much harder to spot than the original. Every `ORDER BY` now ends in a unique id.

### Also

The accounts search now matches `display_name`, not just `handle` and `x_id` — a moderator handed a display name had no way to look the account up.

## Tests

13 new in `server/test/admin.test.js`: page-size clamping, offset sanitising, LIKE-wildcard stripping, the count query covering the same `WHERE` as the page (a total from a different filter would be a confidently wrong denominator), and a **page walk** asserting every row is reachable **exactly once** — checked for loss *and* duplication, including a case where tied sort keys deliberately straddle a page edge, which is the only place a missing tiebreak can actually lose a row.

The walk derives its ordering from the `ORDER BY` in the generated SQL rather than from the test's own assumption, so it genuinely fails when the tiebreak is removed. My first draft of that helper sorted the rows itself and passed either way; it's worth flagging since that version would have looked like coverage without being any.

**Verified failing before passing**, per CONTRIBUTING:

| Mutation | Result |
|---|---|
| drop the unique tiebreak | 2 tests red |
| force offset to 0 (the old un-paged read) | 5 tests red |
| pin `hasMore` to false | 4 tests red |

The paging UI was also exercised end to end against a stubbed API: 347 rows reached over four pages at the right offsets, clans paging independently, tab switch and search both resetting to offset 0, and the button retiring on a short final page.

**214 server tests green** (201 + 13). Worker entry imports cleanly; `check-schema-drift.js` clean.

> `scripts/preflight.sh` could not run locally (no working Python on this machine — only Windows Store alias stubs). Its site-relevant gates pass by hand: extensionless-URL rule, nav destinations, a11y landmarks. CI runs the full script.

## Note on the leaderboard-moderation ask

Nothing was needed there. `site/admin-mod.html`/`.js` already implements disqualify / ban / disband with the append-only ledger, and it works — it was appearing broken because of this bug. No changes made to that behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
