### PR TITLE
leaderboard: the board says it is empty instead of disappearing

### DIFF
--- a/site/arena.css
+++ b/site/arena.css
@@ -1655,3 +1655,111 @@
   .ar-segbar i,
   .ar-window i { transform: scaleX(1); }
 }
+
+/* ==================================================================== *
+ *  Leaderboard board furniture — title bar, window control, medal tone,
+ *  and the empty podium.
+ *
+ *  The board already had a podium and a ranked tower; the reason nobody
+ *  could see ranks was that both panes were display:none whenever the
+ *  entry list came back empty, which it always does right now. So the
+ *  board states its own emptiness instead of vanishing, and the seats
+ *  that have nobody in them are drawn as obviously-open seats rather
+ *  than as placeholder people.
+ * ==================================================================== */
+
+.lb-bar {
+  display: flex; align-items: baseline; gap: 14px;
+  padding: 4px 2px 14px; border-bottom: 1px solid var(--line);
+}
+.lb-title {
+  display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap;
+  font-size: 20px; font-weight: 700; letter-spacing: -0.01em;
+}
+.lb-date {
+  font-family: var(--mono); font-size: 11px; font-weight: 500;
+  letter-spacing: 0.6px; color: var(--dim); text-transform: uppercase;
+}
+.lb-refresh {
+  margin-left: auto; flex: none; display: grid; place-items: center;
+  width: 32px; height: 32px; border-radius: 9px; cursor: pointer;
+  color: var(--muted); background: rgba(255,255,255,0.035); border: var(--edge);
+  transition: color .16s, background .16s, border-color .16s, transform .3s;
+}
+.lb-refresh:hover { color: var(--text); background: rgba(255,255,255,0.08); border-color: var(--line2); }
+.lb-refresh.spin svg { animation: lb-spin .7s linear; }
+@keyframes lb-spin { to { transform: rotate(360deg); } }
+
+.lb-filters {
+  display: flex; align-items: center; gap: 12px; flex-wrap: wrap;
+  padding: 14px 2px 0;
+}
+.lb-scope {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-size: 12.5px; font-weight: 700; color: var(--muted);
+  background: rgba(255,255,255,0.035); border: var(--edge);
+  border-radius: 999px; padding: 7px 14px;
+}
+.lb-windows { margin-left: auto; display: inline-flex; gap: 4px;
+  background: rgba(0,0,0,0.28); border: var(--edge); border-radius: 999px; padding: 3px; }
+.lb-win {
+  font: inherit; font-size: 12px; font-weight: 700; cursor: pointer;
+  color: var(--dim); background: none; border: 0; border-radius: 999px; padding: 6px 13px;
+  transition: color .16s, background .16s;
+}
+.lb-win:hover { color: var(--text); }
+.lb-win.on { color: #2a1a05; background: var(--grad-heat); }
+.lb-winnote {
+  font-size: 12px; color: var(--dim); line-height: 1.55;
+  padding: 10px 2px 0; margin: 0;
+}
+
+/* Medal tone on 2nd and 3rd. The tokens existed and went unused, so every
+   seat but first read as the same neutral card. */
+.ar-pod.rank-2 {
+  border-color: rgba(207, 216, 230, 0.30);
+  background: linear-gradient(180deg, rgba(207, 216, 230, 0.07), rgba(255,255,255,0.012));
+}
+.ar-pod.rank-3 {
+  border-color: rgba(224, 151, 90, 0.30);
+  background: linear-gradient(180deg, rgba(224, 151, 90, 0.07), rgba(255,255,255,0.012));
+}
+.ar-pod.rank-2 .place { color: var(--silver); border-color: rgba(207,216,230,0.34); }
+.ar-pod.rank-3 .place { color: var(--bronze); border-color: rgba(224,151,90,0.34); }
+
+/* Alternating shade on the tower so a long list stays trackable across. */
+.ar-row:nth-child(even of .ar-row) { background: rgba(255,255,255,0.018); }
+
+/* ---------- the open podium ----------
+   Drawn seats with nobody in them. Deliberately not shaped like a player
+   card: no face, no handle line, no number — a greyed-out card with dashes
+   where a name goes reads as data that failed to load. */
+.lb-open-podium { display: grid; grid-template-columns: 1fr 1.18fr 1fr; gap: 14px;
+  align-items: end; padding: 26px 22px 0; }
+@media (max-width: 760px) { .lb-open-podium { grid-template-columns: 1fr; } }
+.lb-seat {
+  border: 1px dashed var(--line2); border-radius: 16px;
+  background: rgba(255,255,255,0.012);
+  padding: 20px 16px; text-align: center; min-height: 132px;
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 8px;
+}
+.lb-seat.s1 { min-height: 168px; border-color: rgba(255,207,92,0.34); background: rgba(255,207,92,0.035); }
+.lb-seat.s2 { border-color: rgba(207,216,230,0.26); }
+.lb-seat.s3 { border-color: rgba(224,151,90,0.26); }
+.lb-seat .lbl {
+  font-family: var(--mono); font-size: 10px; font-weight: 800;
+  letter-spacing: 1.4px; text-transform: uppercase; color: var(--dim);
+}
+.lb-seat.s1 .lbl { color: var(--gold); }
+.lb-seat .mark { font-size: 22px; opacity: .5; }
+.lb-seat .txt { font-size: 12.5px; color: var(--muted); line-height: 1.5; max-width: 190px; }
+
+.lb-gate { margin: 22px 2px 0; padding: 16px 18px; border-radius: 12px;
+  background: rgba(0,0,0,0.24); border: var(--edge); border-left: 2px solid var(--orange); }
+.lb-gate h4 { font-size: 13.5px; font-weight: 750; margin: 0 0 8px; }
+.lb-gate p { font-size: 12.5px; color: var(--muted); line-height: 1.65; margin: 0 0 8px; }
+.lb-gate p:last-child { margin-bottom: 0; }
+.lb-gate b { color: var(--text); font-weight: 700; }
+.lb-counts { display: flex; gap: 18px; flex-wrap: wrap; margin: 10px 0 0;
+  font-family: var(--mono); font-size: 11.5px; color: var(--dim); }
+.lb-counts b { color: var(--text); font-weight: 700; }

--- a/site/leaderboard.html
+++ b/site/leaderboard.html
@@ -113,10 +113,42 @@
         </div>
       </section>
 
-      <section class="ar-pane is-vacant" id="podium-pane" aria-labelledby="board-h">
-        <div class="ar-pane-head">
-          <span class="glyph">🛡</span><span id="board-h">The podium</span>
+      <!-- The board proper: title bar, scope/window controls, podium, tower.
+           This pane is NEVER vacant — an empty board is a fact about the
+           standings and gets said out loud, rather than the whole section
+           disappearing and leaving the visitor to conclude the page is
+           broken. That was the actual complaint: "I just see a bunch of
+           people signed in, I don't see ranks." -->
+      <section class="ar-pane" id="podium-pane" aria-labelledby="board-h">
+        <div class="lb-bar">
+          <div class="lb-title">
+            <span id="board-h">Leaderboard</span>
+            <span class="lb-date" id="lb-date"></span>
+          </div>
+          <button class="lb-refresh" id="lb-refresh" type="button" title="Reload the board" aria-label="Reload the board">
+            <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor"
+                 stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M21 12a9 9 0 1 1-2.64-6.36"/><path d="M21 3v6h-6"/></svg>
+          </button>
         </div>
+
+        <div class="lb-filters">
+          <div class="lb-scope">
+            <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor"
+                 stroke-width="1.8" aria-hidden="true">
+              <circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a15 15 0 0 1 0 18a15 15 0 0 1 0-18"/></svg>
+            <span>Global</span>
+          </div>
+          <!-- Only windows the server actually computes appear here. A 24h or
+               30d pill would have to invent a number: entry stats are lifetime,
+               and the only window the verifier folds is the Sprint's week. -->
+          <div class="lb-windows" role="tablist" aria-label="Scoring window">
+            <button class="lb-win on" type="button" role="tab" aria-selected="true"  data-window="all">All time</button>
+            <button class="lb-win"    type="button" role="tab" aria-selected="false" data-window="week">This week</button>
+          </div>
+        </div>
+        <p class="lb-winnote" id="lb-winnote"></p>
+
         <div id="podium"></div>
         <div id="plinth"></div>
       </section>
@@ -275,6 +307,10 @@
   const streamEl = document.getElementById('stream');
   const tapeEl = document.getElementById('tape');
   const roomsEl = document.getElementById('rooms');
+  const dateEl = document.getElementById('lb-date');
+  const noteEl = document.getElementById('lb-winnote');
+  const refreshEl = document.getElementById('lb-refresh');
+  const winEls = Array.from(document.querySelectorAll('.lb-win'));
   const podiumPane = document.getElementById('podium-pane');
   const towerPane = document.getElementById('tower-pane');
   const formulaPane = document.getElementById('formula-pane');
@@ -350,12 +386,74 @@
       <span class="r">Score</span>
     </div>`;
 
-  (async () => {
+  /* The seats nobody has claimed yet.
+   *
+   * Zero ranked is the CURRENT reality, not an edge case, so it gets a real
+   * design rather than a hidden section. The counts come from /api/trench —
+   * the same numbers the census strip shows — because "why is this empty"
+   * is answerable with facts we already have, and a vague "check back soon"
+   * would be hiding them. */
+  async function openPodium() {
+    podiumEl.innerHTML = `<div class="lb-open-podium">
+        <div class="lb-seat s2"><span class="lbl">Rank 02</span><span class="mark">◎</span>
+          <span class="txt">Open seat</span></div>
+        <div class="lb-seat s1"><span class="lbl">Champion</span><span class="mark">👑</span>
+          <span class="txt">First verified record to clear the bar takes it.</span></div>
+        <div class="lb-seat s3"><span class="lbl">Rank 03</span><span class="mark">◎</span>
+          <span class="txt">Open seat</span></div>
+      </div>`;
+    plinthEl.innerHTML = '';
+
+    let counts = null;
+    try { counts = await L.getOrThrow('/api/trench'); } catch { counts = null; }
+
+    const recs = counts && Array.isArray(counts.people)
+      ? counts.people.map((p) => p.record).filter(Boolean) : [];
+    const tally = (s) => recs.filter((r) => r.status === s).length;
+    const countsLine = recs.length
+      ? `<div class="lb-counts">
+           <span><b>${recs.length}</b> submitted</span>
+           <span><b>${tally('verified')}</b> verified</span>
+           <span><b>${tally('partial')}</b> partial</span>
+           <span><b>${tally('rejected')}</b> rejected</span>
+           <span><b>0</b> ranked</span>
+         </div>`
+      : '';
+
+    podiumEl.insertAdjacentHTML('beforeend', `
+      <div class="lb-gate">
+        <h4>Nobody is ranked yet — here is exactly why.</h4>
+        <p>A record ranks only when it is <b>verified</b> against real market
+        history <i>and</i> carries at least <b>five closed rounds</b>. Records
+        that fail re-pricing, or that are still short of five rounds, stay off
+        the board rather than being ranked on a weaker basis.</p>
+        <p>Everyone who has signed in is on <a href="#trench">the trench</a>
+        below. That wall is attendance, not standings — it is not a ranking and
+        does not pretend to be one.</p>
+        ${countsLine}
+      </div>`);
+    if (countEl) countEl.textContent = '0 ranked';
+    towerEl.innerHTML = L.empty('▤', 'The tower is empty.',
+      'Ranks appear here as verified records clear the bar.');
+    if (formulaPane) formulaPane.classList.add('is-vacant');
+  }
+
+  async function loadBoard(windowKey) {
+    showRanked(true);
+    if (podiumPane) podiumPane.classList.remove('is-vacant');
+
+    const isWeek = windowKey === 'week';
+    noteEl.textContent = isWeek
+      ? 'The weekly window is the Sprint’s — the only window the verifier folds. Shorter ranges would have to be invented: entry stats are lifetime.'
+      : '';
+
+    podiumEl.innerHTML = L.skeleton(1);
+    plinthEl.innerHTML = '';
+
     let body;
     try {
-      body = await L.getOrThrow('/api/leaderboard');
+      body = await L.getOrThrow(isWeek ? '/api/sprint/current' : '/api/leaderboard');
     } catch {
-      if (podiumPane) podiumPane.classList.remove('is-vacant');
       if (towerPane) towerPane.classList.add('is-vacant');
       if (formulaPane) formulaPane.classList.add('is-vacant');
       podiumEl.innerHTML = L.errorState(
@@ -366,14 +464,9 @@
     }
 
     const entries = (body && body.entries) || [];
-    if (!entries.length) {
-      showRanked(false);
-      if (countEl) countEl.textContent = '0 ranked';
-      return;
-    }
+    if (!entries.length) { await openPodium(); return; }
 
-    showRanked(true);
-    const snapshot = L.readSnapshot('global');
+    const snapshot = L.readSnapshot(isWeek ? 'week' : 'global');
     const top = entries.slice(0, 3);
     const rest = entries.slice(3);
 
@@ -402,11 +495,50 @@
     countEl.textContent = entries.length + ' ranked · ' +
       entries.filter((e) => e.status === 'verified').length + ' fully verified';
 
+    if (formulaPane) formulaPane.classList.remove('is-vacant');
     formulaEl.innerHTML = `<div style="font-weight:800;margin-bottom:10px">@${esc(entries[0].handle)}</div>`
       + L.formulaHtml(entries[0].stats);
 
-    L.writeSnapshot('global', entries);
-  })();
+    L.writeSnapshot(isWeek ? 'week' : 'global', entries);
+  }
+
+  /* ---------------- board controls ---------------- */
+
+  // The date is the reader's own, formatted in their locale — the board is
+  // live, so stamping a server date would be the less true of the two.
+  if (dateEl) {
+    dateEl.textContent = new Date().toLocaleDateString(undefined,
+      { year: 'numeric', month: 'short', day: 'numeric' });
+  }
+
+  let activeWindow = 'all';
+
+  if (winEls.length) {
+    winEls.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        if (btn.dataset.window === activeWindow) return;
+        activeWindow = btn.dataset.window;
+        winEls.forEach((b) => {
+          const on = b === btn;
+          b.classList.toggle('on', on);
+          b.setAttribute('aria-selected', on ? 'true' : 'false');
+        });
+        loadBoard(activeWindow);
+      });
+    });
+  }
+
+  if (refreshEl) {
+    refreshEl.addEventListener('click', () => {
+      refreshEl.classList.remove('spin');
+      // Reflow so the animation restarts on a second click.
+      void refreshEl.offsetWidth;
+      refreshEl.classList.add('spin');
+      loadBoard(activeWindow);
+    });
+  }
+
+  loadBoard(activeWindow);
 
   /* ---------------- the trench (everyone who showed up) ---------------- */
 


### PR DESCRIPTION
Owner: *"right now I can't even see, I just see a bunch of people signed in, I don't see ranks."*

## What was actually wrong

The podium and the ranked tower **already existed**, and already had the shape the reference screenshot asks for — a three-card podium with first place centred and larger, and a ranked table below it.

The reason none of it was on screen: `showRanked(false)` sets `display:none` on the podium, tower **and** formula panes together whenever the entry list comes back empty. The board currently returns zero entries, so that path is the only one anyone has ever seen. All that was left was the trench wall of signed-in people — exactly what the owner described.

**An empty board is a fact about the standings, so it gets stated rather than hidden.** The pane no longer goes vacant.

## Added

- A title bar: `LEADERBOARD`, today's date, and a refresh control that works
- A Global scope chip and a scoring-window control
- **Gold / silver / bronze** on the three seats — `--silver` and `--bronze` already existed as tokens and were never used, so every seat but first rendered identically
- Alternating shade on tower rows so a long list stays trackable across

## The empty state is the point

Three **drawn open seats**, plus a panel saying why nobody ranks with real counts read from `/api/trench` (currently *19 submitted · 1 verified · 2 partial · 16 rejected · 0 ranked*).

The seats are deliberately **not** greyed-out player cards with dashes where a name goes — that reads as data that failed to load, which is the wrong thing to say when the data arrived fine and is simply empty.

## One deliberate deviation from the reference

The scoring window offers **"All time" and "This week"**, not 24h/7d/30d. Entry stats are lifetime and the only window the verifier actually folds is the Sprint's ISO week, so 24h and 30d could only be rendered by inventing numbers. Both options here hit a real endpoint. Three real ranges would need server-side windowing that doesn't exist yet.

The ranking formula is **untouched** — still `ROI × ln(1+rounds) × discipline`, not silently switched to a highest-PnL sort.

## Note for review

This changes what the page does when the board is empty, **not why it is empty**. Of 19 submitted records, 16 are rejected by re-pricing, 2 are partial, and the 1 verified record has too few rounds to rank. That's a separate open question for the owner and nothing here touches it — the board renders real data correctly either way, empty or populated.

Suites green: 2073 extension, 219 server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
