### PR TITLE
fix(gmgn): pass `wanted` to the line slots, and give GMGN D-63's off-range guard

### DIFF
--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -110,6 +110,11 @@
   // Its live React chart manager exposes `getActiveChart().createOrderLine()`.
   let gmgnChart = null;
   let gmgnLineSpec = null;
+  // Why the GMGN lines last failed to draw. The paper path has had
+  // lastLineSyncReason since F-41 and D-63 extended it; the GMGN path had no
+  // diagnostic at all, which is why portifly's report (D-64) arrived as
+  // "they never show up" with nothing to say which of the causes it was.
+  let lastGmgnLineReason = null;
   let gmgnRetryTimer = null;
   // DEFECT C-08: the newest close from GMGN's own mcap-candle feed. GMGN's
   // cap definition can differ from the resolver's (circulating vs total,
@@ -2750,18 +2755,71 @@
     return null;
   }
 
+  /** D-64's want-rule, in one place. The sweep and the sync both have to
+   * decide "is a line wanted here", and they have to agree: the sweep calling
+   * a sync that then disagrees is how a line gets re-armed forever without
+   * ever being drawn. Either level source counts, because either can produce
+   * a level (mcap directly, or the native ratio lane). */
+  function gmgnWants(side) {
+    const spec = gmgnLineSpec;
+    if (!spec) return false;
+    return Number(spec['avg' + side + 'Mcap']) > 0 || Number(spec['avg' + side + 'Native']) > 0;
+  }
+
   function syncGmgnAverageLines() {
+    lastGmgnLineReason = null;
     if (!gmgnLineSpec || !gmgnLineSpec.enabled) {
       clearGmgnAverageLines();
       return true;
     }
     const chart = findGmgnChart();
-    if (!chart) return false;
+    if (!chart) { lastGmgnLineReason = 'no-chart'; return false; }
     if (gmgnChart && gmgnChart !== chart) { clearLineSlot(gmgnBuySlot); clearLineSlot(gmgnSellSlot); }
     gmgnChart = chart;
-    const buyOk = syncLineSlot(gmgnBuySlot, chart, gmgnLineLevel('Buy'), gmgnLineSpec.avgBuyText || 'PT Avg Buy', '#34D399');
-    const sellOk = syncLineSlot(gmgnSellSlot, chart, gmgnLineLevel('Sell'), gmgnLineSpec.avgSellText || 'PT Avg Sell', '#FF5F56');
-    return buyOk && sellOk;
+
+    const wantsBuy = gmgnWants('Buy');
+    const wantsSell = gmgnWants('Sell');
+    const buyLevel = gmgnLineLevel('Buy');
+    const sellLevel = gmgnLineLevel('Sell');
+
+    // D-63 parity. That fix landed on syncPaperAverageLines only, but GMGN
+    // draws through the SAME createOrderLine on the SAME TradingView chart,
+    // so an off-range GMGN average line feeds GMGN's autoscale exactly the
+    // way dashgirn's and ark_trades13's did on Padre/Axiom — axis dragged
+    // through zero into negative mcaps, candles squashed into a corner.
+    // Same remedy: don't draw it, clear the slot so it stops feeding
+    // autoscale, name the reason, let the sweep bring it back when the axis
+    // scrolls to it. offVisibleRange fails safe — a chart it cannot measure
+    // accuses nothing.
+    const buyOffRange = offVisibleRange(chart, [buyLevel]) === 'off-range';
+    const sellOffRange = offVisibleRange(chart, [sellLevel]) === 'off-range';
+    if (buyOffRange) clearLineSlot(gmgnBuySlot);
+    if (sellOffRange) clearLineSlot(gmgnSellSlot);
+
+    // The sixth argument is `wanted`, and omitting it was its own defect:
+    // syncLineSlot reads it to tell "there is no line to draw" (clear it)
+    // from "a line IS wanted but its level is momentarily uncomputable"
+    // (keep what is drawn, retry) — F-41's split, which the paper path has
+    // had since. undefined is falsy, so every uncomputable tick CLEARED a
+    // correct line and reported success. D-64 made levels computable far
+    // more often; it did not make them always computable — gmgnLastCandleClose
+    // resets to 0 on every token switch, and both level lanes need it.
+    const buyOk = buyOffRange ? false
+      : syncLineSlot(gmgnBuySlot, chart, buyLevel, gmgnLineSpec.avgBuyText || 'PT Avg Buy', '#34D399', wantsBuy);
+    const sellOk = sellOffRange ? false
+      : syncLineSlot(gmgnSellSlot, chart, sellLevel, gmgnLineSpec.avgSellText || 'PT Avg Sell', '#FF5F56', wantsSell);
+
+    const missingBuy = wantsBuy && !(buyLevel > 0);
+    const missingSell = wantsSell && !(sellLevel > 0);
+    if (buyOffRange || sellOffRange) {
+      lastGmgnLineReason = 'off-range'
+        + (buyOffRange ? ':buy' : '') + (sellOffRange ? ':sell' : '');
+    } else if (missingBuy || missingSell) {
+      lastGmgnLineReason = 'no-level' + (gmgnLastCandleClose > 0 ? '' : ':no-close');
+    } else if (!(buyOk && sellOk)) {
+      lastGmgnLineReason = 'draw-refused';
+    }
+    return buyOk && sellOk && !missingBuy && !missingSell;
   }
 
   function retryGmgnAverageLines() {
@@ -2769,7 +2827,14 @@
     let attempts = 0;
     const retry = () => {
       gmgnRetryTimer = null;
-      if (syncGmgnAverageLines() || ++attempts >= 30) return;
+      if (syncGmgnAverageLines()) return;
+      if (++attempts >= 30) {
+        // Giving up silently after 15s is how "the Avg lines never show up"
+        // reached us with nothing to act on (D-64). Say which cause it was,
+        // once — the sweep still keeps trying afterwards.
+        emit('gmgn-lines-status', { action: 'sync', ok: false, reason: lastGmgnLineReason || 'unknown' });
+        return;
+      }
       gmgnRetryTimer = setTimeout(retry, 500);
     };
     retry();
@@ -3876,8 +3941,8 @@
       // D-64: want-detection must consider every level source — a side whose
       // mcap candidate is null but whose native average exists (C-16 lane)
       // wants a line just as much, and previously never re-armed the sync.
-      const wantsBuy = Number(gmgnLineSpec.avgBuyMcap) > 0 || Number(gmgnLineSpec.avgBuyNative) > 0;
-      const wantsSell = Number(gmgnLineSpec.avgSellMcap) > 0 || Number(gmgnLineSpec.avgSellNative) > 0;
+      const wantsBuy = gmgnWants('Buy');
+      const wantsSell = gmgnWants('Sell');
       const buyMissing = wantsBuy && !gmgnBuySlot.adapter && !gmgnBuySlot.pending;
       const sellMissing = wantsSell && !gmgnSellSlot.adapter && !gmgnSellSlot.pending;
       if (buyMissing || sellMissing) syncGmgnAverageLines();

--- a/extension/test/nativecharts.test.js
+++ b/extension/test/nativecharts.test.js
@@ -2124,3 +2124,81 @@ test('F-35: a spec arriving while the line is still being created wins over the 
   assert.ok(Math.abs(line.values.setPrice - 300_000) < 0.01,
     'the resolved line must carry the newest level, not the one captured at issue time');
 });
+
+/* ------------------------------------------------------------------
+ * GMGN lines: the two protections the paper path has and this one didn't.
+ *
+ * D-64 (v3.18.0) made the LEVEL computable on fresh launches via the C-16
+ * native-ratio lane, and re-armed the sweep on either level source. Both of
+ * those are upstream and are not re-litigated here. Two gaps survive it:
+ *
+ *  1. syncGmgnAverageLines still called syncLineSlot with FIVE arguments.
+ *     The sixth is `wanted`, which separates "there is no line" (clear it)
+ *     from "a line is wanted, its level is momentarily uncomputable" (keep
+ *     it, retry) — F-41's split. undefined is falsy, so every uncomputable
+ *     tick destroyed a correct line and reported success. D-64 made levels
+ *     computable more often, not always: gmgnLastCandleClose resets to 0 on
+ *     every token switch and BOTH level lanes need it.
+ *
+ *  2. D-63 taught the paper path that an off-range line feeds the host
+ *     autoscale and wrecks the axis. GMGN draws through the same
+ *     createOrderLine on the same TradingView chart and never got that fix.
+ * ------------------------------------------------------------------ */
+
+test('GMGN: a wanted line survives a tick whose level is uncomputable', async () => {
+  const env = runBridge({ gmgnMounted: true });
+  env.runTimers();
+
+  // Supply known: the line draws.
+  env.send('gmgn-lines', {
+    enabled: true, avgBuyMcap: 250_000_000, avgBuyNative: 0.0000031,
+    currentMcap: 240_000_000, currentPriceNative: 0.0000030,
+    avgBuyText: 'PT Avg Buy $250M',
+  });
+  await microtasks();
+  assert.ok(env.orderLines.some((l) => !l.removed),
+    'precondition: the line draws while a level can be computed');
+
+  // Same position, next tick: no mcap (fresh-launch shape) and no current
+  // native to build the ratio from, so neither lane yields a level — but
+  // avgBuyNative still says a line IS wanted.
+  env.send('gmgn-lines', {
+    enabled: true, avgBuyMcap: null, avgBuyNative: 0.0000031,
+    currentPriceNative: null, avgBuyText: 'PT Avg Buy $250M',
+  });
+  await microtasks();
+
+  assert.ok(env.orderLines.some((l) => !l.removed),
+    'a wanted line must not be destroyed because one tick could not compute its level');
+});
+
+test('GMGN gets D-63 parity: an off-range line is cleared, not drawn into autoscale', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'price-bridge.js'), 'utf8');
+  const start = src.indexOf('function syncGmgnAverageLines()');
+  assert.ok(start >= 0, 'the GMGN line sync must ship');
+  const block = src.slice(start, start + 4000);
+
+  assert.match(block, /offVisibleRange\(chart,\s*\[buyLevel\]\)/,
+    'the GMGN buy level must be vetted against the visible range, as D-63 does for paper');
+  assert.match(block, /offVisibleRange\(chart,\s*\[sellLevel\]\)/,
+    'and the sell level separately — one bad side must not veto the good one');
+  assert.match(block, /buyOffRange[\s\S]{0,400}clearLineSlot/,
+    'an off-range verdict must CLEAR the slot so it stops feeding autoscale');
+  assert.match(block, /lastGmgnLineReason\s*=\s*'off-range/,
+    'off-range must name itself, per the status-honesty law');
+  assert.match(block, /buyOffRange \? false\s*\n?\s*:\s*syncLineSlot/,
+    'an off-range side must not be passed to syncLineSlot at all — it would recreate the line');
+});
+
+test('GMGN: the line sync passes `wanted`, and shares one want-rule with the sweep', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'price-bridge.js'), 'utf8');
+  assert.match(src, /syncLineSlot\(gmgnBuySlot,[^)]*wantsBuy\)/,
+    'the buy line must pass the wanted flag through');
+  assert.match(src, /syncLineSlot\(gmgnSellSlot,[^)]*wantsSell\)/,
+    'the sell line must pass the wanted flag through');
+  // The sweep re-arms the sync; if they disagreed about "wanted", the sweep
+  // would re-arm forever a sync that then declines to draw.
+  const wants = src.match(/gmgnWants\('Buy'\)/g) || [];
+  assert.ok(wants.length >= 2,
+    'sweep and sync must share one want-rule rather than each carrying its own copy');
+});

--- a/site/index.html
+++ b/site/index.html
@@ -117,7 +117,7 @@
   <span class="home-credits-kicker">proof</span>
   <span class="home-credits-item"><span class="home-credits-role">terminals</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="sites">15</b></span>
   <span class="home-credits-item"><span class="home-credits-role">invented prices</span><span class="home-credits-rule" aria-hidden="true"></span><b>0</b></span>
-  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2457</b></span>
+  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2460</b></span>
   <span class="home-credits-item"><span class="home-credits-role">local</span><span class="home-credits-rule" aria-hidden="true"></span><b>100%</b></span>
 </p>
 

--- a/site/news.html
+++ b/site/news.html
@@ -57,7 +57,7 @@
       <!-- 2299 = 2072 extension + 211 server + 16 bot. Preflight recomputes
            data-check="tests" and data-check="defects" and fails the release
            if either disagrees. Update them together with that check. -->
-      <span><b data-check="tests">2457</b> tests passing</span>
+      <span><b data-check="tests">2460</b> tests passing</span>
       <span><b data-check="defects">195</b> defects closed</span>
       <span><b>0</b> numbers invented</span>
     </div>


### PR DESCRIPTION
**Rebased onto v3.18.0 (a0e3b7b) and cut down.** D-64 fixed portifly's ticket via
a different root cause than this branch originally did, so the overlap is gone
and what remains is two gaps D-64 does not close.

## Dropped, because D-64 covers it

The earlier version added a want-signal (`avgBuyUsd`) to the GMGN spec so the
bridge could tell "no average" from "no level yet". **D-64 does that better** with
`avg{Side}Native`, which also feeds its C-16 native-ratio lane. Gone from this
branch. D-64's sweep re-arming is likewise untouched — this PR now *calls* it
rather than duplicating it.

## Gap 1 — the sixth argument is still missing

`syncGmgnAverageLines` still calls `syncLineSlot` with **five** arguments on
current main:

```js
syncLineSlot(gmgnBuySlot, chart, gmgnLineLevel('Buy'), label, color);      // GMGN
syncLineSlot(averageFillSlot, chart, buyLevel, label, color, wantsBuy);    // paper
```

The sixth is `wanted` — F-41's split between *"there is no line to draw"* (clear
it) and *"a line IS wanted, its level is momentarily uncomputable"* (keep what is
drawn, retry). `undefined` is falsy, so every uncomputable tick **destroys a
correct line and returns true**, which also ends the retry loop.

D-64 made levels computable far more often, **not always**: `gmgnLastCandleClose`
resets to 0 on every token switch and *both* level lanes need it. The null level
is the first moments of every coin the user opens.

## Gap 2 — GMGN never got D-63

D-63 taught `syncPaperAverageLines` that an off-range line **enters the host
autoscale** and drags the axis through zero (dashgirn's -4.71K ticks,
ark_trades13's -175K with candles squashed into a corner).

GMGN draws through the same `createOrderLine` on the same TradingView chart and
has **zero** off-range checking. That axis wreck is reproducible on GMGN today.

Same remedy, deliberately the same shape as D-63: vet per side, clear the slot so
it stops feeding autoscale, never pass an off-range side to `syncLineSlot`, name
the reason, let the sweep bring it back when the axis scrolls. `offVisibleRange`
fails safe — a chart it cannot measure accuses nothing.

## Also

The sweep's want-rule and the sync's are now **one function**. They have to
agree: a sweep that re-arms a sync which then declines to draw is a loop that
never terminates and never draws.

And the GMGN path gains the diagnostic it never had (`lastGmgnLineReason`, emitted
on give-up). The paper path has had `lastLineSyncReason` since F-41 — portifly's
report arrived as "they never show up" precisely because this path could not say
which cause it was.

## Tests

All three new tests fail against v3.18.0 and pass after. The maintainer's
`d63_linelevel` and `d64_gmgnlines` suites stay green.

```
extension: 2151 pass, 0 fail
server:     289 tests, 279 pass, 0 fail, 10 skipped (offline live-API)
```

Site test count 2457 → 2460; defects count untouched (a0e3b7b fixed it on main).