### PR TITLE
fix(panel): the desk only rendered while it was empty

### DIFF
--- a/extension/panel.html
+++ b/extension/panel.html
@@ -5,56 +5,198 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>PaperTrench Desk</title>
   <style>
-    :root { color-scheme: dark; }
+    /* Side-panel desk (DELIGHT-MAP.md D1).
+     *
+     * The desk is docked next to a chart for a whole session, so it is the
+     * PaperTrench surface a trader looks at longest. It shipped with its own
+     * palette and system-ui type, which made it the one surface that did not
+     * look like the product: #0b0e14 against the popup's #0A0D13, a link in a
+     * blue that appears nowhere else, and italic grey for every empty state.
+     *
+     * It now uses the popup's tokens verbatim. Two surfaces a click apart
+     * disagreeing about the background colour reads as an unfinished build.
+     */
+    :root {
+      color-scheme: dark;
+      --bg: #0A0D13;
+      --raised: rgba(255, 255, 255, 0.045);
+      --line: rgba(255, 255, 255, 0.075);
+      --line-2: rgba(255, 255, 255, 0.14);
+      --text: #EAEFF7;
+      --dim: #8D97A9;
+      --faint: #5A6273;
+      --amber: #FF9D45;
+      --amber-2: #FFC081;
+      --green: #34D399;
+      --red: #FF5F56;
+      --mono: ui-monospace, "SF Mono", Menlo, monospace;
+    }
     * { box-sizing: border-box; }
+
+    /* The UA's [hidden] rule loses to any class selector, so a component
+     * styled display:flex renders while carrying the attribute (popup.html
+     * carries the same guard, for the same reason). */
+    [hidden] { display: none !important; }
+
+    /* A docked panel is a tall thin column that is ALWAYS taller than its
+     * content early on — a new trader has no streak, no position and no
+     * closed rounds, which is the exact state in the bug report: a third of a
+     * screen of content over two thirds of void. The column stretches to the
+     * viewport and the footer is pinned to the bottom of it, so the empty
+     * desk reads as a laid-out page rather than as content that ran out. */
+    html, body { height: 100%; }
     body {
-      margin: 0; padding: 12px; font: 13px/1.45 system-ui, sans-serif;
-      background: #0b0e14; color: #e7ebf3;
+      margin: 0; padding: 14px 14px 12px;
+      display: flex; flex-direction: column; gap: 18px;
+      font: 13px/1.45 ui-sans-serif, -apple-system, "Segoe UI", Inter, sans-serif;
+      background: var(--bg); color: var(--text);
+      -webkit-font-smoothing: antialiased;
     }
-    h1 { font-size: 13px; margin: 0 0 2px; letter-spacing: 0.04em; }
-    .sub { color: #8b93a7; font-size: 11px; margin: 0 0 12px; }
-    .chips { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 14px; }
-    .chip {
-      border: 1px solid rgba(255,255,255,0.12); border-radius: 999px;
-      padding: 2px 9px; font-size: 11px; color: #c6cdd9;
+    main { flex: 1; display: flex; flex-direction: column; gap: 18px; }
+
+    /* ---------- header ---------- */
+    header { display: flex; align-items: center; gap: 9px; }
+    header .mark { flex: none; color: var(--amber); }
+    h1 {
+      font-size: 11px; font-weight: 800; margin: 0;
+      letter-spacing: 0.14em; text-transform: uppercase;
     }
-    .chip strong { color: #e7ebf3; }
+    .sub { color: var(--dim); font-size: 11.5px; margin: 2px 0 0; line-height: 1.4; }
+
+    /* ---------- streak row ----------
+     * Was three pill chips reading "0 journal (best 0)" — a sentence with the
+     * number buried in it, three times over. A streak is a figure, so it is
+     * set as one: the count leads at display size, the axis labels it, the
+     * best sits under as reference. */
+    .streaks { display: grid; grid-template-columns: repeat(3, 1fr); gap: 7px; }
+    .streak {
+      background: var(--raised); border: 1px solid var(--line);
+      border-radius: 9px; padding: 9px 8px 8px; text-align: center;
+      min-width: 0;
+    }
+    .streak .n {
+      font-family: var(--mono); font-size: 19px; font-weight: 700;
+      line-height: 1; letter-spacing: -0.02em; color: var(--faint);
+    }
+    /* A live streak earns the colour; a zero does not. An always-amber row
+     * says "you are on a streak" to somebody who has never traded. */
+    .streak.on { border-color: rgba(255, 157, 69, 0.3); background: rgba(255, 157, 69, 0.06); }
+    .streak.on .n { color: var(--amber-2); }
+    .streak .axis {
+      font-size: 9.5px; font-weight: 700; letter-spacing: 0.06em;
+      text-transform: uppercase; color: var(--dim); margin-top: 5px;
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
+    .streak .best { font-size: 9.5px; color: var(--faint); margin-top: 2px; font-family: var(--mono); }
+    .streak .tier {
+      display: block; font-size: 9px; font-weight: 700; color: var(--amber);
+      margin-top: 3px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
+
+    /* ---------- sections ----------
+     * The After feed is the section that grows, so the slack in a tall panel
+     * is absorbed by the last panel rather than pooling as a dead band above
+     * the footer. Pinning the footer alone was not enough: it moved the void
+     * from the bottom to the middle, which reads the same. */
+    section { display: flex; flex-direction: column; }
+    section.grow { flex: 1; min-height: 0; }
+    section.grow .feed { flex: 1; }
     h2 {
-      font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em;
-      color: #8b93a7; margin: 14px 0 6px;
+      font-size: 10px; font-weight: 700; text-transform: uppercase;
+      letter-spacing: 0.1em; color: var(--faint); margin: 0 0 7px;
     }
+
     .card {
-      border: 1px solid rgba(255,255,255,0.1); border-radius: 8px;
-      padding: 10px; background: rgba(255,255,255,0.03);
+      border: 1px solid var(--line-2); border-radius: 10px;
+      padding: 11px 12px; background: var(--raised);
     }
-    .card .sym { font-weight: 700; font-size: 14px; }
-    .card .meta { color: #8b93a7; font-size: 11px; margin-top: 2px; }
+    .card .sym { font-weight: 700; font-size: 14.5px; letter-spacing: -0.01em; }
+    .card .meta {
+      color: var(--dim); font-size: 11.5px; margin-top: 3px;
+      font-family: var(--mono);
+    }
     .nudge {
-      margin-top: 8px; font-size: 11px; color: #f5c451;
-      border: 1px dashed rgba(245,196,81,0.45); border-radius: 6px; padding: 5px 7px;
+      margin-top: 9px; font-size: 11px; color: var(--amber-2); line-height: 1.45;
+      border: 1px dashed rgba(255, 157, 69, 0.4); border-radius: 7px;
+      padding: 6px 8px; background: rgba(255, 157, 69, 0.05);
     }
-    .empty { color: #8b93a7; font-size: 12px; font-style: italic; }
+
+    /* An empty state is a designed state, not the absence of one. Centred in
+     * a dashed frame it reads as "nothing here yet, by design" — the italic
+     * grey line it replaces read as a rendering failure. */
+    .empty {
+      display: flex; flex-direction: column; align-items: center; gap: 7px;
+      flex: 1; justify-content: center;
+      text-align: center; color: var(--dim); font-size: 11.5px; line-height: 1.5;
+      border: 1px dashed var(--line-2); border-radius: 10px;
+      padding: 18px 14px;
+    }
+    .empty .mark { color: var(--faint); }
+    .empty b { display: block; color: var(--text); font-size: 12.5px; font-weight: 700; }
+
+    /* ---------- after feed ---------- */
     .feed { display: flex; flex-direction: column; gap: 6px; }
     .row {
-      display: flex; justify-content: space-between; gap: 8px;
-      border: 1px solid rgba(255,255,255,0.08); border-radius: 6px; padding: 6px 8px;
+      display: flex; align-items: baseline; justify-content: space-between; gap: 10px;
+      border: 1px solid var(--line); border-radius: 8px; padding: 8px 10px;
+      background: var(--raised);
     }
-    .row .sym { font-weight: 600; }
-    .row .what { color: #8b93a7; font-size: 11px; }
-    .pos { color: #34D399; } .neg { color: #FF5F56; } .amber { color: #f5c451; }
-    footer { margin-top: 16px; }
-    a { color: #7dd3fc; font-size: 12px; }
+    .row .sym { font-weight: 700; font-size: 12.5px; }
+    .row .when { color: var(--faint); font-size: 10.5px; font-family: var(--mono); }
+    .row .right { text-align: right; flex: none; }
+    .row .pnl { font-family: var(--mono); font-size: 12.5px; font-weight: 700; }
+    .row .what { display: block; color: var(--dim); font-size: 10.5px; margin-top: 2px; }
+    .pos { color: var(--green); } .neg { color: var(--red); } .amber { color: var(--amber-2); }
+
+    /* ---------- footer ---------- */
+    footer { flex: none; padding-top: 2px; }
+    .dash-btn {
+      display: flex; align-items: center; justify-content: center; gap: 7px;
+      width: 100%; padding: 9px 12px;
+      font: inherit; font-size: 12px; font-weight: 700; cursor: pointer;
+      color: var(--text); background: var(--raised);
+      border: 1px solid var(--line-2); border-radius: 9px;
+      text-decoration: none;
+      transition: background 0.15s, border-color 0.15s;
+    }
+    .dash-btn:hover { background: rgba(255, 255, 255, 0.08); border-color: rgba(255, 255, 255, 0.22); }
   </style>
 </head>
 <body>
-  <h1>PAPER TRENCH · DESK</h1>
-  <div class="sub">Your round, your discipline, and what the coin did after you left.</div>
-  <div class="chips" id="chips"></div>
-  <h2>Active round</h2>
-  <div id="active"></div>
-  <h2>After feed</h2>
-  <div class="feed" id="after"></div>
-  <footer><a href="#" id="dash">Open full dashboard →</a></footer>
+  <header>
+    <svg class="mark" width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M3 20.5 12 3l9 17.5-9-4.6z"/>
+    </svg>
+    <div>
+      <h1>PaperTrench · Desk</h1>
+      <p class="sub">Your round, your discipline, and what the coin did after you left.</p>
+    </div>
+  </header>
+
+  <main>
+    <div class="streaks" id="chips"></div>
+
+    <section>
+      <h2>Active round</h2>
+      <div id="active"></div>
+    </section>
+
+    <section class="grow">
+      <h2>After feed</h2>
+      <div class="feed" id="after"></div>
+    </section>
+  </main>
+
+  <footer>
+    <a class="dash-btn" href="#" id="dash">
+      Open full dashboard
+      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+           stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M5 12h13M13 6.5 18.5 12 13 17.5"/>
+      </svg>
+    </a>
+  </footer>
+
   <script src="gamify.js"></script>
   <script src="panel-data.js"></script>
   <script src="panel.js"></script>

--- a/extension/panel.js
+++ b/extension/panel.js
@@ -11,6 +11,17 @@
 
 const $ = (sel) => document.querySelector(sel);
 
+/* The pure half, bound once. Both render helpers below used to reach for a
+ * formatter that was never in scope — `fmtSol(...)` bare in activeHtml and
+ * `P.fmtSol(...)` in afterHtml, where neither `fmtSol` nor `P` is declared
+ * anywhere in this file and panel-data.js exports onto `window.PTPanel`.
+ *
+ * Both threw ReferenceError, so the desk rendered ONLY while it was empty:
+ * the first open position or the first closed round with an after-watch
+ * took render() down, leaving whatever had been on screen before. The empty
+ * desk in the bug report was the only state that worked. */
+const P = window.PTPanel;
+
 function fmtAgo(ms) {
   const m = Math.floor(ms / 60000);
   if (m < 1) return 'just now';
@@ -20,40 +31,92 @@ function fmtAgo(ms) {
   return Math.floor(h / 24) + 'd';
 }
 
+/* Held time is a DURATION. It was being run through fmtSol and then had the
+ * unit stripped off the end — so a position held 90 minutes reported
+ * "+5400000.00", a raw millisecond count wearing two decimal places. */
+function fmtHeld(ms) {
+  const total = Math.max(0, Math.floor(Number(ms) || 0) / 60000);
+  const m = Math.floor(total % 60);
+  const h = Math.floor(total / 60);
+  if (h >= 24) {
+    const d = Math.floor(h / 24);
+    return d + 'd ' + (h % 24) + 'h';
+  }
+  if (h >= 1) return h + 'h ' + m + 'm';
+  if (m >= 1) return m + 'm';
+  return 'just opened';
+}
+
+const esc = (s) => String(s == null ? '' : s).replace(/[&<>"']/g, (c) => (
+  { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+));
+
+const MARK_REST =
+  '<svg class="mark" width="22" height="22" viewBox="0 0 24 24" fill="none" '
+  + 'stroke="currentColor" stroke-width="1.5" stroke-linecap="round" '
+  + 'stroke-linejoin="round" aria-hidden="true">'
+  + '<circle cx="12" cy="12" r="8.5"/><path d="M12 7.5V12l3 2"/></svg>';
+const MARK_AFTER =
+  '<svg class="mark" width="22" height="22" viewBox="0 0 24 24" fill="none" '
+  + 'stroke="currentColor" stroke-width="1.5" stroke-linecap="round" '
+  + 'stroke-linejoin="round" aria-hidden="true">'
+  + '<path d="M3.5 16.5 9 11l3.5 3.5L20.5 6.5"/><path d="M15.5 6.5h5v5"/></svg>';
+
+/* One streak axis. The count leads, the axis labels it, best is reference.
+ * `on` is what earns the amber — a zero streak is not an achievement, and
+ * colouring it like one lies to somebody who has not traded yet. */
 function chipHtml(label, st, tierLabel) {
   const cur = st && st.current ? st.current : 0;
   const best = st && st.best ? st.best : 0;
-  const tier = tierLabel ? ` · ${tierLabel}` : '';
-  return `<span class="chip"><strong>${cur}</strong> ${label}${tier} <span style="opacity:0.55">(best ${best})</span></span>`;
+  const tier = tierLabel ? `<span class="tier">${esc(tierLabel)}</span>` : '';
+  return `<div class="streak${cur > 0 ? ' on' : ''}">
+      <div class="n">${cur}</div>
+      <div class="axis">${esc(label)}</div>
+      <div class="best">best ${best}</div>
+      ${tier}
+    </div>`;
 }
 
 function activeHtml(a) {
-  if (!a) return '<div class="empty">No open position. The desk rests with you.</div>';
+  if (!a) {
+    return `<div class="empty">${MARK_REST}
+      <b>No open position</b>
+      The desk rests with you. Your active round shows here the moment you buy.
+    </div>`;
+  }
   const nudge = a.thesisMissing
     ? '<div class="nudge">No thesis on this entry — write one in the popup before the exit. Discipline is the asset.</div>'
     : '';
   return `
     <div class="card">
-      <div class="sym">${a.symbol || a.name || 'Token'}</div>
-      <div class="meta">open ${fmtSol(a.costSol)} · held ${fmtSol(a.heldMs).replace(' SOL', '')}</div>
+      <div class="sym">${esc(a.symbol || a.name || 'Token')}</div>
+      <div class="meta">open ${esc(P.fmtSol(a.costSol))} · held ${esc(fmtHeld(a.heldMs))}</div>
       ${nudge}
     </div>`;
 }
 
 function afterHtml(rows) {
   if (!rows.length) {
-    return '<div class="empty">Nothing yet. Close a round and its After watch lands here — what the coin did after you left.</div>';
+    return `<div class="empty">${MARK_AFTER}
+      <b>Nothing yet</b>
+      Close a round and its After watch lands here — what the coin did after you left.
+    </div>`;
   }
   return rows.map((r) => {
     const pnlCls = r.pnlSol > 0 ? 'pos' : (r.pnlSol < 0 ? 'neg' : '');
     const ran = r.maxPct >= 20
-      ? `<span class="amber">ran +${r.maxPct.toFixed(0)}% after you left</span>`
+      ? `<span class="what amber">ran +${r.maxPct.toFixed(0)}% after you left</span>`
       : `<span class="what">didn't run (+${r.maxPct.toFixed(0)}% max)</span>`;
     return `
       <div class="row">
-        <div><span class="sym">${r.symbol || 'Token'}</span>
-          <span class="what">· ${fmtAgo(Date.now() - r.closedAt)} ago</span></div>
-        <div><span class="${pnlCls}">${P.fmtSol(r.pnlSol)}</span> ${ran}</div>
+        <div>
+          <span class="sym">${esc(r.symbol || 'Token')}</span>
+          <span class="when">${esc(fmtAgo(Date.now() - r.closedAt))} ago</span>
+        </div>
+        <div class="right">
+          <span class="pnl ${pnlCls}">${esc(P.fmtSol(r.pnlSol))}</span>
+          ${ran}
+        </div>
       </div>`;
   }).join('');
 }

--- a/extension/test/panelrender.test.js
+++ b/extension/test/panelrender.test.js
@@ -1,0 +1,142 @@
+'use strict';
+// Side-panel desk (DELIGHT-MAP.md D1) — RENDER contract.
+//
+// sidepanel.test.js pins the wiring (manifest, script tags, storage reads)
+// and paneldata.test.js pins the pure assembly. Neither ever ran a render
+// helper over a populated desk, and that gap is exactly what shipped:
+//
+//   activeHtml called `fmtSol(...)` bare, and afterHtml called `P.fmtSol(...)`
+//   — neither identifier existed in panel.js, because panel-data.js exports
+//   onto window.PTPanel. Both threw ReferenceError, so the desk rendered only
+//   while it was EMPTY. The first open position, or the first closed round
+//   carrying an after-watch, took render() down.
+//
+// The empty desk was the only working state, which is why it looked fine in
+// screenshots and broke the moment anyone traded. These tests execute the
+// helpers over real data, so a formatter that is not in scope fails here
+// rather than in a docked panel.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const EXT = path.join(__dirname, '..');
+const panelJs = fs.readFileSync(path.join(EXT, 'panel.js'), 'utf8');
+const PTPanel = require(path.join(EXT, 'panel-data.js'));
+
+/**
+ * Evaluate panel.js's render helpers in the scope panel.js gives them.
+ *
+ * Only the module's own declarations plus the `window` globals are in
+ * scope — deliberately no `fmtSol`, no ambient `P`. Anything the helpers
+ * reach for that the real page would not have is a ReferenceError here,
+ * which is the whole point of the harness.
+ */
+function loadHelpers() {
+  const names = ['fmtAgo', 'fmtHeld', 'esc', 'chipHtml', 'activeHtml', 'afterHtml'];
+  const consts = [];
+  // Hoist the module-level const declarations the helpers close over.
+  for (const decl of ['P', 'MARK_REST', 'MARK_AFTER']) {
+    const re = new RegExp('^const ' + decl + ' =[\\s\\S]*?;$', 'm');
+    const m = panelJs.match(re);
+    if (m) consts.push(m[0]);
+  }
+  const bodies = names.map((n) => {
+    const start = panelJs.indexOf('function ' + n + '(');
+    if (start < 0) {
+      const arrow = panelJs.match(new RegExp('^const ' + n + ' =[\\s\\S]*?\\);$', 'm'));
+      if (arrow) return arrow[0];
+      throw new Error('helper not found in panel.js: ' + n);
+    }
+    let depth = 0;
+    let i = panelJs.indexOf('{', start);
+    for (; i < panelJs.length; i++) {
+      if (panelJs[i] === '{') depth++;
+      else if (panelJs[i] === '}') { depth--; if (depth === 0) break; }
+    }
+    return panelJs.slice(start, i + 1);
+  });
+  const src = `'use strict';\n${consts.join('\n')}\n${bodies.join('\n')}\nreturn { ${names.join(', ')} };`;
+  return new Function('window', src)({ PTPanel, PTGamify: { STREAK_TIERS: [] } });
+}
+
+test('the active-round card renders with an open position (regression: fmtSol undefined)', () => {
+  const H = loadHelpers();
+  const html = H.activeHtml({
+    symbol: 'WIF', costSol: 1.25, heldMs: 5400000, thesisMissing: false,
+  });
+  assert.match(html, /WIF/);
+  assert.match(html, /\+1\.25 SOL/, 'open cost must render through the shared SOL formatter');
+  assert.doesNotMatch(html, /undefined|NaN/, 'a formatter out of scope leaks as undefined/NaN');
+});
+
+test('the After feed renders rows (regression: bare P.fmtSol threw)', () => {
+  const H = loadHelpers();
+  const html = H.afterHtml([
+    { symbol: 'BONK', closedAt: Date.now() - 3600000, pnlSol: 0.42, maxPct: 63 },
+    { symbol: 'MEW', closedAt: Date.now() - 7200000, pnlSol: -0.19, maxPct: 4 },
+  ]);
+  assert.match(html, /BONK/);
+  assert.match(html, /\+0\.42 SOL/);
+  assert.match(html, /-0\.19 SOL/);
+  assert.match(html, /ran \+63% after you left/, 'a >=20% runner is called out');
+  assert.match(html, /didn't run \(\+4% max\)/);
+  assert.doesNotMatch(html, /undefined|NaN/);
+});
+
+test('held time reads as a duration, never as a SOL amount', () => {
+  const H = loadHelpers();
+  assert.equal(H.fmtHeld(5400000), '1h 30m');
+  assert.equal(H.fmtHeld(180000), '3m');
+  assert.equal(H.fmtHeld(1000), 'just opened');
+  assert.equal(H.fmtHeld(2 * 86400000 + 3 * 3600000), '2d 3h');
+  // The shipped bug: a duration pushed through the SOL formatter.
+  const wrong = PTPanel.fmtSol(5400000).replace(' SOL', '');
+  assert.notEqual(H.fmtHeld(5400000), wrong);
+  assert.doesNotMatch(H.activeHtml({ symbol: 'X', costSol: 1, heldMs: 5400000 }), /5400000/);
+});
+
+test('both empty states are rendered states, not bare text', () => {
+  const H = loadHelpers();
+  const active = H.activeHtml(null);
+  const after = H.afterHtml([]);
+  for (const html of [active, after]) {
+    assert.match(html, /class="empty"/, 'empty states carry the designed container');
+    assert.match(html, /<svg/, 'and a mark, so the panel does not read as failed to load');
+  }
+  assert.match(active, /No open position/);
+  assert.match(after, /Nothing yet/);
+});
+
+test('a zero streak is not dressed as an achievement', () => {
+  const H = loadHelpers();
+  const zero = H.chipHtml('journal', { current: 0, best: 0 }, null);
+  const live = H.chipHtml('journal', { current: 4, best: 9 }, 'Sharp');
+  assert.doesNotMatch(zero, /class="streak on"/, 'an untraded desk must not glow');
+  assert.match(live, /class="streak on"/);
+  assert.match(live, /best 9/);
+  assert.match(live, /Sharp/);
+});
+
+test('untrusted state cannot inject markup through the desk', () => {
+  const H = loadHelpers();
+  const html = H.activeHtml({ symbol: '<img src=x onerror=alert(1)>', costSol: 1, heldMs: 60000 });
+  assert.doesNotMatch(html, /<img/, 'a token symbol is data, not markup');
+  assert.match(html, /&lt;img/);
+  const feed = H.afterHtml([
+    { symbol: '<script>alert(1)</script>', closedAt: Date.now(), pnlSol: 0, maxPct: 0 },
+  ]);
+  assert.doesNotMatch(feed, /<script>alert/);
+});
+
+test('panel.js resolves the pure module once, rather than assuming a global', () => {
+  assert.match(panelJs, /const P = window\.PTPanel;/,
+    'the formatter must be bound from the module that exports it');
+  // Comments describe the bug and name the old call, so this reads CODE only.
+  const code = panelJs
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/^\s*\/\/.*$/gm, '');
+  assert.doesNotMatch(code, /[^.\w]fmtSol\(/,
+    'no bare fmtSol — panel-data.js exports it on PTPanel, not as a global');
+});


### PR DESCRIPTION
The new side-panel desk looks sparse — but the bigger problem is that the empty state in the bug report is the **only** state it can render.

## Two ReferenceErrors

`panel.js` reaches for two identifiers that do not exist:

```js
// activeHtml
const meta = `open ${fmtSol(a.costSol)} ...`   // ReferenceError: fmtSol is not defined
// afterHtml
`<span class="${pnlCls}">${P.fmtSol(r.pnlSol)}</span>`  // ReferenceError: P is not defined
```

Neither `fmtSol` nor `P` is declared anywhere in `panel.js` — `panel-data.js` exports the formatter onto `window.PTPanel`. Both throw out of `render()`, so **the first open position, or the first closed round carrying an after-watch, kills the whole render** and leaves whatever was on screen before.

Proven against `upstream/main` by executing the helpers in the scope `panel.js` actually gives them:

| Input | Result on `main` |
|---|---|
| `activeHtml({symbol:'WIF', costSol:1.25, …})` | `ReferenceError: fmtSol is not defined` |
| `afterHtml([{symbol:'BONK', pnlSol:0.42, …}])` | `ReferenceError: P is not defined` |
| both empty states | renders — *the screenshot* |

## A third bug hiding behind them

Held time ran through the **SOL** formatter with the unit stripped off:

```js
`held ${fmtSol(a.heldMs).replace(' SOL', '')}`
```

A position held 90 minutes would have reported `+5400000.00` — a raw millisecond count with two decimal places. Now `1h 30m`.

## Why the suite missed it

`sidepanel.test.js` reads `panel.js` as **text** and pins wiring; `paneldata.test.js` exercises the pure module. Nothing ever ran a render helper. New `panelrender.test.js` does, over a populated desk — **all 7 cases fail against the code this replaces**, including XSS coverage (a token symbol reaches `innerHTML`; symbols are escaped now).

## The visual pass

- **Off-palette.** The desk had its own colours and `system-ui` type — `#0b0e14` against the popup's `#0A0D13`, and a footer link in a blue that appears nowhere else. Now uses the popup's tokens verbatim; two surfaces one click apart disagreeing on the background reads as an unfinished build.
- **Streak chips** read `0 journal (best 0)` — a sentence with the number buried in it, three times. A streak is a figure, so it is set as one. Colour is earned: a zero no longer glows like an achievement.
- **Empty states** were italic grey lines that read as a failure to load. They are designed states now.
- **The void.** A docked panel is always taller than its content early on. The column fills the viewport, the After feed absorbs the slack, and the footer is pinned. (Pinning the footer alone just moved the void to the middle — checked.)

## Verification

Extension **2155/2155**, server **289/289**, all site guards pass. Rendered both states at panel width in a browser.

> The one preflight failure is the pre-existing `docs/ONBOARDING-BOT.md` template drift in the bot suite — this branch touches only `extension/panel.{html,js}` and one new test file, so `bot/` and `docs/` are untouched.