### PR TITLE
fix(rpc): the "get a personal endpoint" notice was silent in the one state that needs it

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -3350,19 +3350,47 @@ async function sweepPendingBuys() {
 const SLOW_POOL_MS = 750;
 const SLOW_POOL_MIN_SAMPLES = 12;
 
+/* A pool can fail without ever being SLOW, and that is the common case.
+ * poolLatency() is built from reportSuccess() alone, so a throttled or
+ * policy-blocked endpoint contributes no sample: the one endpoint still
+ * answering reports its own healthy latency and bestMs stays under the
+ * threshold while most reads are dying. ticket-0010 (fomo.family,
+ * 2026-08-29) is the shape — a console full of "http 429 getMultipleAccounts
+ * @ tatum" and "http 403 … @ publicnode", the price taking "a very long
+ * time", and the user asking whether there is a fix. There is, it is the
+ * same two-minute fix, and this notice existed to say so but could not see
+ * the failure. Half of recent attempts failing is a pool that cannot do its
+ * job, whatever the survivors' latency says. */
+const FAILING_POOL_RATE = 0.5;
+const FAILING_POOL_MIN_ATTEMPTS = 12;
+
 async function maybeNoteSlowPool(settings) {
   try {
     if (settings && settings.rpcUrl) return; // they already fixed it
     if (!self.PTRpcPool || typeof PTRpcPool.poolLatency !== 'function') return;
     const measured = PTRpcPool.poolLatency();
-    if (!measured || measured.samples < SLOW_POOL_MIN_SAMPLES) return;
-    if (measured.bestMs <= SLOW_POOL_MS) return;
+    const stress = typeof PTRpcPool.poolStress === 'function' ? PTRpcPool.poolStress() : null;
+
+    const slow = Boolean(measured
+      && measured.samples >= SLOW_POOL_MIN_SAMPLES
+      && measured.bestMs > SLOW_POOL_MS);
+    const failing = Boolean(stress
+      && stress.attempts >= FAILING_POOL_MIN_ATTEMPTS
+      && stress.failRate >= FAILING_POOL_RATE);
+    if (!slow && !failing) return;
+
     const flags = await new Promise((resolve) =>
       chrome.storage.local.get(['pt_rpc_slow_told'], (v) => resolve(v || {})));
     if (flags.pt_rpc_slow_told) return; // once per install, never a nag
+    // Name which one it is: "slow from your region" is the wrong sentence to
+    // read when the endpoints are refusing you outright, and the wrong
+    // sentence makes a correct fix look irrelevant.
+    const notice = { reason: failing ? 'failing' : 'slow', at: Date.now() };
+    if (measured) { notice.bestMs = measured.bestMs; notice.samples = measured.samples; }
+    if (stress) { notice.failRate = Math.round(stress.failRate * 100) / 100; notice.attempts = stress.attempts; }
     await new Promise((resolve) => chrome.storage.local.set({
       pt_rpc_slow_told: Date.now(),
-      pt_rpc_notice: { bestMs: measured.bestMs, samples: measured.samples, at: Date.now() },
+      pt_rpc_notice: notice,
     }, () => resolve()));
   } catch (_) { /* a notice must never break a price path */ }
 }

--- a/extension/content.js
+++ b/extension/content.js
@@ -2350,9 +2350,16 @@
       const rpcNotice = changes.pt_rpc_notice;
       if (rpcNotice && rpcNotice.newValue && !rpcNotice.oldValue) {
         const ms = Number(rpcNotice.newValue.bestMs) || 0;
-        toast('Heads-up: the public price connection is slow from your region'
-          + (ms ? ` (~${ms}ms)` : '')
-          + '. A free personal endpoint makes new coins instant — Dashboard → Settings → Price connection.');
+        // Two different faults, one fix. Saying "slow from your region" to
+        // someone whose endpoints are returning 429/403 describes something
+        // they can see is not happening, and a fix introduced by a wrong
+        // diagnosis reads as irrelevant.
+        const why = rpcNotice.newValue.reason === 'failing'
+          ? 'the public price connection is being throttled or refused where you are'
+          : 'the public price connection is slow from your region'
+            + (ms ? ` (~${ms}ms)` : '');
+        toast(`Heads-up: ${why}. A free personal endpoint makes new coins instant`
+          + ' — Dashboard → Settings → Price connection.');
       }
 
       const stateChange = changes[E.STORAGE_KEYS.state];

--- a/extension/rpc-pool.js
+++ b/extension/rpc-pool.js
@@ -272,6 +272,35 @@
    * public endpoints slow; a free personal endpoint made launches
    * instant). Null until anything is measured.
    */
+  /**
+   * How much of the pool's RECENT traffic is failing.
+   *
+   * poolLatency() below can only see calls that SUCCEEDED — latencyMs and
+   * samples are written in reportSuccess() and nowhere else — so a throttled
+   * or policy-blocked endpoint contributes no sample at all. That makes the
+   * pool look FAST precisely when it is failing: the one endpoint still
+   * answering reports its own healthy latency while the others 429/403 into
+   * the bench, and any measure built on latency alone reads "fine".
+   *
+   * The attempt log is the honest record, because a failure is written there
+   * with its status. A user whose console is full of
+   * "http 429 getMultipleAccounts @ tatum" / "http 403 … @ publicnode"
+   * (ticket-0010, fomo.family, 2026-08-29) is in exactly that state, and
+   * nothing keyed off latency will ever notice.
+   */
+  function poolStress() {
+    const attempts = attemptLog.length;
+    if (!attempts) return { attempts: 0, failures: 0, failRate: 0 };
+    let failures = 0;
+    for (const entry of attemptLog) {
+      // 200 is the only success the log records; every other status is a
+      // failed attempt (403/429/5xx, 'rpc-policy', 'rpc-error', 'timeout',
+      // 'rejected'). Counting anything-not-200 keeps new statuses honest.
+      if (entry && entry.status !== 200) failures += 1;
+    }
+    return { attempts, failures, failRate: failures / attempts };
+  }
+
   function poolLatency() {
     let best = null;
     let samples = 0;
@@ -473,7 +502,7 @@
   const api = {
     PUBLIC_ENDPOINTS, COOLDOWN_MS,
     setUserEndpoint, hasUserEndpoint,
-    ranked, call, websocketUrls, poolLatency,
+    ranked, call, websocketUrls, poolLatency, poolStress,
     reportSuccess, reportFailure, methodBlockedEverywhere,
     _health: health,
     _attempts: () => attemptLog.slice(),

--- a/extension/test/rpcpool.test.js
+++ b/extension/test/rpcpool.test.js
@@ -300,3 +300,79 @@ test("F-63 refined: a second 403 on the same method confirms the block; 403s nev
   assert.equal(fetchCalls, callsBefore,
     'a fully method-blocked pool must fail fast without network traffic');
 });
+
+/* ---------------- a dead pool does not look slow, it looks like nothing ------
+ *
+ * ticket-0010 (fomo.family, 2026-08-29): a console full of
+ *   "PaperTrench: on-chain watch failed: http 429 getMultipleAccounts @ tatum"
+ *   "PaperTrench: on-chain watch failed: http 403 getMultipleAccounts @ publicnode"
+ * a live price that "takes a very long time", and the user asking whether
+ * there is a fix. There is — a free personal endpoint, Settings → Price
+ * connection — and the product carries a notice built to volunteer exactly
+ * that, unprompted, so nobody has to discover it (cojica456's report).
+ *
+ * It cannot fire for this user. latencyMs and samples are written in
+ * reportSuccess() and nowhere else, so when every endpoint refuses, there is
+ * no successful call to measure and poolLatency() returns NULL outright — and
+ * the notice's first guard is `if (!measured …) return`. The worst possible
+ * pool state is the one state that guarantees silence.
+ * ------------------------------------------------------------------------- */
+
+test('a wholly refused pool reports null latency — the notice guard bails on its worst case', async () => {
+  const P = loadPool(async (url) => (/publicnode/.test(url)
+    ? { ok: false, status: 403, json: async () => ({}) }
+    : { ok: false, status: 429, json: async () => ({}) }));
+
+  for (let i = 0; i < 8; i += 1) {
+    try { await P.call('getMultipleAccounts', [[]]); } catch (_) { /* every endpoint refuses */ }
+  }
+
+  assert.equal(P.poolLatency(), null,
+    'no successful call means nothing to measure — this is why a latency-only notice is silent');
+
+  const stress = P.poolStress();
+  assert.ok(stress.attempts >= 12, `real attempts must be recorded, got ${stress.attempts}`);
+  assert.equal(stress.failRate, 1, 'every attempt failed; the pool cannot do its job');
+});
+
+test('a pool that fails over and serves is NOT reported as failing', async () => {
+  // Two endpoints refuse, one answers. F-63's demotion routes around them, the
+  // user is served, and nothing should nag: a self-healed pool is a pool that
+  // works, and a notice fired here would be noise the user cannot act on.
+  const P = loadPool(async (url) => {
+    if (/publicnode/.test(url)) return { ok: false, status: 403, json: async () => ({}) };
+    if (/tatum/.test(url)) return { ok: false, status: 429, json: async () => ({}) };
+    return okResponse('ok');
+  });
+  for (let i = 0; i < 8; i += 1) {
+    try { await P.call('getMultipleAccounts', [[]]); } catch (_) {}
+  }
+  const stress = P.poolStress();
+  assert.ok(stress.failRate < 0.5,
+    `a serving pool must stay under the notice threshold, got ${stress.failRate}`);
+});
+
+test('poolStress reports a clean pool as unstressed', async () => {
+  const P = loadPool(async () => okResponse('ok'));
+  for (let i = 0; i < 12; i += 1) await P.call('getMultipleAccounts', [[]]);
+  const stress = P.poolStress();
+  assert.equal(stress.failures, 0, 'a healthy pool has no failed attempts');
+  assert.equal(stress.failRate, 0, 'and must never be reported as failing');
+});
+
+test('the notice fires on a failing pool and names which fault it saw', () => {
+  const src = fs.readFileSync(path.join(ROOT, 'background.js'), 'utf8');
+  assert.match(src, /PTRpcPool\.poolStress/,
+    'the notice must consult failure evidence, not latency alone');
+  assert.match(src, /if \(!slow && !failing\) return;/,
+    'either fault alone must be enough to tell the user the fix exists');
+  assert.match(src, /reason: failing \? 'failing' : 'slow'/,
+    'the notice must record which fault it saw');
+
+  // "slow from your region" is the wrong sentence to read when the endpoints
+  // are refusing you outright; a fix introduced by a wrong diagnosis reads as
+  // irrelevant, and this user already knows their price is not merely slow.
+  const content = fs.readFileSync(path.join(ROOT, 'content.js'), 'utf8');
+  assert.match(content, /throttled or refused where you are/,
+    'the toast must describe a refused pool honestly rather than calling it slow');
+});

--- a/site/index.html
+++ b/site/index.html
@@ -117,7 +117,7 @@
   <span class="home-credits-kicker">proof</span>
   <span class="home-credits-item"><span class="home-credits-role">terminals</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="sites">15</b></span>
   <span class="home-credits-item"><span class="home-credits-role">invented prices</span><span class="home-credits-rule" aria-hidden="true"></span><b>0</b></span>
-  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2457</b></span>
+  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2461</b></span>
   <span class="home-credits-item"><span class="home-credits-role">local</span><span class="home-credits-rule" aria-hidden="true"></span><b>100%</b></span>
 </p>
 

--- a/site/news.html
+++ b/site/news.html
@@ -57,7 +57,7 @@
       <!-- 2299 = 2072 extension + 211 server + 16 bot. Preflight recomputes
            data-check="tests" and data-check="defects" and fails the release
            if either disagrees. Update them together with that check. -->
-      <span><b data-check="tests">2457</b> tests passing</span>
+      <span><b data-check="tests">2461</b> tests passing</span>
       <span><b data-check="defects">195</b> defects closed</span>
       <span><b>0</b> numbers invented</span>
     </div>


### PR DESCRIPTION
**Rebased onto v3.18.0 (a0e3b7b). Complementary to D-62, and the two now compose
correctly — details below.**

## The ticket

ticket-0010 (fomo.family, 2026-08-29) — a console full of:

```
PaperTrench: on-chain watch failed: http 429 getMultipleAccounts @ tatum
PaperTrench: on-chain watch failed: http 403 getMultipleAccounts @ publicnode
```

a live price that "takes a very long time", and the user asking whether there's a
fix. There is — a free personal endpoint, Settings → Price connection — and the
product ships a notice built to volunteer exactly that unprompted (cojica456's
report), so nobody has to discover it. It could not fire for this user.

## Why it was silent — worse than "it only measures latency"

`latencyMs` and `samples` are written in `reportSuccess()` and nowhere else, so a
refused endpoint contributes **no sample**. Measured on the reported pool shape:

| pool state | `poolStress()` | `poolLatency()` |
|---|---|---|
| every endpoint refusing | 40/40 failed, rate 1.0 | **`null`** |
| two refusing, one serving | rate 0.11 | healthy |

The notice's first guard is `if (!measured || …) return`. When the whole pool is
down — the state that produces the symptom — `poolLatency()` returns `null` and
it **returns immediately**. The worst possible pool state was the one guaranteed
to stay silent.

## How this composes with D-62

Different layers, and they compose the right way round:

- **D-62** reduces how often the pool gets refused at all — batches capped at 20
  keys, `getAccountInfo` fallback in a different weight class.
- **This PR** is the user-facing notice for whoever still hits it.

Concretely: with D-62's fallback succeeding, those `getAccountInfo` calls land in
the attempt log as 200s, so `failRate` drops below the threshold and **the notice
correctly does not fire** — that user is being served. It fires only on the true
remainder, where even the fallback cannot get through. That is the intended
relationship, not a coincidence.

Verified: `poolStress` and D-62's `d62_gma_fallback` suite both green together
(28/28). D-62's only `rpc-pool.js` change stamps `kind:'method'` on the
blocked-everywhere throw and does not touch the attempt log, `reportSuccess`, or
`reportFailure`.

## The wording half

*"The public price connection is slow from your region"* is the wrong sentence for
someone being refused outright: they can see their price is not merely slow, and a
correct fix introduced by a visibly wrong diagnosis reads as irrelevant. A failing
pool now says it is being **throttled or refused**, pointing at the same setting.

**A pool that fails over and still serves is deliberately not reported** — F-63's
demotion routes around dead endpoints, and a notice there is noise the user cannot
act on. Locked by a negative-control test.

## Tests

All four new tests fail against shipped code and pass after.

```
extension: 2152 pass, 0 fail
server:     289 tests, 279 pass, 0 fail, 10 skipped (offline live-API)
```

Site test count 2457 → 2461; defects count untouched (a0e3b7b fixed it on main).

## Not fixed here

The 403 from `publicnode` and 429 from `tatum` are real and remain — keyless
public endpoints doing what keyless public endpoints do. That is the case for the
personal-endpoint fix existing at all, and this PR is about making sure the
affected user is actually told about it.