### PR TITLE
site: /events — what is actually running right now (first pass)

### DIFF
--- a/site/404.html
+++ b/site/404.html
@@ -139,6 +139,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/admin-mod.html
+++ b/site/admin-mod.html
@@ -162,6 +162,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/admin.html
+++ b/site/admin.html
@@ -162,6 +162,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/clan.html
+++ b/site/clan.html
@@ -30,6 +30,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/clans.html
+++ b/site/clans.html
@@ -30,6 +30,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans" aria-current="page">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/duel.html
+++ b/site/duel.html
@@ -321,6 +321,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels" aria-current="page">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/duels.html
+++ b/site/duels.html
@@ -472,6 +472,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels" aria-current="page">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/events.html
+++ b/site/events.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PaperTrench | Events</title>
+<meta name="description" content="What is running on PaperTrench right now: the open Sprint window, streamers live in the trenches, and the verifier tape as records land.">
+<link rel="icon" href="/favicon.ico" sizes="48x48">
+<link rel="icon" type="image/png" href="/assets/icon96.png" sizes="96x96">
+<link rel="icon" type="image/png" href="/assets/icon192.png" sizes="192x192">
+<link rel="apple-touch-icon" href="/assets/icon192.png">
+<link rel="stylesheet" href="style.css">
+<link rel="stylesheet" href="arena.css">
+<style>
+  /* ================================================================== *
+   *  /events — what is running right now.
+   *
+   *  FIRST PASS, and deliberately an aggregator rather than a new system.
+   *  PaperTrench already has time-bound things: the Sprint runs in weekly
+   *  windows the verifier actually folds, streamers go live, and records
+   *  land on the tape. None of that was collected anywhere, so "events"
+   *  is read here as "the calendar those already imply" rather than as a
+   *  new events table nobody has specified.
+   *
+   *  Every panel is backed by a real endpoint. Nothing on this page is a
+   *  placeholder event, because a fake scheduled event is a promise the
+   *  project has not made.
+   * ================================================================== */
+  .ev-head { padding: 128px 0 10px; }
+  .ev-head h1 { font-size: clamp(30px, 4.4vw, 46px); font-weight: 700; letter-spacing: -0.02em; }
+  .ev-head p { font-size: 14.5px; color: var(--muted); margin-top: 12px; max-width: 660px; line-height: 1.65; }
+
+  .ev-grid { display: grid; gap: 16px; grid-template-columns: 1.25fr 1fr; align-items: start; }
+  @media (max-width: 900px) { .ev-grid { grid-template-columns: 1fr; } }
+
+  .ev-now { padding: 22px 24px; }
+  .ev-kicker { font-family: var(--mono); font-size: 10.5px; font-weight: 800;
+    letter-spacing: 1.5px; text-transform: uppercase; color: var(--dim); }
+  .ev-title { font-size: 22px; font-weight: 750; letter-spacing: -0.01em; margin: 8px 0 4px; }
+  .ev-sub { font-size: 13px; color: var(--muted); line-height: 1.6; }
+
+  .ev-clock { display: flex; gap: 10px; flex-wrap: wrap; margin: 18px 0 4px; }
+  .ev-unit { min-width: 68px; padding: 10px 12px; border-radius: 12px;
+    background: rgba(0,0,0,0.28); border: var(--edge); text-align: center; }
+  .ev-unit b { display: block; font-family: var(--mono); font-size: 22px; font-weight: 700;
+    color: var(--text); font-variant-numeric: tabular-nums; }
+  .ev-unit span { font-family: var(--mono); font-size: 9.5px; letter-spacing: 1.2px;
+    text-transform: uppercase; color: var(--dim); }
+
+  .ev-bar { height: 6px; border-radius: 999px; background: rgba(255,255,255,0.07);
+    overflow: hidden; margin-top: 16px; }
+  .ev-bar i { display: block; height: 100%; border-radius: 999px; background: var(--grad-heat); }
+  .ev-barnote { display: flex; justify-content: space-between; gap: 10px;
+    font-family: var(--mono); font-size: 10.5px; color: var(--dim); margin-top: 7px; }
+
+  .ev-list { display: grid; gap: 9px; }
+  .ev-item { display: flex; align-items: center; gap: 11px; padding: 11px 14px;
+    border-radius: 11px; background: rgba(255,255,255,0.022); border: var(--edge); }
+  .ev-item .dot { width: 7px; height: 7px; border-radius: 50%; flex: none; background: var(--dim); }
+  .ev-item.on .dot { background: var(--red); box-shadow: 0 0 9px var(--red); animation: pulse 1.6s infinite; }
+  .ev-item .nm { font-weight: 700; font-size: 13.5px; }
+  .ev-item .mt { font-family: var(--mono); font-size: 10.5px; color: var(--dim); margin-left: auto; }
+
+  .ev-firstpass { margin-top: 20px; padding: 14px 18px; border-radius: 12px;
+    background: rgba(255,157,69,0.05); border: 1px solid rgba(255,157,69,0.22);
+    border-left: 2px solid var(--orange); font-size: 12.5px; color: var(--muted); line-height: 1.6; }
+  .ev-firstpass b { color: var(--text); font-weight: 700; }
+</style>
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="bg-glow" aria-hidden="true"></div>
+<div class="bg-grid" aria-hidden="true"></div>
+
+<nav aria-label="Primary">
+  <div class="nav-inner">
+    <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
+    <div class="nav-links">
+      <a href="/leaderboard">Leaderboard</a>
+      <a href="/sprint" aria-current="page">Sprint</a>
+      <a href="/events">Events</a>
+      <a href="/duels">Duels</a>
+      <a href="/clans">Clans</a>
+      <a href="/replay">Replay</a>
+      <a href="/news">News</a>
+      <a href="/links">Links</a>
+      <a href="/#install">Install</a>
+      <a class="nav-live" href="/streams" title="Watch streamers run the PaperTrench Challenge live on Twitch"><span class="dot"></span>Live</a>
+      <span id="nav-wallet"></span>
+      <span id="nav-profile"></span>
+      <a class="nav-cta" href="https://github.com/OnlyTerp/papertrench/releases/latest" target="_blank" rel="noopener">Download</a>
+    </div>
+  </div>
+</nav>
+
+<main id="main" class="wrap" style="padding-bottom:96px">
+  <header class="ev-head">
+    <h1>Events</h1>
+    <p>What is actually running right now. The Sprint window below is the one the
+    verifier folds; the streams are checked live; the tape is the verifier talking.
+    Nothing here is a scheduled placeholder.</p>
+  </header>
+
+  <div class="ev-grid">
+    <section class="ar-pane" aria-labelledby="ev-now-h">
+      <div class="ar-pane-head"><span class="glyph" style="color:var(--orange2)">◷</span>
+        <span id="ev-now-h">The open window</span></div>
+      <div class="ev-now" id="ev-now"><p class="ar-note">Reading the Sprint window…</p></div>
+    </section>
+
+    <div style="display:grid;gap:16px">
+      <section class="ar-pane" aria-labelledby="ev-live-h">
+        <div class="ar-pane-head"><span class="glyph" style="color:var(--red)">▶</span>
+          <span id="ev-live-h">Live in the trenches</span></div>
+        <div class="pad" id="ev-live"><p class="ar-note">Checking who is live…</p></div>
+      </section>
+
+      <section class="ar-pane" aria-labelledby="ev-tape-h">
+        <div class="ar-pane-head"><span class="glyph" style="color:var(--green)">▸</span>
+          <span id="ev-tape-h">The tape</span></div>
+        <div class="pad" id="ev-tape"><p class="ar-note">Reading the tape…</p></div>
+      </section>
+    </div>
+  </div>
+
+  <p class="ev-firstpass"><b>First pass.</b> "Events" had no spec, so this page
+  collects the time-bound things PaperTrench already runs rather than inventing an
+  events system. If what was wanted is scheduled, announced events — tournaments with
+  a start date, prize pools, sign-ups — that needs somewhere to store them and a way
+  for a moderator to post one, which is a bigger build than this page.</p>
+</main>
+
+<footer>
+  <div class="wrap">
+    <div class="foot-inner">
+      <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="">PaperTrench</a>
+      <div class="foot-links">
+        <a href="/sprint">Weekly Sprint</a>
+        <a href="/duels">Duels</a>
+        <a href="/clans">Clans</a>
+        <a href="/news">News &amp; patch notes</a>
+        <a href="/privacy">Privacy</a>
+        <a href="https://github.com/OnlyTerp/papertrench" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener">Leaderboard protocol</a>
+      </div>
+    </div>
+        <nav class="term-dock" aria-label="Paper terminals">
+      <span class="term-lbl">Open a terminal</span>
+      <a href="https://axiom.trade/@usepaper" target="_blank" rel="noopener">Axiom</a>
+      <a href="https://trade.padre.gg/rk/papertrench" target="_blank" rel="noopener">Padre</a>
+      <a href="https://gmgn.ai/r/papertrench" target="_blank" rel="noopener">GMGN</a>
+      <a href="https://lute.gg/@papertrench" target="_blank" rel="noopener">Lute</a>
+    </nav>
+    <div class="foot-social">
+      <a class="foot-btn discord" href="https://discord.gg/papertrench" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M20.317 4.3698a19.7913 19.7913 0 00-4.8851-1.5152.0741.0741 0 00-.0785.0371c-.211.3753-.4447.8648-.6083 1.2495-1.8447-.2762-3.68-.2762-5.4868 0-.1636-.3933-.4058-.8742-.6177-1.2495a.077.077 0 00-.0785-.037 19.7363 19.7363 0 00-4.8852 1.515.0699.0699 0 00-.0321.0277C.5334 9.0458-.319 13.5799.0992 18.0578a.0824.0824 0 00.0312.0561c2.0528 1.5076 4.0413 2.4228 5.9929 3.0294a.0777.0777 0 00.0842-.0276c.4616-.6304.8731-1.2952 1.226-1.9942a.076.076 0 00-.0416-.1057c-.6528-.2476-1.2743-.5495-1.8722-.8923a.077.077 0 01-.0076-.1277c.1258-.0943.2517-.1923.3718-.2914a.0743.0743 0 01.0776-.0105c3.9278 1.7933 8.18 1.7933 12.0614 0a.0739.0739 0 01.0785.0095c.1202.099.246.198.3728.2924a.077.077 0 01-.0066.1276 12.2986 12.2986 0 01-1.873.8914.0766.0766 0 00-.0407.1067c.3604.698.7719 1.3628 1.225 1.9932a.076.076 0 00.0842.0286c1.961-.6067 3.9495-1.5219 6.0023-3.0294a.077.077 0 00.0313-.0552c.5004-5.177-.8382-9.6739-3.5485-13.6604a.061.061 0 00-.0312-.0286zM8.02 15.3312c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9555-2.4189 2.157-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.9555 2.4189-2.1569 2.4189zm7.9748 0c-1.1825 0-2.1569-1.0857-2.1569-2.419 0-1.3332.9554-2.4189 2.1569-2.4189 1.2108 0 2.1757 1.0952 2.1568 2.419 0 1.3332-.946 2.4189-2.1568 2.4189Z"/></svg>Join the Discord
+      </a>
+      <a class="foot-btn x" href="https://x.com/PaperTrench_" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>@PaperTrench_
+      </a>
+      <a class="foot-btn tiktok" href="https://www.tiktok.com/@papertrench" target="_blank" rel="noopener">
+        <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12.525.02c1.31-.02 2.61-.01 3.91-.02.08 1.53.63 3.09 1.75 4.17 1.12 1.11 2.7 1.62 4.24 1.79v4.03c-1.44-.05-2.89-.35-4.2-.97-.57-.26-1.1-.59-1.62-.93-.01 2.92.01 5.84-.02 8.75-.08 1.4-.54 2.79-1.35 3.94-1.31 1.92-3.58 3.17-5.91 3.21-1.43.08-2.86-.31-4.08-1.03-2.02-1.19-3.44-3.37-3.65-5.71-.02-.5-.03-1-.01-1.49.18-1.9 1.12-3.72 2.58-4.96 1.66-1.44 3.98-2.13 6.15-1.72.02 1.48-.04 2.96-.04 4.44-.99-.32-2.15-.23-3.02.37-.63.41-1.11 1.04-1.36 1.75-.21.51-.15 1.07-.14 1.61.24 1.64 1.82 3.02 3.5 2.87 1.12-.01 2.19-.66 2.77-1.61.19-.33.4-.67.41-1.06.1-1.79.06-3.57.07-5.36.01-4.03-.01-8.05.02-12.07z"/></svg>@papertrench
+      </a>
+    </div>
+  </div>
+</footer>
+
+<script src="arena.js?v=trench2"></script>
+<script src="events.js"></script>
+<script src="/nav-wallet.js"></script>
+<script src="/nav-profile.js"></script>
+</body>
+</html>

--- a/site/events.js
+++ b/site/events.js
@@ -1,0 +1,205 @@
+/* PaperTrench — /events.
+ *
+ * FIRST PASS. "Events" arrived without a spec, so this reads it as "the
+ * calendar the product already implies" rather than as a new events system:
+ * the Sprint window the verifier actually folds, who is streaming right now,
+ * and what the verifier has been saying. Every panel is backed by a live
+ * endpoint, and a panel that cannot read its endpoint says so — none of them
+ * fall back to an invented event, because a fake scheduled event is a promise
+ * the project has not made.
+ */
+(() => {
+  'use strict';
+
+  const API = 'https://papertrench-api.onerobby.workers.dev';
+  const $ = (id) => document.getElementById(id);
+  const esc = (s) => String(s == null ? '' : s).replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ));
+
+  async function get(path) {
+    const res = await fetch(API + path, { credentials: 'omit', cache: 'no-store' });
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    return res.json();
+  }
+
+  const note = (el, text) => { el.innerHTML = `<p class="ar-note">${esc(text)}</p>`; };
+
+  /* ---------- the open Sprint window ---------- */
+
+  const pad = (n) => String(n).padStart(2, '0');
+
+  function renderWindow(sprint) {
+    const el = $('ev-now');
+    const start = Number(sprint.startTs) || 0;
+    const end = Number(sprint.endTs) || 0;
+    if (!start || !end) { note(el, 'No window is open right now.'); return; }
+
+    const entries = Array.isArray(sprint.entries) ? sprint.entries.length : 0;
+    const fmtDay = (ts) => new Date(ts).toLocaleDateString(undefined,
+      { month: 'short', day: 'numeric' });
+
+    el.innerHTML = `
+      <div class="ev-kicker">Sprint · ${esc(sprint.weekId || '')}</div>
+      <div class="ev-title">The weekly window is open</div>
+      <p class="ev-sub">One ISO week. Only fills inside it count, and the slice is
+      computed by the same verifier that folds the main board — this is the one
+      window the server actually windows.</p>
+      <div class="ev-clock" id="ev-clock"></div>
+      <div class="ev-bar"><i id="ev-fill" style="width:0%"></i></div>
+      <div class="ev-barnote">
+        <span>${esc(fmtDay(start))}</span>
+        <span id="ev-pct">—</span>
+        <span>${esc(fmtDay(end))}</span>
+      </div>
+      <p class="ev-sub" style="margin-top:14px">
+        <b style="color:var(--text)">${entries}</b> record${entries === 1 ? '' : 's'} in
+        this window so far · <a href="/sprint" style="color:var(--orange2)">open the Sprint →</a>
+      </p>`;
+
+    const clock = $('ev-clock');
+    const fill = $('ev-fill');
+    const pct = $('ev-pct');
+
+    const tick = () => {
+      const now = Date.now();
+      const left = Math.max(0, end - now);
+      const total = Math.max(1, end - start);
+      const done = Math.min(1, Math.max(0, (now - start) / total));
+
+      const d = Math.floor(left / 86400000);
+      const h = Math.floor((left % 86400000) / 3600000);
+      const m = Math.floor((left % 3600000) / 60000);
+      const s = Math.floor((left % 60000) / 1000);
+
+      clock.innerHTML = left > 0
+        ? `<div class="ev-unit"><b>${d}</b><span>days</span></div>
+           <div class="ev-unit"><b>${pad(h)}</b><span>hrs</span></div>
+           <div class="ev-unit"><b>${pad(m)}</b><span>min</span></div>
+           <div class="ev-unit"><b>${pad(s)}</b><span>sec</span></div>`
+        : '<div class="ev-unit" style="min-width:auto;padding:10px 16px"><b>closed</b><span>window</span></div>';
+      fill.style.width = (done * 100).toFixed(1) + '%';
+      pct.textContent = Math.round(done * 100) + '% elapsed';
+    };
+    tick();
+    setInterval(tick, 1000);
+  }
+
+  /* ---------- who is live ----------
+   * Twitch and Kick are asked their own way, the same rule /streams uses:
+   * a probe that fails is unknown and simply does not claim a status. */
+
+  async function liveTwitch(login) {
+    try {
+      const r = await fetch(
+        `https://static-cdn.jtvnw.net/previews-ttv/live_user_${encodeURIComponent(login)}-80x45.jpg?t=${Date.now()}`,
+        { mode: 'cors', cache: 'no-store' });
+      if (!r.ok) return null;
+      return !r.url.includes('404_preview');
+    } catch (_) { return null; }
+  }
+
+  async function liveKick(slug) {
+    try {
+      const r = await fetch('https://kick.com/api/v2/channels/' + encodeURIComponent(slug),
+        { mode: 'cors', cache: 'no-store' });
+      if (r.status === 404) return false;
+      if (!r.ok) return null;
+      const body = await r.json();
+      return !!(body && body.livestream && body.livestream.is_live === true);
+    } catch (_) { return null; }
+  }
+
+  async function renderLive() {
+    const el = $('ev-live');
+    let roster = [];
+    try {
+      const body = await get('/api/streamer/roster');
+      roster = Array.isArray(body && body.streamers) ? body.streamers : [];
+    } catch (_) { roster = []; }
+
+    // The hand-maintained names on /streams are the floor: an empty or
+    // unreachable roster API must not read as "nobody streams here".
+    const seeds = [
+      { name: 'OnlyTerp', platform: 'twitch', login: 'onlyterp' },
+      { name: 'Ark1317', platform: 'kick', channel: 'ark1317' },
+    ];
+    for (const row of roster) {
+      const login = String((row && row.login) || '').toLowerCase();
+      if (login && !seeds.some((s) => s.login === login)) {
+        seeds.push({ name: row.name || login, platform: 'twitch', login });
+      }
+    }
+
+    const results = await Promise.all(seeds.map(async (s) => ({
+      s,
+      up: s.platform === 'kick' ? await liveKick(s.channel) : await liveTwitch(s.login),
+    })));
+
+    const live = results.filter((r) => r.up === true);
+    if (!live.length) {
+      el.innerHTML = `<p class="ar-note">Nobody is live this minute.
+        <a href="/streams" style="color:var(--orange2)">The roster →</a></p>`;
+      return;
+    }
+    el.innerHTML = '<div class="ev-list">'
+      + live.map(({ s }) => `
+        <a class="ev-item on" href="/streams">
+          <span class="dot"></span>
+          <span class="nm">${esc(s.name)}</span>
+          <span class="mt">${esc(s.platform)}</span>
+        </a>`).join('')
+      + '</div>';
+  }
+
+  /* ---------- the tape ---------- */
+
+  // Verb only: the subject is printed separately, and rejections deliberately
+  // arrive with no handle, so the row has to read as a sentence either way —
+  // "@someone · verified" and "A record · rejected".
+  const KIND_LABEL = {
+    accepted: 'accepted',
+    rejected: 'rejected',
+    verified: 'verified',
+    joined: 'joined the trench',
+  };
+
+  function ago(ts) {
+    const mins = Math.max(0, Math.round((Date.now() - Number(ts)) / 60000));
+    if (mins < 60) return mins + 'm';
+    const h = Math.round(mins / 60);
+    return h < 48 ? h + 'h' : Math.round(h / 24) + 'd';
+  }
+
+  async function renderTape() {
+    const el = $('ev-tape');
+    let events = [];
+    try {
+      const body = await get('/api/activity');
+      events = Array.isArray(body && body.events) ? body.events : [];
+    } catch (_) {
+      note(el, 'The tape is unreachable right now.');
+      return;
+    }
+    if (!events.length) { note(el, 'Nothing on the tape yet.'); return; }
+
+    el.innerHTML = '<div class="ev-list">'
+      + events.slice(0, 8).map((e) => `
+        <div class="ev-item">
+          <span class="dot"></span>
+          <span class="nm">${e.handle ? '@' + esc(e.handle) : 'A record'}</span>
+          <span class="ev-sub" style="font-size:12px">${esc(KIND_LABEL[e.kind] || e.kind || '')}</span>
+          <span class="mt">${esc(ago(e.ts))}</span>
+        </div>`).join('')
+      + '</div>';
+  }
+
+  /* ---------- boot ---------- */
+
+  (async () => {
+    try { renderWindow(await get('/api/sprint/current')); }
+    catch (_) { note($('ev-now'), 'The Sprint window is unreachable right now.'); }
+  })();
+  renderLive();
+  renderTape();
+})();

--- a/site/index.html
+++ b/site/index.html
@@ -34,6 +34,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/leaderboard.html
+++ b/site/leaderboard.html
@@ -30,6 +30,7 @@
     <div class="nav-links">
       <a href="/leaderboard" aria-current="page">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/news-chain.html
+++ b/site/news-chain.html
@@ -57,6 +57,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/news-fees.html
+++ b/site/news-fees.html
@@ -45,6 +45,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/news-fills.html
+++ b/site/news-fills.html
@@ -62,6 +62,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/news-flex.html
+++ b/site/news-flex.html
@@ -71,6 +71,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/news-instant-x.html
+++ b/site/news-instant-x.html
@@ -52,6 +52,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/news-perps.html
+++ b/site/news-perps.html
@@ -39,6 +39,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/news-quickedit.html
+++ b/site/news-quickedit.html
@@ -56,6 +56,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/news-rugguard.html
+++ b/site/news-rugguard.html
@@ -56,6 +56,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/news-the-after.html
+++ b/site/news-the-after.html
@@ -52,6 +52,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/news-trench-rank.html
+++ b/site/news-trench-rank.html
@@ -48,6 +48,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/news-turbo.html
+++ b/site/news-turbo.html
@@ -59,6 +59,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/news-v2.html
+++ b/site/news-v2.html
@@ -45,6 +45,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/news-xray.html
+++ b/site/news-xray.html
@@ -66,6 +66,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/news.html
+++ b/site/news.html
@@ -26,6 +26,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -36,6 +36,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/profile.html
+++ b/site/profile.html
@@ -372,6 +372,7 @@
            aria-current="page" would claim this IS leaderboard.html. -->
       <a href="/leaderboard" aria-current="true">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/replay.html
+++ b/site/replay.html
@@ -28,6 +28,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/sitemap.xml
+++ b/site/sitemap.xml
@@ -24,6 +24,7 @@
   <url><loc>https://papertrench.com/links</loc></url>
   <url><loc>https://papertrench.com/leaderboard</loc></url>
   <url><loc>https://papertrench.com/sprint</loc></url>
+  <url><loc>https://papertrench.com/events</loc></url>
   <url><loc>https://papertrench.com/duels</loc></url>
   <url><loc>https://papertrench.com/clans</loc></url>
   <url><loc>https://papertrench.com/streams</loc></url>

--- a/site/sprint.html
+++ b/site/sprint.html
@@ -151,6 +151,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint" aria-current="page">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/streamer-signup.html
+++ b/site/streamer-signup.html
@@ -205,6 +205,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>

--- a/site/streams.html
+++ b/site/streams.html
@@ -249,6 +249,7 @@
     <div class="nav-links">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
+      <a href="/events">Events</a>
       <a href="/duels">Duels</a>
       <a href="/clans">Clans</a>
       <a href="/replay">Replay</a>


### PR DESCRIPTION
> **This is a first pass, not a finished feature.** The page says so on its own face, and this description does too — please read it as an interpretation to react to rather than something ready to be signed off.

## Why an interpretation at all

"Add an Events tab" arrived without a spec. Before inventing anything I checked `ROADMAP.md`, `docs/` and the existing nav: **there is no events concept anywhere in the project.**

What *does* exist is a set of time-bound things that were never collected in one place — the Sprint runs in ISO-week windows the verifier actually folds, streamers go live, and records land on the tape. So "events" is read here as **the calendar the product already implies**, rather than as a new events system nobody has specified.

## Three panels, each backed by a live endpoint

- **The open Sprint window** — real `startTs`/`endTs` from `/api/sprint/current`, with a live countdown and an elapsed bar
- **Who is streaming this minute** — Twitch's preview CDN and Kick's channel API, the same per-platform rules `/streams` uses; a probe that fails is *unknown* rather than claimed either way
- **The verifier tape** — from `/api/activity`, with rejections carrying no handle, matching the existing rule

**Nothing on the page is a placeholder event.** A panel that can't read its endpoint says so instead of falling back to invented content, because a fake scheduled event is a promise the project hasn't made.

Added to the primary nav on the 29 pages that carry one.

## What this is probably not

If what you actually want is **announced tournaments** — start dates, prize pools, sign-ups — that needs somewhere to store them and a moderator flow to post one. That's a much bigger build than this page, and I'd want your call on it before starting rather than guessing twice.

## Note for review

`site/events.html` carries the shared footer, which includes the TikTok button from #82. Harmless in either merge order — if that PR lands first this page matches, and if it lands second this page is simply already correct.

Suites green: 2073 extension, 219 server. Merges cleanly against current `main` and the sibling PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
