### PR TITLE
fix(debug): the shared debug report carries the price path — the one thing it was missing

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -8913,6 +8913,57 @@
       toggleOverlayEnabled().catch(() => {});
       return undefined;
     }
+    if (msg?.type === 'pt_price_debug') {
+      /* Share-debug-logs pull: why is this coin not priced?
+       *
+       * The recorder already carries the two error rings and the chip map,
+       * and that is enough for anything that THROWS. The most-reported bug
+       * we have throws nothing: the panel sits on "Fetching live price…"
+       * while every path quietly declines to produce a number, so the report
+       * a user attaches to that ticket contains no evidence about it at all
+       * (CHENG, 2026-08-29, v3.17.1 — the third report of this symptom, each
+       * time with nothing to read).
+       *
+       * These are the states that decide whether a price arrives: whether the
+       * page feed is alive (which is also what D-61's live-market bypass
+       * keys off), how far into the D-60S exponential backoff the chain probe
+       * has walked, and whether the probe is latched or released.
+       *
+       * NO ADDRESSES. errors.js strips keys, tokens and addresses at RECORD
+       * time so the report is safe by construction rather than by an
+       * export-time scrub — this snapshot keeps that property by emitting
+       * ages, counters and booleans only, never a mint or pool. */
+      const now = Date.now();
+      const age = (t) => (t > 0 ? now - t : null);
+      try {
+        respond({
+          ok: true,
+          price: {
+            site: (site && site.id) || null,
+            hasToken: Boolean(token),
+            pending: Boolean(token && token.pending),
+            priceSource: (token && token.priceSource) || null,
+            hasPriceNative: Boolean(token && Number(token.priceNative) > 0),
+            hasMcap: Boolean(token && Number(token.mcap) > 0),
+            // Feed liveness — the input to D-61's live-market exception.
+            lastPriceAgeMs: age(lastPriceAt),
+            lastPageTickAgeMs: age(lastPageTickAt),
+            lastMcapTickAgeMs: age(lastMcapTickAt),
+            // Chain probe: the D-60/D-60S/D-61 path itself.
+            prewatchAttempts,
+            prewatchBackoffRemainingMs: token && token.srcAddress
+              ? prewatchBackoffMs(token.srcAddress)
+              : null,
+            prewatchLatched: prewatchedAddress !== null,
+            prewatchLastTryAgeMs: age(prewatchLastTryAt),
+            onchainLive: Boolean(onchainLive),
+            // An intent waiting on a first quote is the user-visible symptom.
+            armedBuy: armedBuy ? { ageMs: age(armedBuy.at), fromClick: Boolean(armedBuy.fromClick) } : null,
+          },
+        });
+      } catch (_) { /* popup gone */ }
+      return undefined;
+    }
     if (msg?.type === 'pt_chip_debug') {
       // Share-debug-logs pull: the chip map lives in the MAIN-world bridge,
       // so relay the request over the postMessage bridge and hand back the

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -101,6 +101,12 @@ async function shareDebugLogs() {
           const chips = await chrome.tabs.sendMessage(tab.id, { type: 'pt_chip_debug' });
           if (chips && chips.ok) report.chips = chips.chips || null;
         } catch (_) { /* chip bridge absent (non-screener page) */ }
+        // The price path answers the report this recorder exists for and
+        // that the error rings cannot: "Fetching live price…" throws nothing.
+        try {
+          const price = await chrome.tabs.sendMessage(tab.id, { type: 'pt_price_debug' });
+          if (price && price.ok) report.price = price.price || null;
+        } catch (_) { /* no content script on this tab */ }
       }
     } catch (_) { /* tabs query denied: report still carries the worker half */ }
     const text = JSON.stringify(report, null, 1);

--- a/extension/test/errors.test.js
+++ b/extension/test/errors.test.js
@@ -443,3 +443,70 @@ test('the global handlers survive a missing recorder', () => {
     /window\.PTErrors \|\| null/,
     'content must tolerate a missing recorder rather than throwing on the page');
 });
+
+/* ------------------------------------------------------------------
+ * The debug report must answer the report it exists for.
+ *
+ * The rings capture anything that THROWS. The most-reported symptom we have
+ * throws nothing: the panel sits on "Fetching live price…" while every path
+ * quietly declines to produce a number. Before this, a user who hit that and
+ * dutifully clicked "Share debug logs" sent back two empty error rings and a
+ * chip map — nothing about the price path at all.
+ * ------------------------------------------------------------------ */
+
+test('the debug report carries the price path, not only errors and chips', () => {
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const ROOT = path.join(__dirname, '..');
+  const read = (f) => fs.readFileSync(path.join(ROOT, f), 'utf8');
+
+  const popup = read('popup.js');
+  assert.match(popup, /type: 'pt_price_debug'/,
+    'shareDebugLogs must ask the tab for the price path');
+  assert.match(popup, /report\.price = /,
+    'the answer must reach the report the user pastes');
+
+  const content = read('content.js');
+  assert.match(content, /msg\?\.type === 'pt_price_debug'/,
+    'the content script must answer the price-path pull');
+
+  // The states that actually decide whether a price arrives. Each of these
+  // is load-bearing for the D-60 / D-60S / D-61 chain-probe path; without
+  // them the report cannot distinguish "feed dead" from "probe benched".
+  for (const field of [
+    'lastMcapTickAgeMs',      // D-61's live-market exception keys off this
+    'prewatchAttempts',       // how far into D-60S's exponential backoff
+    'prewatchBackoffRemainingMs',
+    'prewatchLatched',        // D-60: did a failed probe release the latch
+    'onchainLive',
+  ]) {
+    assert.ok(content.includes(field), `the price snapshot must report ${field}`);
+  }
+});
+
+test('the price snapshot reports no addresses — the report stays safe by construction', () => {
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const ROOT = path.join(__dirname, '..');
+  const content = fs.readFileSync(path.join(ROOT, 'content.js'), 'utf8');
+
+  const start = content.indexOf("msg?.type === 'pt_price_debug'");
+  const end = content.indexOf("msg?.type === 'pt_chip_debug'");
+  assert.ok(start !== -1 && end > start, 'the price-debug handler must ship');
+  // Scan CODE only. A comment that mentions a mint is documentation, not a
+  // leak, and a check that cannot tell the two apart would punish the
+  // explanation of why the rule exists.
+  const block = content.slice(start, end)
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^[ \t]*\/\/.*$/gm, '');
+
+  // errors.js redacts at RECORD time so the report is safe by construction
+  // rather than by an export-time scrub that a new field could slip past.
+  // This snapshot is built at EXPORT time, so it must never carry an
+  // identifier in the first place: ages, counters and booleans only.
+  assert.ok(!/\bmint\b/.test(block), 'the snapshot must not emit a mint');
+  assert.ok(!/srcAddress:/.test(block), 'the snapshot must not emit an address as a value');
+  assert.ok(!/pairAddress/.test(block), 'the snapshot must not emit a pair address');
+  assert.match(block, /prewatchLatched: prewatchedAddress !== null/,
+    'the probe latch must be reported as a boolean, never as the address itself');
+});

--- a/site/index.html
+++ b/site/index.html
@@ -117,7 +117,7 @@
   <span class="home-credits-kicker">proof</span>
   <span class="home-credits-item"><span class="home-credits-role">terminals</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="sites">15</b></span>
   <span class="home-credits-item"><span class="home-credits-role">invented prices</span><span class="home-credits-rule" aria-hidden="true"></span><b>0</b></span>
-  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2457</b></span>
+  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2459</b></span>
   <span class="home-credits-item"><span class="home-credits-role">local</span><span class="home-credits-rule" aria-hidden="true"></span><b>100%</b></span>
 </p>
 

--- a/site/news.html
+++ b/site/news.html
@@ -57,7 +57,7 @@
       <!-- 2299 = 2072 extension + 211 server + 16 bot. Preflight recomputes
            data-check="tests" and data-check="defects" and fails the release
            if either disagrees. Update them together with that check. -->
-      <span><b data-check="tests">2457</b> tests passing</span>
+      <span><b data-check="tests">2459</b> tests passing</span>
       <span><b data-check="defects">195</b> defects closed</span>
       <span><b>0</b> numbers invented</span>
     </div>


### PR DESCRIPTION
**Rebased onto v3.18.0 (a0e3b7b). Re-evaluated against D-62 — still needed, and here is the honest accounting of why.**

## What D-62 changed, and what it didn't

D-62 is the real fix for the freeze this PR was originally chasing: publicnode's
WAF refuses `getMultipleAccounts` by cumulative request weight, and the whole
feed rode that one method. Batches are now capped at 20 keys with a per-account
`getAccountInfo` fallback in a different weight class. That is the root cause for
CHENG / ark_trades13 / giovinastro, named in the defect entry.

**So the specific freeze is fixed, and this PR does not claim otherwise.**

What D-62 did not add is any way to see the price path from a debug report.
Verified against current `upstream/main`:

```
popup.js   — pt_price_debug / report.price occurrences: 0
content.js — pt_price_debug handler:                    0
```

`shareDebugLogs` still collects only the two error rings and the chip map, and a
"Fetching live price…" stall still **throws nothing**. Any user hitting a stall
D-62 does not cover — a different endpoint's WAF, a dead page feed, a probe stuck
behind D-60S's backoff — still sends back a report with nothing in it about the
price.

## Why that still matters after D-62

The five debug exports that made D-62 diagnosable did so because they happened to
carry `http 403 getMultipleAccounts @ publicnode` in the error ring — the failure
threw. The failures that **don't** throw are still invisible, and those are the
ones left.

This snapshot records feed liveness (`lastPriceAt` / `lastPageTickAt` /
`lastMcapTickAt` ages — the last being what D-61's live-market bypass keys off),
the probe's position in D-60S's 2s→30s backoff, whether D-60's latch is held or
released, plus `onchainLive` / `pending` / `priceSource` and any waiting armed
buy. That separates "page feed is dead" from "feed is alive, probe is benched" —
two cases whose fixes point in opposite directions.

## Privacy

`errors.js` redacts at **record** time, so the report is safe by construction
rather than by an export-time scrub a new field could slip past. This snapshot is
built at export time, so it carries no identifier at all: ages, counters and
booleans only. The probe latch is `prewatchedAddress !== null`, never the
address. A test pins that, scanning code with comments stripped so the
documentation can still explain the rule.

## Tests

Both new tests fail against shipped code and pass after.

```
extension: 2150 pass, 0 fail
server:     289 tests, 279 pass, 0 fail, 10 skipped (offline live-API)
```

Site test count 2457 → 2459. The defects count needed no change — a0e3b7b fixed
the 191/192 drift on main, so this branch no longer carries the redundant hunk it
did before.