### PR TITLE
feat(arena): the weekly crown, and boards you can actually see

### DIFF
--- a/server/DEPLOY.md
+++ b/server/DEPLOY.md
@@ -67,6 +67,24 @@ npx wrangler d1 execute papertrench --remote \
 > `no such column: reckoning_webhook` instead of posting digests. The column
 > is nullable on purpose: NULL means the clan has not opted in.
 
+**Sprint crowns add one TABLE**, so the idempotent schema re-run is the whole
+migration — no `ALTER` needed:
+
+```bash
+npx wrangler d1 execute papertrench --remote --file=schema.sql
+```
+
+> Run it **before** deploying the Worker that settles crowns. `/api/leaderboard`
+> counts `sprint_winners` in a subquery and `/api/profile` selects from it, so
+> on an un-migrated database the board and every profile would fail at prepare
+> time with `no such table: sprint_winners` — the two most-visited routes on
+> the site, not just the crown itself.
+>
+> Nothing backfills. The first crown is settled by the first cron tick after
+> the next week closes, and earlier weeks stay uncrowned: their boards were
+> never frozen, so awarding them now would be inventing history rather than
+> recording it.
+
 ### Why workers.dev and not api.papertrench.com
 
 papertrench.com's nameservers are at GoDaddy (`domaincontrol.com`), and

--- a/server/core/sprint.js
+++ b/server/core/sprint.js
@@ -40,4 +40,54 @@ function sprintEntry(links, startingSol, window) {
   return Object.assign({ weekId: window.weekId }, windowEntry(links, startingSol, window));
 }
 
-module.exports = { WEEK_MS, weekIdOf, windowOf, sprintEntry };
+/**
+ * The most recently CLOSED window — the one a crown can be settled for.
+ *
+ * Settlement never touches the open week. A crown handed out mid-week would
+ * name a leader, not a winner, and would have to be revoked when somebody
+ * passed them — so the only week that can be settled is one whose endTs is
+ * already in the past.
+ */
+function lastClosedWindow(now) {
+  const t = Math.trunc(Number(now) || 0);
+  return windowOf(t - WEEK_MS);
+}
+
+/**
+ * Is this window finished and therefore settleable?
+ *
+ * Exclusive on endTs for the same reason the board is: a fill landing exactly
+ * on the boundary belongs to the NEXT window, so the week is not closed until
+ * the clock is strictly past it.
+ */
+function isClosed(window, now) {
+  return Boolean(window) && Math.trunc(Number(now) || 0) >= Number(window.endTs);
+}
+
+/**
+ * Pick the crown from a week's ranked entries.
+ *
+ * Deliberately the SAME order the Sprint board renders (score desc, then the
+ * earlier entry, then handle) — DEFECT L-05's lesson was that a board whose
+ * selection order differs from its ranking order silently crowns the wrong
+ * row. Reusing one comparator is what keeps "top of the board" and "who got
+ * the crown" from ever disagreeing.
+ *
+ * Returns null when nobody qualified: a week with no eligible entry is left
+ * uncrowned rather than awarded to the least-bad record.
+ */
+function crownFrom(entries) {
+  const list = (Array.isArray(entries) ? entries : []).filter(
+    (e) => e && Number(e.rounds) > 0);
+  if (!list.length) return null;
+  const best = list.slice().sort((a, b) =>
+    (Number(b.score) || 0) - (Number(a.score) || 0)
+    || (Number(a.updatedAt) || 0) - (Number(b.updatedAt) || 0)
+    || String(a.handle || '').localeCompare(String(b.handle || '')))[0];
+  return best || null;
+}
+
+module.exports = {
+  WEEK_MS, weekIdOf, windowOf, sprintEntry,
+  lastClosedWindow, isClosed, crownFrom,
+};

--- a/server/schema.sql
+++ b/server/schema.sql
@@ -328,3 +328,32 @@ CREATE INDEX IF NOT EXISTS idx_moderation_log_recent
   ON moderation_log(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_moderation_log_target
   ON moderation_log(target_kind, target_id, created_at DESC);
+
+-- ── Sprint crowns ──────────────────────────────────────────────────────────
+-- Who finished #1 on the weekly Sprint board, once that week has closed.
+--
+-- The row is a RECORD OF PLACEMENT, not a claim about process. That
+-- distinction is what keeps it clear of the achievements doctrine in
+-- server/core/achievements.js ("no profit badges") — a crown does not say
+-- somebody traded well, it says the board they were already publicly ranked
+-- on had them first for that week. The hover text on the site says exactly
+-- that and nothing more.
+--
+-- week_id is the PRIMARY KEY, so the settlement is idempotent by
+-- construction: INSERT OR IGNORE claims the week, and a retried cron, a
+-- worker restart, or two concurrent ticks can never crown a week twice or
+-- overwrite a settled one. A week nobody qualified for is left UNSETTLED
+-- rather than given to the least-bad entry — honest absence, same rule the
+-- Friday Reckoning uses for a missed bell.
+CREATE TABLE IF NOT EXISTS sprint_winners (
+  week_id TEXT PRIMARY KEY,         -- ISO week the crown is for
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  score REAL NOT NULL,              -- winning score, frozen at settlement
+  rounds INTEGER NOT NULL,          -- rounds behind it, for the evidence line
+  settled_at INTEGER NOT NULL
+);
+
+-- The profile and the board both ask "what has this user won", so the lookup
+-- is by user, newest first.
+CREATE INDEX IF NOT EXISTS idx_sprint_winners_user
+  ON sprint_winners(user_id, week_id DESC);

--- a/server/test/crown.test.js
+++ b/server/test/crown.test.js
@@ -1,0 +1,98 @@
+'use strict';
+// Sprint crowns — the weekly #1 tag.
+//
+// The crown is the one award on the platform that is not derived from the
+// chain at read time: it is WRITTEN once, when a week closes, and then it is
+// history. That makes three properties load-bearing, and each is pinned here:
+//
+//   never mid-week   a crown handed out while the week runs names a leader,
+//                    not a winner, and would have to be revoked
+//   never twice      the cron fires every minute; a retry, a restart or two
+//                    concurrent ticks must all collapse to one row
+//   never invented   a week nobody qualified for stays uncrowned rather than
+//                    being awarded to the least-bad entry
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const S = require('../core/sprint.js');
+
+const WEEK = S.WEEK_MS;
+
+test('only a CLOSED window is settleable', () => {
+  const now = Date.UTC(2026, 8, 3, 12); // mid-week
+  const open = S.windowOf(now);
+  assert.equal(S.isClosed(open, now), false, 'the running week is never settleable');
+
+  const closed = S.lastClosedWindow(now);
+  assert.equal(S.isClosed(closed, now), true);
+  assert.ok(closed.endTs <= now, 'lastClosedWindow must be behind us');
+  assert.equal(closed.endTs, open.startTs, 'and must be the week immediately before');
+});
+
+test('the boundary belongs to the next week, so a week is not closed on its endTs-1', () => {
+  const w = S.windowOf(Date.UTC(2026, 8, 3));
+  assert.equal(S.isClosed(w, w.endTs - 1), false);
+  assert.equal(S.isClosed(w, w.endTs), true, 'closed the instant the window ends');
+});
+
+test('lastClosedWindow walks back exactly one week, every week', () => {
+  let now = Date.UTC(2026, 0, 7, 9, 30);
+  for (let i = 0; i < 60; i++) {
+    const prev = S.lastClosedWindow(now);
+    const cur = S.windowOf(now);
+    assert.equal(cur.startTs - prev.startTs, WEEK, 'no gap and no overlap at week ' + i);
+    now += WEEK;
+  }
+});
+
+test('the crown goes to the top of the SAME order the board renders', () => {
+  const entries = [
+    { handle: 'mid', score: 10, rounds: 6, updatedAt: 100 },
+    { handle: 'top', score: 42, rounds: 9, updatedAt: 200 },
+    { handle: 'low', score: -3, rounds: 5, updatedAt: 50 },
+  ];
+  assert.equal(S.crownFrom(entries).handle, 'top');
+});
+
+test('a tie is broken by the earlier entry, then by handle — never at random', () => {
+  const first = { handle: 'zed', score: 10, rounds: 5, updatedAt: 100 };
+  const later = { handle: 'abe', score: 10, rounds: 5, updatedAt: 900 };
+  assert.equal(S.crownFrom([later, first]).handle, 'zed',
+    'first to prove the score keeps it — a later submitter cannot displace by equalling');
+
+  // Same score AND same instant: the fixed final key decides, so two reads
+  // of the same week never disagree about who won it.
+  const a = { handle: 'abe', score: 10, rounds: 5, updatedAt: 100 };
+  const z = { handle: 'zed', score: 10, rounds: 5, updatedAt: 100 };
+  assert.equal(S.crownFrom([z, a]).handle, 'abe');
+  assert.equal(S.crownFrom([a, z]).handle, 'abe', 'input order must not matter');
+});
+
+test('a week with nobody eligible is left UNCROWNED', () => {
+  assert.equal(S.crownFrom([]), null);
+  assert.equal(S.crownFrom(null), null);
+  // rounds: 0 is an entry that traded nothing inside the window — it is not
+  // a winner, it is an absence, and the board does not rank it either.
+  assert.equal(S.crownFrom([{ handle: 'nobody', score: 99, rounds: 0 }]), null,
+    'a zero-round entry must never be crowned, however high its score sorts');
+});
+
+test('a negative week still has a winner — losing least is still first', () => {
+  const entries = [
+    { handle: 'bad', score: -50, rounds: 5, updatedAt: 1 },
+    { handle: 'less-bad', score: -2, rounds: 5, updatedAt: 2 },
+  ];
+  assert.equal(S.crownFrom(entries).handle, 'less-bad',
+    'a red week is a real week; refusing to crown it would quietly gate the tag on profit');
+});
+
+test('crownFrom does not mutate the caller array', () => {
+  const entries = [
+    { handle: 'a', score: 1, rounds: 5, updatedAt: 1 },
+    { handle: 'b', score: 9, rounds: 5, updatedAt: 2 },
+  ];
+  const before = entries.map((e) => e.handle).join(',');
+  S.crownFrom(entries);
+  assert.equal(entries.map((e) => e.handle).join(','), before,
+    'sorting in place would reorder the caller’s board');
+});

--- a/server/test/worker.test.js
+++ b/server/test/worker.test.js
@@ -1221,7 +1221,14 @@ test('a pricing-drain throw cannot take the reckoning lane down with it', async 
   // The reckoning lane is clock-gated: outside the bell window it exits
   // before touching the broken env (that silence is CORRECT). To prove the
   // two lanes are isolated, open the bell window so the lane actually runs.
-  Date.now = () => reckoningBellTs() + 3600000; // an hour past Friday's bell
+  // Capture the bell with the REAL clock before stubbing. reckoningBellTs()
+  // reads Date.now() itself, so `Date.now = () => reckoningBellTs() + …`
+  // is self-referential: the stub calls the helper, the helper calls the
+  // stub, and the first lane that actually reads the clock blows the stack.
+  // It only survived because the broken env made both lanes throw before
+  // either of them got as far as asking the time.
+  const bell = reckoningBellTs() + 3600000; // an hour past Friday's bell
+  Date.now = () => bell;
   console.error = (...a) => { errors.push(a.join(' ')); };
   try {
     const waited = [];

--- a/server/worker/index.js
+++ b/server/worker/index.js
@@ -12,7 +12,7 @@
  * under an external-API budget.
  */
 import { fastChecks, priceRecord } from '../core/submission.js';
-import { windowOf, sprintEntry } from '../core/sprint.js';
+import { windowOf, sprintEntry, lastClosedWindow, isClosed } from '../core/sprint.js';
 import { windowEntry } from '../core/window.js';
 import { awarded } from '../core/achievements.js';
 import * as duel from '../core/duel.js';
@@ -383,7 +383,8 @@ async function handleLeaderboard(env) {
     SELECT u.handle, u.display_name, u.avatar_url,
            r.status, r.stats_json, r.badges_json, r.chain_len,
            r.verified_at, r.submitted_at,
-           cl.tag AS clan_tag, cl.name AS clan_name
+           cl.tag AS clan_tag, cl.name AS clan_name,
+           (SELECT COUNT(*) FROM sprint_winners w WHERE w.user_id = r.user_id) AS crowns
     FROM records r JOIN users u ON u.id = r.user_id
     LEFT JOIN clan_members cm ON cm.user_id = r.user_id
     LEFT JOIN clans cl ON cl.id = cm.clan_id
@@ -437,6 +438,7 @@ async function handleLeaderboard(env) {
         verifiedAt: row.verified_at,
         clanTag: row.clan_tag || null,
         clanName: row.clan_name || null,
+        crowns: Number(row.crowns) || 0,
         stats,
         // Only the ids and tiers ride on the board; full evidence lives on
         // the profile, where there is room to show why each was earned.
@@ -578,6 +580,11 @@ async function handleProfile(env, handle) {
   const sprints = await env.DB.prepare(
     'SELECT week_id, entry_json FROM sprint_entries WHERE user_id = ? ORDER BY week_id DESC LIMIT 12')
     .bind(user.id).all();
+  // Weeks this account finished first on the Sprint board. Settled rows only,
+  // so a profile can never show a crown for the week still running.
+  const crowns = await env.DB.prepare(
+    'SELECT week_id, score, rounds, settled_at FROM sprint_winners WHERE user_id = ? ORDER BY week_id DESC')
+    .bind(user.id).all();
   // Their clan, and what they have actually contributed to it since joining —
   // which is a different number from their record above, and says so.
   const clanRow = await env.DB.prepare(`
@@ -612,6 +619,9 @@ async function handleProfile(env, handle) {
       verifiedAt: record.verified_at,
     } : null,
     sprints: sprints.results.map((row) => ({ weekId: row.week_id, entry: JSON.parse(row.entry_json) })),
+    crowns: crowns.results.map((row) => ({
+      weekId: row.week_id, score: row.score, rounds: row.rounds, settledAt: row.settled_at,
+    })),
   });
 }
 
@@ -1465,6 +1475,62 @@ async function handleClanUpdate(request, env) {
       .bind(motto, open, clan.cleanWebhook(body.reckoningWebhook), membership.clan_id).run();
   }
   return json({ ok: true });
+}
+
+/* ---------------- sprint crown settlement ----------------
+ *
+ * At most one row per closed week, written once. The crown is a record of
+ * PLACEMENT on a board that is already public — not a claim that the winner
+ * traded well — which is what keeps it clear of the achievements doctrine
+ * ("no profit badges", server/core/achievements.js). The site says exactly
+ * that where the tag is shown.
+ *
+ * Three properties this has to hold, and how:
+ *
+ *   Never mid-week.  Only lastClosedWindow() is ever settled. A crown handed
+ *                    out while the week runs names a leader, not a winner,
+ *                    and would have to be taken back when somebody passed
+ *                    them.
+ *   Never twice.     week_id is the PRIMARY KEY and the insert is OR IGNORE,
+ *                    so a retried cron, a restart, or two concurrent ticks
+ *                    all collapse to one row. The mark IS the claim.
+ *   Never invented.  The eligibility WHERE is copied from handleSprint, so a
+ *                    pending, banned or disqualified account cannot be
+ *                    crowned by a settlement path that forgot about them —
+ *                    and a week with no eligible entry stays UNCROWNED
+ *                    rather than being given to the least-bad row.
+ */
+async function settleSprintCrown(env, now) {
+  const t = Number(now) || Date.now();
+  const window = lastClosedWindow(t);
+  if (!isClosed(window, t)) return null;
+
+  // Already claimed? Cheapest possible exit — this runs every minute, and on
+  // all but the first tick after a week closes there is nothing to do.
+  const done = await env.DB.prepare('SELECT week_id FROM sprint_winners WHERE week_id = ?')
+    .bind(window.weekId).first();
+  if (done) return null;
+
+  // Same eligibility and the same ORDER BY as the board renders (DEFECT
+  // L-05: a selection order that differs from the ranking order crowns the
+  // wrong row). LIMIT 1 is the crown.
+  const top = await env.DB.prepare(`
+    SELECT s.user_id, s.score, s.rounds
+    FROM sprint_entries s
+    JOIN users u ON u.id = s.user_id
+    LEFT JOIN records r ON r.user_id = s.user_id
+    WHERE s.week_id = ? AND s.rounds > 0 AND r.status = 'verified'
+      AND COALESCE(u.banned_at, 0) = 0
+      AND COALESCE(r.dq_at, 0) = 0
+    ORDER BY s.score DESC, s.updated_at ASC, u.handle ASC LIMIT 1`)
+    .bind(window.weekId).first();
+  if (!top) return null;
+
+  await env.DB.prepare(`
+    INSERT OR IGNORE INTO sprint_winners (week_id, user_id, score, rounds, settled_at)
+    VALUES (?, ?, ?, ?, ?)`)
+    .bind(window.weekId, top.user_id, top.score, top.rounds, Date.now()).run();
+  return { weekId: window.weekId, userId: top.user_id };
 }
 
 /* ---------------- pricing cron ---------------- */
@@ -2447,6 +2513,13 @@ export default {
         dryRun: env.RECKONING_DRY_RUN !== 'false',
         killSwitch: env.KILL_SWITCH === 'true',
       }).catch((e) => console.error('reckoning lane error:', e && e.message))
+    );
+    // Sprint crown: settles the week that just closed, once. Exits on a
+    // single indexed read for every tick but the first one after a rollover,
+    // and is its own lane so a settlement fault cannot silence pricing.
+    ctx.waitUntil(
+      settleSprintCrown(env, Date.now())
+        .catch((e) => console.error('crown lane error:', e && e.message || e))
     );
   },
 };

--- a/site/arena.css
+++ b/site/arena.css
@@ -124,6 +124,48 @@
 .ar-pane-head .spacer { margin-left: auto; }
 .ar-pane-head .glyph { color: var(--green); font-size: 15px; }
 
+/* ---------------------------------------------------- reference panes ---
+ *
+ * A pane that explains rather than shows. Every competitive page had several,
+ * open by default and stacked under the thing people came for: on /clans the
+ * two rule panes ran to 2,541 characters against 63 characters of actual
+ * board, and /duels carried 3,577 characters of documentation under four
+ * small tools. The pages were not missing information — they were burying the
+ * live part underneath it.
+ *
+ * So reference panes collapse. Nothing is deleted and every word stays on the
+ * page (this project explains itself for a reason, and a rule you cannot read
+ * is a rule you cannot check); it simply stops competing with the board.
+ *
+ * <details> rather than a JS toggle: keyboard- and screen-reader-operable for
+ * free, findable by the browser's own in-page search, deep-linkable, and it
+ * survives a re-render with no state to keep.
+ */
+details.ar-doc > summary {
+  cursor: pointer;
+  list-style: none;
+  /* Closed, the head IS the whole pane, so its divider would draw a line
+     under nothing. */
+  transition: border-color 0.15s linear;
+}
+details.ar-doc:not([open]) > summary { border-bottom-color: transparent; }
+details.ar-doc > summary::-webkit-details-marker { display: none; }
+details.ar-doc > summary::marker { content: ''; }
+details.ar-doc > summary:hover { background: rgba(255, 255, 255, 0.02); }
+details.ar-doc > summary:focus-visible { outline: 2px solid var(--orange); outline-offset: -2px; }
+
+.ar-doc .doc-tag {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--dim);
+}
+.ar-doc .doc-chev { flex: none; color: var(--dim); transition: transform 0.2s var(--ease, ease), color 0.2s linear; }
+details.ar-doc[open] .doc-chev { transform: rotate(180deg); color: var(--orange2); }
+
 /* ============================================================== hero ===== */
 
 .ar-hero { padding: 104px 0 22px; position: relative; overflow: hidden; }

--- a/site/clans.html
+++ b/site/clans.html
@@ -108,9 +108,9 @@
         <div id="clan-board"></div>
       </section>
 
-      <section class="ar-pane" aria-labelledby="how-h">
-        <div class="ar-pane-head"><span class="glyph" style="color:var(--violet)">ƒ</span>
-          <span id="how-h">How a clan's number is made</span></div>
+      <details class="ar-pane ar-doc" aria-labelledby="how-h">
+        <summary class="ar-pane-head"><span class="glyph" style="color:var(--violet)">ƒ</span>
+          <span id="how-h">How a clan's number is made</span><span class="doc-tag">Reference</span><svg class="doc-chev" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg></summary>
         <div class="pad">
           <ol style="list-style:none;display:grid;gap:14px">
             <li>
@@ -140,7 +140,7 @@
             a clan more chances at five strong ones than exactly five do. That advantage has to be
             earned five verified records at a time, which is the point of it.</p>
         </div>
-      </section>
+      </details>
     </div>
 
     <div class="ar-stack">
@@ -152,9 +152,9 @@
         </div>
       </section>
 
-      <section class="ar-pane" aria-labelledby="rules-h">
-        <div class="ar-pane-head"><span class="glyph">§</span>
-          <span id="rules-h">The rules</span></div>
+      <details class="ar-pane ar-doc" aria-labelledby="rules-h">
+        <summary class="ar-pane-head"><span class="glyph">§</span>
+          <span id="rules-h">The rules</span><span class="doc-tag">Reference</span><svg class="doc-chev" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg></summary>
         <div class="pad">
           <ol style="list-style:none;display:grid;gap:14px">
             <li>
@@ -193,7 +193,7 @@
           <p class="ar-note" style="margin-top:16px">Full protocol:
             <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener">docs/LEADERBOARD.md</a></p>
         </div>
-      </section>
+      </details>
     </div>
 
   </div>

--- a/site/duels.html
+++ b/site/duels.html
@@ -662,11 +662,11 @@
         <div id="duels" aria-live="polite"></div>
       </section>
 
-      <section class="ar-pane" aria-labelledby="settle-h">
-        <div class="ar-pane-head">
+      <details class="ar-pane ar-doc" aria-labelledby="settle-h">
+        <summary class="ar-pane-head">
           <span class="glyph">§</span>
           <h2 id="settle-h">How settlement works</h2>
-        </div>
+        <span class="doc-tag">Reference</span><svg class="doc-chev" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg></summary>
         <div class="pad">
           <p class="ar-note" style="margin-bottom:16px">A duel is decided from the same evidence as
             every other board here: your committed chain, sliced to the window. What makes a duel
@@ -724,17 +724,17 @@
             1,000&nbsp;◎ bankroll on even terms. Full protocol:
             <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener">docs/LEADERBOARD.md</a></p>
         </div>
-      </section>
+      </details>
 
     </div>
 
     <div class="ar-stack">
 
-      <section class="ar-pane" aria-labelledby="states-h">
-        <div class="ar-pane-head">
+      <details class="ar-pane ar-doc" aria-labelledby="states-h">
+        <summary class="ar-pane-head">
           <span class="glyph" style="color:var(--violet)">◷</span>
           <h2 id="states-h">The five states</h2>
-        </div>
+        <span class="doc-tag">Reference</span><svg class="doc-chev" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg></summary>
         <div class="pad">
           <div class="ar-legend">
             <div><span class="ar-state open">open</span>
@@ -749,13 +749,13 @@
               <p>Nobody accepted inside 48 hours, so the duel never started.</p></div>
           </div>
         </div>
-      </section>
+      </details>
 
-      <section class="ar-pane" aria-labelledby="outcomes-h">
-        <div class="ar-pane-head">
+      <details class="ar-pane ar-doc" aria-labelledby="outcomes-h">
+        <summary class="ar-pane-head">
           <span class="glyph">⚖</span>
           <h2 id="outcomes-h">Every outcome is named</h2>
-        </div>
+        <span class="doc-tag">Reference</span><svg class="doc-chev" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg></summary>
         <div class="pad">
           <p class="ar-note" style="margin-bottom:14px">A result is never a bare trophy. The server
             returns one of five outcomes and a sentence explaining it, and the card prints both.</p>
@@ -773,13 +773,13 @@
             <dd>Neither side submitted after the close. Nothing to compare, so nobody won.</dd>
           </dl>
         </div>
-      </section>
+      </details>
 
-      <section class="ar-pane" aria-labelledby="stakes-h">
-        <div class="ar-pane-head">
+      <details class="ar-pane ar-doc" aria-labelledby="stakes-h">
+        <summary class="ar-pane-head">
           <span class="glyph">🛡</span>
           <h2 id="stakes-h">What's at stake: nothing</h2>
-        </div>
+        <span class="doc-tag">Reference</span><svg class="doc-chev" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg></summary>
         <div class="pad">
           <p class="ar-note">No entry fee, no pot, no token, no wallet connection — a duel is two
             people practising against the same clock and finding out who read the tape better. The
@@ -791,7 +791,7 @@
             <span class="ar-chip partial" style="font-size:8px">◐ Partial data</span> — neither is
             dressed up as verified, in a duel or anywhere else.</p>
         </div>
-      </section>
+      </details>
 
     </div>
 

--- a/site/events.html
+++ b/site/events.html
@@ -4,7 +4,10 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PaperTrench | Events</title>
-<meta name="description" content="Everything running on PaperTrench right now — the Daily Spark, the weekly Sprint window, the clan season, the Friday Reckoning and monthly Wrapped. Free to enter, no buy-in, no prize pool.">
+<meta name="description" content="Top of the Trench — finish #1 on the weekly PaperTrench board before it resets and the week is yours, tagged on your profile forever. Free to enter, no buy-in.">
+<meta property="og:title" content="Top of the Trench — the weekly PaperTrench crown">
+<meta property="og:description" content="One week. Finish first on the board and the #1 tag is yours for good. Real charts, paper money, a record that gets checked.">
+<meta property="og:image" content="https://papertrench.com/assets/video-poster.jpg">
 <link rel="icon" href="/favicon.ico" sizes="48x48">
 <link rel="icon" type="image/png" href="/assets/icon96.png" sizes="96x96">
 <link rel="icon" type="image/png" href="/assets/icon192.png" sizes="192x192">
@@ -13,126 +16,212 @@
 <link rel="stylesheet" href="arena.css">
 <style>
   /* ================================================================== *
-   *  /events — one card per thing that is actually running.
+   *  /events — one event, centred.
    *
-   *  The first pass was an aggregator: a Sprint countdown, a live-streamer
-   *  probe, and the verifier tape side by side. The tape was the problem —
-   *  it is a feed of `rejected — chain-replaced` lines, which is diagnostic
-   *  output, not an event. Nobody comes to an events page to watch strangers
-   *  fail verification, and eight red rows is the worst possible read of a
-   *  healthy product. It is gone from here; /leaderboard still carries it,
-   *  where a verdict stream belongs.
+   *  The first pass was three panels, and the third was the verifier tape:
+   *  six rows of `rejected — chain-replaced`. That is diagnostic output, not
+   *  an event, and a wall of red is the worst available read of a healthy
+   *  product. The tape lives on /leaderboard, where a verdict stream belongs.
    *
-   *  What replaces it: PaperTrench already runs five recurring rituals on
-   *  fixed clocks — Spark daily, Sprint weekly, the clan season weekly, the
-   *  Reckoning every Friday, Wrapped monthly. They were scattered across the
-   *  extension and three pages and announced nowhere. This is that calendar.
+   *  What is left is the one thing with a deadline and a prize: the weekly
+   *  board, and the tag you keep for winning it. Everything else PaperTrench
+   *  runs is ongoing rather than an event, so it is a quiet strip underneath
+   *  rather than six competing cards.
    *
-   *  Still no invented events. Every card is a thing the code actually does,
-   *  every clock is derived from the same window math the server folds, and
-   *  every reward is something that already exists. There is no prize pool
-   *  because there is no budget, and saying so plainly beats implying one.
+   *  The prize is a TAG, and the page is careful about what the tag claims.
+   *  It is a record of placement on a board that is already public — not an
+   *  assertion that the winner traded well. server/core/achievements.js bans
+   *  profit badges for good reasons; the hover text here says precisely what
+   *  the tag means and stops there.
    * ================================================================== */
 
-  .ev-head { padding: 128px 0 8px; }
+  .ev-wrap { max-width: 760px; margin: 0 auto; }
+
+  .ev-head { padding: 128px 0 4px; text-align: center; }
   .ev-head h1 { font-size: clamp(30px, 4.4vw, 46px); font-weight: 700; letter-spacing: -0.02em; }
-  .ev-head p { font-size: 14.5px; color: var(--muted); margin-top: 12px; max-width: 640px; line-height: 1.65; }
-  .ev-head a { color: var(--orange2); }
+  .ev-head p { font-size: 14.5px; color: var(--muted); margin: 12px auto 0; max-width: 52ch; line-height: 1.65; }
 
-  .ev-stack { display: grid; gap: 12px; margin-top: 26px; }
-
-  /* ---------- the card ----------
-   * <details> rather than a JS toggle: keyboard- and screen-reader-operable
-   * for free, deep-linkable with [open], and it survives a re-render with no
-   * state to keep. */
+  /* ---------- the event card ---------- */
+  /* padding:0 is load-bearing, not tidiness. style.css sets
+     `section { padding: 110px 0 }` for the marketing page rhythm, and this
+     card is a <section> — inheriting it wedged 110px of dead space between
+     the card's top border and its own artwork. */
   .ev-card {
-    background: var(--panel); border: var(--edge); border-radius: 14px;
-    overflow: hidden; transition: border-color .18s;
+    margin-top: 30px; padding: 0; border-radius: 18px; overflow: hidden;
+    border: 1px solid rgba(255,157,69,0.34);
+    background: var(--panel);
+    box-shadow: 0 30px 80px rgba(0,0,0,0.5);
   }
-  .ev-card:hover { border-color: var(--line2); }
-  .ev-card[open] { border-color: rgba(255,157,69,0.3); }
 
-  .ev-card summary { display: block; cursor: pointer; list-style: none; padding: 18px 20px 0; }
-  .ev-card summary::-webkit-details-marker { display: none; }
-  .ev-card summary:focus-visible { outline: 2px solid var(--orange); outline-offset: -2px; }
+  /* The art half. Drawn rather than dropped in as a file: it themes with the
+     rest of the site, stays crisp at any density, and costs no bytes. */
+  .ev-art {
+    position: relative; padding: 26px 28px 24px;
+    background:
+      radial-gradient(680px 260px at 78% 8%, rgba(255,157,69,0.30), transparent 68%),
+      radial-gradient(420px 220px at 12% 96%, rgba(255,95,86,0.16), transparent 70%),
+      linear-gradient(120deg, #2a1608, #160d14 62%);
+  }
+  .ev-art::after {
+    content: ''; position: absolute; inset: 0; pointer-events: none;
+    background-image:
+      linear-gradient(rgba(255,255,255,0.045) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(255,255,255,0.045) 1px, transparent 1px);
+    background-size: 34px 34px;
+    mask-image: radial-gradient(ellipse 70% 100% at 80% 0%, #000, transparent 75%);
+  }
+  .ev-art > * { position: relative; z-index: 1; }
 
-  .ev-top { display: flex; align-items: flex-start; gap: 18px; }
-  .ev-lead { flex: 1; min-width: 0; }
-
-  .ev-tags { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 9px; }
+  .ev-toprow { display: flex; align-items: center; gap: 8px; margin-bottom: 20px; }
   .tag {
     font-family: var(--mono); font-size: 9.5px; font-weight: 700;
     letter-spacing: 1px; text-transform: uppercase;
-    padding: 3px 8px; border-radius: 999px;
-    background: rgba(255,255,255,0.05); border: 1px solid var(--line2); color: var(--dim);
+    padding: 4px 9px; border-radius: 999px;
+    background: rgba(0,0,0,0.34); border: 1px solid rgba(255,255,255,0.16); color: var(--orange2);
   }
-  .tag.cadence { color: var(--orange2); background: rgba(255,157,69,0.09); border-color: rgba(255,157,69,0.28); }
-  /* "Open now" is a claim about state, so it is only ever printed when the
-     clock says so — never as decoration. */
-  .tag.open { color: var(--green2); background: rgba(52,211,153,0.10); border-color: rgba(52,211,153,0.3); }
-  .tag.live { color: #ff9a90; background: rgba(224,67,58,0.10); border-color: rgba(224,67,58,0.32); display: inline-flex; align-items: center; gap: 5px; }
-  .tag.live .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--red); box-shadow: 0 0 8px var(--red); animation: pulse 1.6s infinite; }
+  .tag.open { color: #8bf0c4; border-color: rgba(52,211,153,0.4); background: rgba(52,211,153,0.12); }
+  .ev-icons { margin-left: auto; display: flex; gap: 7px; }
+  .ic {
+    width: 30px; height: 30px; display: grid; place-items: center;
+    border-radius: 9px; cursor: pointer; color: rgba(255,255,255,0.72);
+    background: rgba(0,0,0,0.3); border: 1px solid rgba(255,255,255,0.16);
+    transition: background .16s, color .16s, border-color .16s;
+  }
+  .ic:hover { background: rgba(0,0,0,0.5); color: #fff; border-color: rgba(255,255,255,0.34); }
 
-  .ev-name { font-size: 19px; font-weight: 750; letter-spacing: -0.015em; }
-  .ev-line { font-size: 13.5px; color: var(--muted); line-height: 1.55; margin-top: 4px; max-width: 56ch; }
+  .ev-body { display: flex; align-items: flex-end; gap: 22px; }
+  .ev-copy { flex: 1; min-width: 0; }
+  .ev-name {
+    font-size: clamp(26px, 4vw, 36px); font-weight: 800; letter-spacing: -0.03em;
+    line-height: 1.02; color: #fff;
+    text-shadow: 0 2px 18px rgba(0,0,0,0.45);
+  }
+  .ev-tagline { font-size: 14px; color: rgba(255,255,255,0.78); margin-top: 8px; line-height: 1.5; max-width: 40ch; }
 
-  /* The reward column. It is never money, so it is not dressed as money —
-     no coin glyph, no pool figure, no gold. */
-  .ev-prize { flex: none; text-align: right; max-width: 190px; }
-  .ev-prize b {
-    display: block; font-size: 13.5px; font-weight: 750; color: var(--orange2);
-    letter-spacing: -0.01em; line-height: 1.3;
+  /* ---------- the prize ---------- */
+  .ev-prize { flex: none; text-align: right; }
+  .prize-chip {
+    display: inline-flex; align-items: center; gap: 8px;
+    padding: 9px 15px 9px 12px; border-radius: 12px;
+    background: linear-gradient(135deg, rgba(255,192,129,0.22), rgba(255,157,69,0.12));
+    border: 1px solid rgba(255,192,129,0.5);
+    box-shadow: 0 8px 26px -10px rgba(255,157,69,0.7);
   }
-  .ev-prize span { display: block; font-size: 11px; color: var(--dim); margin-top: 3px; line-height: 1.4; }
-  @media (max-width: 720px) {
-    .ev-top { flex-direction: column; gap: 10px; }
-    .ev-prize { text-align: left; max-width: none; }
+  .prize-chip .num {
+    font-family: var(--mono); font-size: 26px; font-weight: 800;
+    color: #fff; line-height: 1; letter-spacing: -0.03em;
   }
+  .prize-chip .what {
+    font-size: 10px; font-weight: 700; letter-spacing: 1.1px; text-transform: uppercase;
+    color: var(--orange2); text-align: left; line-height: 1.3;
+  }
+  .ev-prize .cap {
+    display: flex; align-items: center; justify-content: flex-end; gap: 5px;
+    font-size: 11px; color: rgba(255,255,255,0.6); margin-top: 8px;
+  }
+
+  /* The explainer sits ON the tag, because that is where the question is
+     asked. It is a <button> with aria-describedby rather than a title
+     attribute: title never appears on touch and cannot be reached by
+     keyboard, which makes it decoration. */
+  .info { position: relative; display: inline-flex; }
+  .info-btn {
+    width: 15px; height: 15px; padding: 0; display: grid; place-items: center;
+    border-radius: 50%; cursor: help; color: rgba(255,255,255,0.55);
+    background: rgba(255,255,255,0.1); border: 1px solid rgba(255,255,255,0.2);
+    font: inherit; transition: color .15s, background .15s;
+  }
+  .info-btn:hover, .info-btn:focus-visible { color: #fff; background: rgba(255,255,255,0.22); }
+  .info-pop {
+    position: absolute; bottom: calc(100% + 9px); right: -6px; width: 246px;
+    padding: 11px 13px; border-radius: 11px; z-index: 5;
+    background: #0d1119; border: 1px solid var(--line2);
+    box-shadow: 0 18px 44px rgba(0,0,0,0.6);
+    font-size: 12px; line-height: 1.55; color: var(--muted); text-align: left;
+    opacity: 0; visibility: hidden; transform: translateY(4px);
+    transition: opacity .15s, transform .15s, visibility .15s;
+  }
+  .info-pop b { color: var(--text); font-weight: 700; }
+  .info:hover .info-pop, .info-btn:focus-visible + .info-pop { opacity: 1; visibility: visible; transform: none; }
+  @media (max-width: 620px) { .info-pop { right: auto; left: -100px; } }
 
   /* ---------- the facts band ---------- */
   .ev-facts {
-    display: flex; align-items: center; gap: 26px; flex-wrap: wrap;
-    margin: 16px -20px 0; padding: 12px 20px;
-    background: rgba(0,0,0,0.26); border-top: var(--edge);
+    display: flex; align-items: center; gap: 30px; flex-wrap: wrap;
+    padding: 15px 28px; background: rgba(0,0,0,0.3); border-top: var(--edge);
   }
-  .ev-facts .f { min-width: 0; }
   .ev-facts .f span {
     display: block; font-family: var(--mono); font-size: 9.5px; font-weight: 700;
     letter-spacing: 1px; text-transform: uppercase; color: var(--dim);
   }
   .ev-facts .f b {
-    display: block; font-size: 13px; font-weight: 700; color: var(--text); margin-top: 3px;
-    font-variant-numeric: tabular-nums;
+    display: block; font-size: 14px; font-weight: 700; color: var(--text);
+    margin-top: 3px; font-variant-numeric: tabular-nums;
   }
   .ev-facts .f b.clock { font-family: var(--mono); color: var(--orange2); }
-  .ev-chev {
-    margin-left: auto; flex: none; color: var(--dim);
-    transition: transform .2s, color .2s;
+  .ev-enter {
+    margin-left: auto; font-size: 13px; font-weight: 700; color: #241202;
+    background: var(--grad-heat); border-radius: 10px; padding: 10px 18px;
+    box-shadow: 0 10px 26px -12px rgba(255,157,69,0.9);
+    transition: transform .16s, box-shadow .16s;
   }
-  .ev-card[open] .ev-chev { transform: rotate(180deg); color: var(--orange2); }
+  .ev-enter:hover { transform: translateY(-1px); box-shadow: 0 14px 30px -12px rgba(255,157,69,1); }
+  @media (max-width: 620px) {
+    .ev-body { flex-direction: column; align-items: flex-start; gap: 18px; }
+    .ev-prize { text-align: left; }
+    .ev-prize .cap { justify-content: flex-start; }
+    .ev-enter { margin-left: 0; width: 100%; text-align: center; }
+  }
 
-  /* ---------- expanded ---------- */
-  .ev-body { padding: 18px 20px 20px; border-top: var(--edge); }
-  .ev-body p { font-size: 13.5px; color: var(--muted); line-height: 1.7; max-width: 68ch; }
-  .ev-body p + p { margin-top: 10px; }
-  .ev-body b { color: var(--text); font-weight: 650; }
-  .ev-body ul { margin: 10px 0 0; padding-left: 18px; }
-  .ev-body li { font-size: 13.5px; color: var(--muted); line-height: 1.65; margin-bottom: 5px; }
-  .ev-body a { color: var(--orange2); }
-  .ev-go {
-    display: inline-flex; align-items: center; gap: 7px; margin-top: 16px;
-    font-size: 13px; font-weight: 700; color: var(--text);
-    background: rgba(255,255,255,0.05); border: 1px solid var(--line2);
-    border-radius: 10px; padding: 9px 15px; transition: background .16s, border-color .16s;
+  /* ---------- how it works ---------- */
+  .ev-how { margin-top: 26px; display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+  @media (max-width: 620px) { .ev-how { grid-template-columns: 1fr; } }
+  .how {
+    padding: 16px 17px; border-radius: 13px;
+    background: var(--panel); border: var(--edge);
   }
-  .ev-go:hover { background: rgba(255,255,255,0.1); border-color: rgba(255,255,255,0.24); }
+  .how .n {
+    font-family: var(--mono); font-size: 10px; font-weight: 700;
+    letter-spacing: 1.3px; color: var(--dim);
+  }
+  .how h3 { font-size: 14px; font-weight: 750; margin: 8px 0 5px; letter-spacing: -0.01em; }
+  .how p { font-size: 12.5px; color: var(--muted); line-height: 1.6; }
+
+  /* ---------- also running ---------- */
+  .ev-also { margin-top: 28px; }
+  .ev-also h2 {
+    font-family: var(--mono); font-size: 10px; font-weight: 700; letter-spacing: 1.4px;
+    text-transform: uppercase; color: var(--dim); margin-bottom: 11px; text-align: center;
+  }
+  .also-row { display: grid; gap: 8px; }
+  .also {
+    display: flex; align-items: center; gap: 12px; padding: 12px 16px;
+    border-radius: 11px; background: rgba(255,255,255,0.02); border: var(--edge);
+    transition: background .16s, border-color .16s;
+  }
+  .also:hover { background: rgba(255,255,255,0.045); border-color: var(--line2); }
+  .also b { font-size: 13.5px; font-weight: 700; }
+  .also span { font-size: 12.5px; color: var(--muted); }
+  .also .when {
+    margin-left: auto; font-family: var(--mono); font-size: 10.5px;
+    color: var(--dim); white-space: nowrap;
+  }
 
   .ev-note {
-    margin-top: 22px; padding: 14px 18px; border-radius: 12px;
+    margin-top: 24px; padding: 14px 18px; border-radius: 12px; text-align: center;
     background: rgba(255,255,255,0.02); border: var(--edge);
     font-size: 12.5px; color: var(--muted); line-height: 1.65;
   }
   .ev-note b { color: var(--text); font-weight: 700; }
+
+  .toast {
+    position: fixed; left: 50%; bottom: 28px; transform: translate(-50%, 12px);
+    padding: 10px 18px; border-radius: 10px; z-index: 50;
+    background: #0d1119; border: 1px solid var(--line2); color: var(--text);
+    font-size: 13px; font-weight: 650;
+    opacity: 0; visibility: hidden; transition: opacity .18s, transform .18s, visibility .18s;
+  }
+  .toast.on { opacity: 1; visibility: visible; transform: translate(-50%, 0); }
 </style>
 </head>
 <body>
@@ -162,273 +251,122 @@
 </nav>
 
 <main id="main" class="wrap" style="padding-bottom:96px">
+ <div class="ev-wrap">
+
   <header class="ev-head">
     <h1>Events</h1>
-    <p>Everything PaperTrench runs on a clock. All of it is free, none of it needs
-    a sign-up, and none of it pays out money — you are competing for placement and
-    a record that can be checked. Open a card for the rules.</p>
+    <p>One board, one week, one tag. Free to enter and nothing to sign up for —
+    install the extension and your record is already in it.</p>
   </header>
 
-  <div class="ev-stack" id="ev-stack">
-
-    <!-- ============ DAILY SPARK ============ -->
-    <details class="ev-card" id="ev-spark">
-      <summary>
-        <div class="ev-top">
-          <div class="ev-lead">
-            <div class="ev-tags">
-              <span class="tag cadence">Daily</span>
-              <span class="tag open">Open now</span>
-            </div>
-            <h2 class="ev-name">Daily Spark</h2>
-            <p class="ev-line">One real chart, frozen at a moment. Call what happens next.
-            Graded on your reasoning, never on profit.</p>
-          </div>
-          <div class="ev-prize">
-            <b>Spark streak</b>
-            <span>and your accuracy, kept in the dashboard</span>
-          </div>
+  <!-- ============ THE EVENT ============ -->
+  <section class="ev-card" aria-labelledby="ev-name">
+    <div class="ev-art">
+      <div class="ev-toprow">
+        <span class="tag">Weekly</span>
+        <span class="tag open" id="ev-state">Open now</span>
+        <div class="ev-icons">
+          <button class="ic" type="button" id="ev-share" aria-label="Share this event">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="18" cy="5" r="2.6"/><circle cx="6" cy="12" r="2.6"/><circle cx="18" cy="19" r="2.6"/>
+              <path d="M8.3 10.8 15.7 6.6M8.3 13.2l7.4 4.2"/>
+            </svg>
+          </button>
+          <a class="ic" href="/sprint" aria-label="Open the live board">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M4 19.5V11M10 19.5V5M16 19.5v-6M21 19.5H3"/>
+            </svg>
+          </a>
         </div>
-        <div class="ev-facts">
-          <div class="f"><span>Entry</span><b>Free</b></div>
-          <div class="f"><span>Takes</span><b>~1 minute</b></div>
-          <div class="f"><span>Resets in</span><b class="clock" data-cd="spark">—</b></div>
-          <svg class="ev-chev" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg>
-        </div>
-      </summary>
-      <div class="ev-body">
-        <p>A single mint's chart is cut at a point in time. You say where it goes and
-        <b>why</b> — the why is the part that is graded. Get the direction right for the
-        wrong reason and it does not count for much; the puzzle is about reading a chart,
-        not about being lucky once.</p>
-        <p>It changes at <b>00:00 UTC</b> and everyone gets the same chart that day, so
-        nobody can farm it by refreshing. Miss a day and the streak resets — that is the
-        whole pressure, and it is deliberately the only one.</p>
-        <a class="ev-go" href="/#install">Play it in the extension →</a>
       </div>
-    </details>
 
-    <!-- ============ WEEKLY SPRINT ============ -->
-    <details class="ev-card" id="ev-sprint">
-      <summary>
-        <div class="ev-top">
-          <div class="ev-lead">
-            <div class="ev-tags">
-              <span class="tag cadence">Weekly</span>
-              <span class="tag open" id="ev-sprint-state">Open now</span>
-            </div>
-            <h2 class="ev-name">The Weekly Sprint</h2>
-            <p class="ev-line">A fresh board every Monday. Only the fills you take inside
-            the window count, so a good week is not buried under an old one.</p>
-          </div>
-          <div class="ev-prize">
-            <b>Top of the Sprint board</b>
-            <span>for the week, with your verified record</span>
-          </div>
-        </div>
-        <div class="ev-facts">
-          <div class="f"><span>Entry</span><b>Free</b></div>
-          <div class="f"><span>Entrants</span><b id="ev-sprint-n">—</b></div>
-          <div class="f"><span>Closes in</span><b class="clock" data-cd="sprint">—</b></div>
-          <svg class="ev-chev" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg>
-        </div>
-      </summary>
       <div class="ev-body">
-        <p>The Sprint is one ISO week, Monday to Monday. Your slice is computed by the
-        same verifier that folds the main leaderboard — the fills are re-hashed, the book
-        is replayed, and every price is checked against real market history before it
-        ranks. Nothing here is self-reported.</p>
-        <p>Because the window resets, the Sprint is the board a newcomer can actually win.
-        The lifetime leaderboard rewards a long history; this one only asks about
-        <b>this week</b>.</p>
-        <a class="ev-go" href="/sprint">Open the Sprint board →</a>
-      </div>
-    </details>
+        <div class="ev-copy">
+          <h2 class="ev-name" id="ev-name">Top of the Trench</h2>
+          <p class="ev-tagline">Finish first on the board before the week resets.
+          Win it and the tag is yours for good — there is exactly one a week.</p>
+        </div>
 
-    <!-- ============ CLAN SEASON ============ -->
-    <details class="ev-card" id="ev-clans">
-      <summary>
-        <div class="ev-top">
-          <div class="ev-lead">
-            <div class="ev-tags">
-              <span class="tag cadence">Weekly</span>
-              <span class="tag">Team</span>
-            </div>
-            <h2 class="ev-name">Clan Season</h2>
-            <p class="ev-line">Trade for a crew. Every member's week rolls into one clan
-            score, and your tag rides beside your name on the leaderboard.</p>
+        <div class="ev-prize">
+          <div class="prize-chip">
+            <span class="num">#1</span>
+            <span class="what">the tag<br>you keep</span>
           </div>
-          <div class="ev-prize">
-            <b>Your [TAG] on the board</b>
-            <span>and the clan's place in the season</span>
+          <div class="cap">
+            Winner's tag
+            <span class="info">
+              <button class="info-btn" type="button" id="tag-info"
+                      aria-label="What the #1 tag means" aria-describedby="tag-pop">
+                <svg width="9" height="9" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <path d="M11 10h2v8h-2zM11 6h2v2.4h-2z"/>
+                </svg>
+              </button>
+              <span class="info-pop" id="tag-pop" role="tooltip">
+                <b>Finished #1 on the weekly board.</b> Awarded when the week
+                closes and kept permanently, with the week it was won for. It
+                records where you placed on a public board — it does not claim
+                you traded well, and it can never be bought or transferred.
+              </span>
+            </span>
           </div>
         </div>
-        <div class="ev-facts">
-          <div class="f"><span>Entry</span><b>Free</b></div>
-          <div class="f"><span>Clans</span><b id="ev-clans-n">—</b></div>
-          <div class="f"><span>Week ends in</span><b class="clock" data-cd="sprint">—</b></div>
-          <svg class="ev-chev" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg>
-        </div>
-      </summary>
-      <div class="ev-body">
-        <p>Found a clan or join one with an invite code. A clan counts only what its
-        members traded <b>since they joined</b>, so recruiting somebody with a big history
-        does not import their past — a clan's score is a clan's own work.</p>
-        <p>A new clan reads <b>forming</b> until it has five counting members, and shows no
-        score at all rather than a zero. An empty clan is not last place; it has not
-        started.</p>
-        <a class="ev-go" href="/clans">Find a clan →</a>
       </div>
-    </details>
+    </div>
 
-    <!-- ============ THE FRIDAY RECKONING ============ -->
-    <details class="ev-card" id="ev-reckoning">
-      <summary>
-        <div class="ev-top">
-          <div class="ev-lead">
-            <div class="ev-tags">
-              <span class="tag cadence">Fridays</span>
-              <span class="tag">Discord</span>
-            </div>
-            <h2 class="ev-name">The Friday Reckoning</h2>
-            <p class="ev-line">Every Friday evening the week gets read out: how each clan
-            traded, who held their discipline, what the board did.</p>
-          </div>
-          <div class="ev-prize">
-            <b>Your clan's week, posted</b>
-            <span>to the Discord, by name</span>
-          </div>
-        </div>
-        <div class="ev-facts">
-          <div class="f"><span>Entry</span><b>Be in a clan</b></div>
-          <div class="f"><span>Bell</span><b>Fri 20:00 UTC</b></div>
-          <div class="f"><span>Rings in</span><b class="clock" data-cd="reckoning">—</b></div>
-          <svg class="ev-chev" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg>
-        </div>
-      </summary>
-      <div class="ev-body">
-        <p>One anchored ritual a week instead of a stream of notifications. The digest is
-        built from standing data — the same facts the public clan page shows — and it is
-        <b>process only</b>: rounds, score, placement. No profit-and-loss goes in it, by
-        design.</p>
-        <p>If the bell is missed because something was down, the window stays open until
-        Saturday evening and then the week is left unposted. A late digest pretending to be
-        on time would be worse than a gap.</p>
-        <a class="ev-go" href="https://discord.gg/papertrench" target="_blank" rel="noopener">Join the Discord →</a>
-      </div>
-    </details>
+    <div class="ev-facts">
+      <div class="f"><span>Entry</span><b>Free</b></div>
+      <div class="f"><span>In the running</span><b id="ev-entrants">—</b></div>
+      <div class="f"><span>Resets in</span><b class="clock" id="ev-clock">—</b></div>
+      <a class="ev-enter" href="/sprint">See the board →</a>
+    </div>
+  </section>
 
-    <!-- ============ TRENCH WRAPPED ============ -->
-    <details class="ev-card" id="ev-wrapped">
-      <summary>
-        <div class="ev-top">
-          <div class="ev-lead">
-            <div class="ev-tags">
-              <span class="tag cadence">Monthly</span>
-              <span class="tag">Shareable</span>
-            </div>
-            <h2 class="ev-name">Trench Wrapped</h2>
-            <p class="ev-line">A month of your trading, cut into one card you can post —
-            your habits, your discipline, your best call.</p>
-          </div>
-          <div class="ev-prize">
-            <b>A card worth posting</b>
-            <span>rendered from your own month</span>
-          </div>
-        </div>
-        <div class="ev-facts">
-          <div class="f"><span>Entry</span><b>Free</b></div>
-          <div class="f"><span>Covers</span><b>The calendar month</b></div>
-          <div class="f"><span>Next one in</span><b class="clock" data-cd="wrapped">—</b></div>
-          <svg class="ev-chev" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg>
-        </div>
-      </summary>
-      <div class="ev-body">
-        <p>Wrapped is about <b>how you traded</b>, not how much you made — hold times,
-        journal streaks, whether you revenge-traded, the round you played best. It builds
-        from data already on your machine and renders in the dashboard.</p>
-        <p>It is the one surface that will tell you something you did not want to hear,
-        which is rather the point of practising with paper money.</p>
-        <a class="ev-go" href="/#install">Open the dashboard →</a>
-      </div>
-    </details>
-
-    <!-- ============ DUELS ============ -->
-    <details class="ev-card" id="ev-duels">
-      <summary>
-        <div class="ev-top">
-          <div class="ev-lead">
-            <div class="ev-tags">
-              <span class="tag">Anytime</span>
-              <span class="tag">1v1</span>
-            </div>
-            <h2 class="ev-name">Duels</h2>
-            <p class="ev-line">Challenge one person, pick a window, and both records are
-            folded over exactly that stretch. Settled by the verifier, not by argument.</p>
-          </div>
-          <div class="ev-prize">
-            <b>A settled result</b>
-            <span>with a link you can send them</span>
-          </div>
-        </div>
-        <div class="ev-facts">
-          <div class="f"><span>Entry</span><b>Free</b></div>
-          <div class="f"><span>Players</span><b>2</b></div>
-          <div class="f"><span>Starts</span><b>When they join</b></div>
-          <svg class="ev-chev" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg>
-        </div>
-      </summary>
-      <div class="ev-body">
-        <p>Create a duel, send the invite link, and the clock starts when your opponent
-        accepts — not when you made it, so nobody gets a head start on a challenge they
-        have not seen.</p>
-        <p>Both sides show as <b>provisional</b> until the window closes and a post-close
-        submission lands. A duel that cannot yet be judged says so instead of guessing a
-        winner.</p>
-        <a class="ev-go" href="/duels">Start a duel →</a>
-      </div>
-    </details>
-
-    <!-- ============ LIVE NOW ============ -->
-    <details class="ev-card" id="ev-live">
-      <summary>
-        <div class="ev-top">
-          <div class="ev-lead">
-            <div class="ev-tags" id="ev-live-tags">
-              <span class="tag">Right now</span>
-            </div>
-            <h2 class="ev-name">Live in the trenches</h2>
-            <p class="ev-line" id="ev-live-line">Checking who is streaming the challenge…</p>
-          </div>
-          <div class="ev-prize">
-            <b>A card on the roster</b>
-            <span>if you stream it yourself</span>
-          </div>
-        </div>
-        <div class="ev-facts">
-          <div class="f"><span>Entry</span><b>Free to watch</b></div>
-          <div class="f"><span>Streaming now</span><b id="ev-live-n">—</b></div>
-          <div class="f"><span>Platforms</span><b>Twitch · Kick</b></div>
-          <svg class="ev-chev" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg>
-        </div>
-      </summary>
-      <div class="ev-body">
-        <p>Streamers run the same paper wallet as everyone else, under the same protocol —
-        no house accounts, no seeded balances. Watching somebody read a launch in real time
-        is the fastest way to learn the read.</p>
-        <p id="ev-live-detail">Live status is checked against each platform directly, so a
-        channel that cannot be reached shows as unknown rather than as offline.</p>
-        <a class="ev-go" href="/streams">See the roster →</a>
-      </div>
-    </details>
-
+  <!-- ============ HOW ============ -->
+  <div class="ev-how">
+    <div class="how">
+      <div class="n">01</div>
+      <h3>Trade the week</h3>
+      <p>Only fills you take inside the window count. Last week's run does not carry over.</p>
+    </div>
+    <div class="how">
+      <div class="n">02</div>
+      <h3>It gets checked</h3>
+      <p>Every fill is re-hashed and re-priced against real market history before it ranks.</p>
+    </div>
+    <div class="how">
+      <div class="n">03</div>
+      <h3>Monday, it's settled</h3>
+      <p>The board freezes, the top record is crowned once, and a fresh week opens.</p>
+    </div>
   </div>
 
-  <p class="ev-note"><b>No buy-in, no prize pool, no payouts.</b> PaperTrench is free and
-  runs on nobody's budget, so what you are competing for is placement, a record that
-  survives verification, and the badge on your profile. If that changes, it will be
-  announced here first — and it will not be quietly added to a card.</p>
+  <!-- ============ ALSO RUNNING ============ -->
+  <div class="ev-also">
+    <h2>Also running</h2>
+    <div class="also-row">
+      <a class="also" href="/#install">
+        <b>Daily Spark</b><span>one chart, one call — graded on your reasoning</span>
+        <span class="when" id="spark-clock">—</span>
+      </a>
+      <a class="also" href="/clans">
+        <b>Clan season</b><span>trade for a crew, your tag rides on the board</span>
+        <span class="when">weekly</span>
+      </a>
+      <a class="also" href="/duels">
+        <b>Duels</b><span>challenge one person over a window you pick</span>
+        <span class="when">anytime</span>
+      </a>
+    </div>
+  </div>
+
+  <p class="ev-note"><b>No buy-in and no payout.</b> PaperTrench is free and runs on
+  nobody's budget — what is on the line is the tag, your place on the board, and a
+  record anyone can check. If that ever changes it will be said here first.</p>
+
+ </div>
 </main>
+
+<div class="toast" id="toast" role="status" aria-live="polite"></div>
 
 <footer>
   <div class="wrap">

--- a/site/events.html
+++ b/site/events.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>PaperTrench | Events</title>
-<meta name="description" content="What is running on PaperTrench right now: the open Sprint window, streamers live in the trenches, and the verifier tape as records land.">
+<meta name="description" content="Everything running on PaperTrench right now — the Daily Spark, the weekly Sprint window, the clan season, the Friday Reckoning and monthly Wrapped. Free to enter, no buy-in, no prize pool.">
 <link rel="icon" href="/favicon.ico" sizes="48x48">
 <link rel="icon" type="image/png" href="/assets/icon96.png" sizes="96x96">
 <link rel="icon" type="image/png" href="/assets/icon192.png" sizes="192x192">
@@ -13,58 +13,126 @@
 <link rel="stylesheet" href="arena.css">
 <style>
   /* ================================================================== *
-   *  /events — what is running right now.
+   *  /events — one card per thing that is actually running.
    *
-   *  FIRST PASS, and deliberately an aggregator rather than a new system.
-   *  PaperTrench already has time-bound things: the Sprint runs in weekly
-   *  windows the verifier actually folds, streamers go live, and records
-   *  land on the tape. None of that was collected anywhere, so "events"
-   *  is read here as "the calendar those already imply" rather than as a
-   *  new events table nobody has specified.
+   *  The first pass was an aggregator: a Sprint countdown, a live-streamer
+   *  probe, and the verifier tape side by side. The tape was the problem —
+   *  it is a feed of `rejected — chain-replaced` lines, which is diagnostic
+   *  output, not an event. Nobody comes to an events page to watch strangers
+   *  fail verification, and eight red rows is the worst possible read of a
+   *  healthy product. It is gone from here; /leaderboard still carries it,
+   *  where a verdict stream belongs.
    *
-   *  Every panel is backed by a real endpoint. Nothing on this page is a
-   *  placeholder event, because a fake scheduled event is a promise the
-   *  project has not made.
+   *  What replaces it: PaperTrench already runs five recurring rituals on
+   *  fixed clocks — Spark daily, Sprint weekly, the clan season weekly, the
+   *  Reckoning every Friday, Wrapped monthly. They were scattered across the
+   *  extension and three pages and announced nowhere. This is that calendar.
+   *
+   *  Still no invented events. Every card is a thing the code actually does,
+   *  every clock is derived from the same window math the server folds, and
+   *  every reward is something that already exists. There is no prize pool
+   *  because there is no budget, and saying so plainly beats implying one.
    * ================================================================== */
-  .ev-head { padding: 128px 0 10px; }
+
+  .ev-head { padding: 128px 0 8px; }
   .ev-head h1 { font-size: clamp(30px, 4.4vw, 46px); font-weight: 700; letter-spacing: -0.02em; }
-  .ev-head p { font-size: 14.5px; color: var(--muted); margin-top: 12px; max-width: 660px; line-height: 1.65; }
+  .ev-head p { font-size: 14.5px; color: var(--muted); margin-top: 12px; max-width: 640px; line-height: 1.65; }
+  .ev-head a { color: var(--orange2); }
 
-  .ev-grid { display: grid; gap: 16px; grid-template-columns: 1fr 1.1fr; align-items: start; }
-  @media (max-width: 900px) { .ev-grid { grid-template-columns: 1fr; } }
+  .ev-stack { display: grid; gap: 12px; margin-top: 26px; }
 
-  .ev-now { padding: 22px 24px; }
-  .ev-kicker { font-family: var(--mono); font-size: 10.5px; font-weight: 800;
-    letter-spacing: 1.5px; text-transform: uppercase; color: var(--dim); }
-  .ev-title { font-size: 22px; font-weight: 750; letter-spacing: -0.01em; margin: 8px 0 4px; }
-  .ev-sub { font-size: 13px; color: var(--muted); line-height: 1.6; }
+  /* ---------- the card ----------
+   * <details> rather than a JS toggle: keyboard- and screen-reader-operable
+   * for free, deep-linkable with [open], and it survives a re-render with no
+   * state to keep. */
+  .ev-card {
+    background: var(--panel); border: var(--edge); border-radius: 14px;
+    overflow: hidden; transition: border-color .18s;
+  }
+  .ev-card:hover { border-color: var(--line2); }
+  .ev-card[open] { border-color: rgba(255,157,69,0.3); }
 
-  .ev-clock { display: flex; gap: 10px; flex-wrap: wrap; margin: 18px 0 4px; }
-  .ev-unit { min-width: 68px; padding: 10px 12px; border-radius: 12px;
-    background: rgba(0,0,0,0.28); border: var(--edge); text-align: center; }
-  .ev-unit b { display: block; font-family: var(--mono); font-size: 22px; font-weight: 700;
-    color: var(--text); font-variant-numeric: tabular-nums; }
-  .ev-unit span { font-family: var(--mono); font-size: 9.5px; letter-spacing: 1.2px;
-    text-transform: uppercase; color: var(--dim); }
+  .ev-card summary { display: block; cursor: pointer; list-style: none; padding: 18px 20px 0; }
+  .ev-card summary::-webkit-details-marker { display: none; }
+  .ev-card summary:focus-visible { outline: 2px solid var(--orange); outline-offset: -2px; }
 
-  .ev-bar { height: 6px; border-radius: 999px; background: rgba(255,255,255,0.07);
-    overflow: hidden; margin-top: 16px; }
-  .ev-bar i { display: block; height: 100%; border-radius: 999px; background: var(--grad-heat); }
-  .ev-barnote { display: flex; justify-content: space-between; gap: 10px;
-    font-family: var(--mono); font-size: 10.5px; color: var(--dim); margin-top: 7px; }
+  .ev-top { display: flex; align-items: flex-start; gap: 18px; }
+  .ev-lead { flex: 1; min-width: 0; }
 
-  .ev-list { display: grid; gap: 9px; }
-  .ev-item { display: flex; align-items: center; gap: 11px; padding: 11px 14px;
-    border-radius: 11px; background: rgba(255,255,255,0.022); border: var(--edge); }
-  .ev-item .dot { width: 7px; height: 7px; border-radius: 50%; flex: none; background: var(--dim); }
-  .ev-item.on .dot { background: var(--red); box-shadow: 0 0 9px var(--red); animation: pulse 1.6s infinite; }
-  .ev-item .nm { font-weight: 700; font-size: 13.5px; }
-  .ev-item .mt { font-family: var(--mono); font-size: 10.5px; color: var(--dim); margin-left: auto; }
+  .ev-tags { display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 9px; }
+  .tag {
+    font-family: var(--mono); font-size: 9.5px; font-weight: 700;
+    letter-spacing: 1px; text-transform: uppercase;
+    padding: 3px 8px; border-radius: 999px;
+    background: rgba(255,255,255,0.05); border: 1px solid var(--line2); color: var(--dim);
+  }
+  .tag.cadence { color: var(--orange2); background: rgba(255,157,69,0.09); border-color: rgba(255,157,69,0.28); }
+  /* "Open now" is a claim about state, so it is only ever printed when the
+     clock says so — never as decoration. */
+  .tag.open { color: var(--green2); background: rgba(52,211,153,0.10); border-color: rgba(52,211,153,0.3); }
+  .tag.live { color: #ff9a90; background: rgba(224,67,58,0.10); border-color: rgba(224,67,58,0.32); display: inline-flex; align-items: center; gap: 5px; }
+  .tag.live .dot { width: 5px; height: 5px; border-radius: 50%; background: var(--red); box-shadow: 0 0 8px var(--red); animation: pulse 1.6s infinite; }
 
-  .ev-firstpass { margin-top: 20px; padding: 14px 18px; border-radius: 12px;
-    background: rgba(255,157,69,0.05); border: 1px solid rgba(255,157,69,0.22);
-    border-left: 2px solid var(--orange); font-size: 12.5px; color: var(--muted); line-height: 1.6; }
-  .ev-firstpass b { color: var(--text); font-weight: 700; }
+  .ev-name { font-size: 19px; font-weight: 750; letter-spacing: -0.015em; }
+  .ev-line { font-size: 13.5px; color: var(--muted); line-height: 1.55; margin-top: 4px; max-width: 56ch; }
+
+  /* The reward column. It is never money, so it is not dressed as money —
+     no coin glyph, no pool figure, no gold. */
+  .ev-prize { flex: none; text-align: right; max-width: 190px; }
+  .ev-prize b {
+    display: block; font-size: 13.5px; font-weight: 750; color: var(--orange2);
+    letter-spacing: -0.01em; line-height: 1.3;
+  }
+  .ev-prize span { display: block; font-size: 11px; color: var(--dim); margin-top: 3px; line-height: 1.4; }
+  @media (max-width: 720px) {
+    .ev-top { flex-direction: column; gap: 10px; }
+    .ev-prize { text-align: left; max-width: none; }
+  }
+
+  /* ---------- the facts band ---------- */
+  .ev-facts {
+    display: flex; align-items: center; gap: 26px; flex-wrap: wrap;
+    margin: 16px -20px 0; padding: 12px 20px;
+    background: rgba(0,0,0,0.26); border-top: var(--edge);
+  }
+  .ev-facts .f { min-width: 0; }
+  .ev-facts .f span {
+    display: block; font-family: var(--mono); font-size: 9.5px; font-weight: 700;
+    letter-spacing: 1px; text-transform: uppercase; color: var(--dim);
+  }
+  .ev-facts .f b {
+    display: block; font-size: 13px; font-weight: 700; color: var(--text); margin-top: 3px;
+    font-variant-numeric: tabular-nums;
+  }
+  .ev-facts .f b.clock { font-family: var(--mono); color: var(--orange2); }
+  .ev-chev {
+    margin-left: auto; flex: none; color: var(--dim);
+    transition: transform .2s, color .2s;
+  }
+  .ev-card[open] .ev-chev { transform: rotate(180deg); color: var(--orange2); }
+
+  /* ---------- expanded ---------- */
+  .ev-body { padding: 18px 20px 20px; border-top: var(--edge); }
+  .ev-body p { font-size: 13.5px; color: var(--muted); line-height: 1.7; max-width: 68ch; }
+  .ev-body p + p { margin-top: 10px; }
+  .ev-body b { color: var(--text); font-weight: 650; }
+  .ev-body ul { margin: 10px 0 0; padding-left: 18px; }
+  .ev-body li { font-size: 13.5px; color: var(--muted); line-height: 1.65; margin-bottom: 5px; }
+  .ev-body a { color: var(--orange2); }
+  .ev-go {
+    display: inline-flex; align-items: center; gap: 7px; margin-top: 16px;
+    font-size: 13px; font-weight: 700; color: var(--text);
+    background: rgba(255,255,255,0.05); border: 1px solid var(--line2);
+    border-radius: 10px; padding: 9px 15px; transition: background .16s, border-color .16s;
+  }
+  .ev-go:hover { background: rgba(255,255,255,0.1); border-color: rgba(255,255,255,0.24); }
+
+  .ev-note {
+    margin-top: 22px; padding: 14px 18px; border-radius: 12px;
+    background: rgba(255,255,255,0.02); border: var(--edge);
+    font-size: 12.5px; color: var(--muted); line-height: 1.65;
+  }
+  .ev-note b { color: var(--text); font-weight: 700; }
 </style>
 </head>
 <body>
@@ -96,38 +164,270 @@
 <main id="main" class="wrap" style="padding-bottom:96px">
   <header class="ev-head">
     <h1>Events</h1>
-    <p>What is actually running right now. The Sprint window below is the one the
-    verifier folds; the streams are checked live; the tape is the verifier talking.
-    Nothing here is a scheduled placeholder.</p>
+    <p>Everything PaperTrench runs on a clock. All of it is free, none of it needs
+    a sign-up, and none of it pays out money — you are competing for placement and
+    a record that can be checked. Open a card for the rules.</p>
   </header>
 
-  <div class="ev-grid">
-    <section class="ar-pane" aria-labelledby="ev-now-h">
-      <div class="ar-pane-head"><span class="glyph" style="color:var(--orange2)">◷</span>
-        <span id="ev-now-h">The open window</span></div>
-      <div class="ev-now" id="ev-now"><p class="ar-note">Reading the Sprint window…</p></div>
-    </section>
+  <div class="ev-stack" id="ev-stack">
 
-    <div style="display:grid;gap:16px">
-      <section class="ar-pane" aria-labelledby="ev-live-h">
-        <div class="ar-pane-head"><span class="glyph" style="color:var(--red)">▶</span>
-          <span id="ev-live-h">Live in the trenches</span></div>
-        <div class="pad" id="ev-live"><p class="ar-note">Checking who is live…</p></div>
-      </section>
+    <!-- ============ DAILY SPARK ============ -->
+    <details class="ev-card" id="ev-spark">
+      <summary>
+        <div class="ev-top">
+          <div class="ev-lead">
+            <div class="ev-tags">
+              <span class="tag cadence">Daily</span>
+              <span class="tag open">Open now</span>
+            </div>
+            <h2 class="ev-name">Daily Spark</h2>
+            <p class="ev-line">One real chart, frozen at a moment. Call what happens next.
+            Graded on your reasoning, never on profit.</p>
+          </div>
+          <div class="ev-prize">
+            <b>Spark streak</b>
+            <span>and your accuracy, kept in the dashboard</span>
+          </div>
+        </div>
+        <div class="ev-facts">
+          <div class="f"><span>Entry</span><b>Free</b></div>
+          <div class="f"><span>Takes</span><b>~1 minute</b></div>
+          <div class="f"><span>Resets in</span><b class="clock" data-cd="spark">—</b></div>
+          <svg class="ev-chev" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg>
+        </div>
+      </summary>
+      <div class="ev-body">
+        <p>A single mint's chart is cut at a point in time. You say where it goes and
+        <b>why</b> — the why is the part that is graded. Get the direction right for the
+        wrong reason and it does not count for much; the puzzle is about reading a chart,
+        not about being lucky once.</p>
+        <p>It changes at <b>00:00 UTC</b> and everyone gets the same chart that day, so
+        nobody can farm it by refreshing. Miss a day and the streak resets — that is the
+        whole pressure, and it is deliberately the only one.</p>
+        <a class="ev-go" href="/#install">Play it in the extension →</a>
+      </div>
+    </details>
 
-      <section class="ar-pane" aria-labelledby="ev-tape-h">
-        <div class="ar-pane-head"><span class="glyph" style="color:var(--green)">▸</span>
-          <span id="ev-tape-h">The tape</span></div>
-        <div class="pad" id="ev-tape"><p class="ar-note">Reading the tape…</p></div>
-      </section>
-    </div>
+    <!-- ============ WEEKLY SPRINT ============ -->
+    <details class="ev-card" id="ev-sprint">
+      <summary>
+        <div class="ev-top">
+          <div class="ev-lead">
+            <div class="ev-tags">
+              <span class="tag cadence">Weekly</span>
+              <span class="tag open" id="ev-sprint-state">Open now</span>
+            </div>
+            <h2 class="ev-name">The Weekly Sprint</h2>
+            <p class="ev-line">A fresh board every Monday. Only the fills you take inside
+            the window count, so a good week is not buried under an old one.</p>
+          </div>
+          <div class="ev-prize">
+            <b>Top of the Sprint board</b>
+            <span>for the week, with your verified record</span>
+          </div>
+        </div>
+        <div class="ev-facts">
+          <div class="f"><span>Entry</span><b>Free</b></div>
+          <div class="f"><span>Entrants</span><b id="ev-sprint-n">—</b></div>
+          <div class="f"><span>Closes in</span><b class="clock" data-cd="sprint">—</b></div>
+          <svg class="ev-chev" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg>
+        </div>
+      </summary>
+      <div class="ev-body">
+        <p>The Sprint is one ISO week, Monday to Monday. Your slice is computed by the
+        same verifier that folds the main leaderboard — the fills are re-hashed, the book
+        is replayed, and every price is checked against real market history before it
+        ranks. Nothing here is self-reported.</p>
+        <p>Because the window resets, the Sprint is the board a newcomer can actually win.
+        The lifetime leaderboard rewards a long history; this one only asks about
+        <b>this week</b>.</p>
+        <a class="ev-go" href="/sprint">Open the Sprint board →</a>
+      </div>
+    </details>
+
+    <!-- ============ CLAN SEASON ============ -->
+    <details class="ev-card" id="ev-clans">
+      <summary>
+        <div class="ev-top">
+          <div class="ev-lead">
+            <div class="ev-tags">
+              <span class="tag cadence">Weekly</span>
+              <span class="tag">Team</span>
+            </div>
+            <h2 class="ev-name">Clan Season</h2>
+            <p class="ev-line">Trade for a crew. Every member's week rolls into one clan
+            score, and your tag rides beside your name on the leaderboard.</p>
+          </div>
+          <div class="ev-prize">
+            <b>Your [TAG] on the board</b>
+            <span>and the clan's place in the season</span>
+          </div>
+        </div>
+        <div class="ev-facts">
+          <div class="f"><span>Entry</span><b>Free</b></div>
+          <div class="f"><span>Clans</span><b id="ev-clans-n">—</b></div>
+          <div class="f"><span>Week ends in</span><b class="clock" data-cd="sprint">—</b></div>
+          <svg class="ev-chev" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg>
+        </div>
+      </summary>
+      <div class="ev-body">
+        <p>Found a clan or join one with an invite code. A clan counts only what its
+        members traded <b>since they joined</b>, so recruiting somebody with a big history
+        does not import their past — a clan's score is a clan's own work.</p>
+        <p>A new clan reads <b>forming</b> until it has five counting members, and shows no
+        score at all rather than a zero. An empty clan is not last place; it has not
+        started.</p>
+        <a class="ev-go" href="/clans">Find a clan →</a>
+      </div>
+    </details>
+
+    <!-- ============ THE FRIDAY RECKONING ============ -->
+    <details class="ev-card" id="ev-reckoning">
+      <summary>
+        <div class="ev-top">
+          <div class="ev-lead">
+            <div class="ev-tags">
+              <span class="tag cadence">Fridays</span>
+              <span class="tag">Discord</span>
+            </div>
+            <h2 class="ev-name">The Friday Reckoning</h2>
+            <p class="ev-line">Every Friday evening the week gets read out: how each clan
+            traded, who held their discipline, what the board did.</p>
+          </div>
+          <div class="ev-prize">
+            <b>Your clan's week, posted</b>
+            <span>to the Discord, by name</span>
+          </div>
+        </div>
+        <div class="ev-facts">
+          <div class="f"><span>Entry</span><b>Be in a clan</b></div>
+          <div class="f"><span>Bell</span><b>Fri 20:00 UTC</b></div>
+          <div class="f"><span>Rings in</span><b class="clock" data-cd="reckoning">—</b></div>
+          <svg class="ev-chev" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg>
+        </div>
+      </summary>
+      <div class="ev-body">
+        <p>One anchored ritual a week instead of a stream of notifications. The digest is
+        built from standing data — the same facts the public clan page shows — and it is
+        <b>process only</b>: rounds, score, placement. No profit-and-loss goes in it, by
+        design.</p>
+        <p>If the bell is missed because something was down, the window stays open until
+        Saturday evening and then the week is left unposted. A late digest pretending to be
+        on time would be worse than a gap.</p>
+        <a class="ev-go" href="https://discord.gg/papertrench" target="_blank" rel="noopener">Join the Discord →</a>
+      </div>
+    </details>
+
+    <!-- ============ TRENCH WRAPPED ============ -->
+    <details class="ev-card" id="ev-wrapped">
+      <summary>
+        <div class="ev-top">
+          <div class="ev-lead">
+            <div class="ev-tags">
+              <span class="tag cadence">Monthly</span>
+              <span class="tag">Shareable</span>
+            </div>
+            <h2 class="ev-name">Trench Wrapped</h2>
+            <p class="ev-line">A month of your trading, cut into one card you can post —
+            your habits, your discipline, your best call.</p>
+          </div>
+          <div class="ev-prize">
+            <b>A card worth posting</b>
+            <span>rendered from your own month</span>
+          </div>
+        </div>
+        <div class="ev-facts">
+          <div class="f"><span>Entry</span><b>Free</b></div>
+          <div class="f"><span>Covers</span><b>The calendar month</b></div>
+          <div class="f"><span>Next one in</span><b class="clock" data-cd="wrapped">—</b></div>
+          <svg class="ev-chev" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg>
+        </div>
+      </summary>
+      <div class="ev-body">
+        <p>Wrapped is about <b>how you traded</b>, not how much you made — hold times,
+        journal streaks, whether you revenge-traded, the round you played best. It builds
+        from data already on your machine and renders in the dashboard.</p>
+        <p>It is the one surface that will tell you something you did not want to hear,
+        which is rather the point of practising with paper money.</p>
+        <a class="ev-go" href="/#install">Open the dashboard →</a>
+      </div>
+    </details>
+
+    <!-- ============ DUELS ============ -->
+    <details class="ev-card" id="ev-duels">
+      <summary>
+        <div class="ev-top">
+          <div class="ev-lead">
+            <div class="ev-tags">
+              <span class="tag">Anytime</span>
+              <span class="tag">1v1</span>
+            </div>
+            <h2 class="ev-name">Duels</h2>
+            <p class="ev-line">Challenge one person, pick a window, and both records are
+            folded over exactly that stretch. Settled by the verifier, not by argument.</p>
+          </div>
+          <div class="ev-prize">
+            <b>A settled result</b>
+            <span>with a link you can send them</span>
+          </div>
+        </div>
+        <div class="ev-facts">
+          <div class="f"><span>Entry</span><b>Free</b></div>
+          <div class="f"><span>Players</span><b>2</b></div>
+          <div class="f"><span>Starts</span><b>When they join</b></div>
+          <svg class="ev-chev" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg>
+        </div>
+      </summary>
+      <div class="ev-body">
+        <p>Create a duel, send the invite link, and the clock starts when your opponent
+        accepts — not when you made it, so nobody gets a head start on a challenge they
+        have not seen.</p>
+        <p>Both sides show as <b>provisional</b> until the window closes and a post-close
+        submission lands. A duel that cannot yet be judged says so instead of guessing a
+        winner.</p>
+        <a class="ev-go" href="/duels">Start a duel →</a>
+      </div>
+    </details>
+
+    <!-- ============ LIVE NOW ============ -->
+    <details class="ev-card" id="ev-live">
+      <summary>
+        <div class="ev-top">
+          <div class="ev-lead">
+            <div class="ev-tags" id="ev-live-tags">
+              <span class="tag">Right now</span>
+            </div>
+            <h2 class="ev-name">Live in the trenches</h2>
+            <p class="ev-line" id="ev-live-line">Checking who is streaming the challenge…</p>
+          </div>
+          <div class="ev-prize">
+            <b>A card on the roster</b>
+            <span>if you stream it yourself</span>
+          </div>
+        </div>
+        <div class="ev-facts">
+          <div class="f"><span>Entry</span><b>Free to watch</b></div>
+          <div class="f"><span>Streaming now</span><b id="ev-live-n">—</b></div>
+          <div class="f"><span>Platforms</span><b>Twitch · Kick</b></div>
+          <svg class="ev-chev" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg>
+        </div>
+      </summary>
+      <div class="ev-body">
+        <p>Streamers run the same paper wallet as everyone else, under the same protocol —
+        no house accounts, no seeded balances. Watching somebody read a launch in real time
+        is the fastest way to learn the read.</p>
+        <p id="ev-live-detail">Live status is checked against each platform directly, so a
+        channel that cannot be reached shows as unknown rather than as offline.</p>
+        <a class="ev-go" href="/streams">See the roster →</a>
+      </div>
+    </details>
+
   </div>
 
-  <p class="ev-firstpass"><b>First pass.</b> "Events" had no spec, so this page
-  collects the time-bound things PaperTrench already runs rather than inventing an
-  events system. If what was wanted is scheduled, announced events — tournaments with
-  a start date, prize pools, sign-ups — that needs somewhere to store them and a way
-  for a moderator to post one, which is a bigger build than this page.</p>
+  <p class="ev-note"><b>No buy-in, no prize pool, no payouts.</b> PaperTrench is free and
+  runs on nobody's budget, so what you are competing for is placement, a record that
+  survives verification, and the badge on your profile. If that changes, it will be
+  announced here first — and it will not be quietly added to a card.</p>
 </main>
 
 <footer>

--- a/site/events.js
+++ b/site/events.js
@@ -1,21 +1,25 @@
 /* PaperTrench — /events.
  *
- * FIRST PASS. "Events" arrived without a spec, so this reads it as "the
- * calendar the product already implies" rather than as a new events system:
- * the Sprint window the verifier actually folds, who is streaming right now,
- * and what the verifier has been saying. Every panel is backed by a live
- * endpoint, and a panel that cannot read its endpoint says so — none of them
- * fall back to an invented event, because a fake scheduled event is a promise
- * the project has not made.
+ * The page is a static list of the recurring things the product actually
+ * runs; this file only supplies what has to be live: the clocks, and the
+ * three counts (Sprint entrants, clans, who is streaming).
+ *
+ * Two rules carried over from the first pass, because they are what stop an
+ * events page becoming a page of promises:
+ *
+ *   1. Nothing here invents an event. Every card in events.html maps to code
+ *      that exists, and the clocks are derived from the same window math the
+ *      server folds — not from a hardcoded date somebody has to remember to
+ *      update.
+ *   2. A number that cannot be read is not printed as zero. "0 entrants" and
+ *      "we could not reach the server" are different claims, and the second
+ *      one must never render as the first.
  */
 (() => {
   'use strict';
 
   const API = 'https://papertrench-api.onerobby.workers.dev';
   const $ = (id) => document.getElementById(id);
-  const esc = (s) => String(s == null ? '' : s).replace(/[&<>"']/g, (c) => (
-    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
-  ));
 
   async function get(path) {
     const res = await fetch(API + path, { credentials: 'omit', cache: 'no-store' });
@@ -23,71 +27,118 @@
     return res.json();
   }
 
-  const note = (el, text) => { el.innerHTML = `<p class="ar-note">${esc(text)}</p>`; };
+  /* ---------------- clocks ----------------
+   *
+   * Each deadline is a function of NOW rather than a stored date, so the page
+   * stays correct with nobody maintaining it. The Sprint deadline is replaced
+   * by the server's real endTs once that arrives; the fallback below is the
+   * same ISO-week rule the server uses, so the two agree even offline. */
 
-  /* ---------- the open Sprint window ---------- */
+  const DAY = 86400000;
 
-  const pad = (n) => String(n).padStart(2, '0');
-
-  function renderWindow(sprint) {
-    const el = $('ev-now');
-    const start = Number(sprint.startTs) || 0;
-    const end = Number(sprint.endTs) || 0;
-    if (!start || !end) { note(el, 'No window is open right now.'); return; }
-
-    const entries = Array.isArray(sprint.entries) ? sprint.entries.length : 0;
-    const fmtDay = (ts) => new Date(ts).toLocaleDateString(undefined,
-      { month: 'short', day: 'numeric' });
-
-    el.innerHTML = `
-      <div class="ev-kicker">Sprint · ${esc(sprint.weekId || '')}</div>
-      <div class="ev-title">The weekly window is open</div>
-      <p class="ev-sub">One ISO week. Only fills inside it count, and the slice is
-      computed by the same verifier that folds the main board — this is the one
-      window the server actually windows.</p>
-      <div class="ev-clock" id="ev-clock"></div>
-      <div class="ev-bar"><i id="ev-fill" style="width:0%"></i></div>
-      <div class="ev-barnote">
-        <span>${esc(fmtDay(start))}</span>
-        <span id="ev-pct">—</span>
-        <span>${esc(fmtDay(end))}</span>
-      </div>
-      <p class="ev-sub" style="margin-top:14px">
-        <b style="color:var(--text)">${entries}</b> record${entries === 1 ? '' : 's'} in
-        this window so far · <a href="/sprint" style="color:var(--orange2)">open the Sprint →</a>
-      </p>`;
-
-    const clock = $('ev-clock');
-    const fill = $('ev-fill');
-    const pct = $('ev-pct');
-
-    const tick = () => {
-      const now = Date.now();
-      const left = Math.max(0, end - now);
-      const total = Math.max(1, end - start);
-      const done = Math.min(1, Math.max(0, (now - start) / total));
-
-      const d = Math.floor(left / 86400000);
-      const h = Math.floor((left % 86400000) / 3600000);
-      const m = Math.floor((left % 3600000) / 60000);
-      const s = Math.floor((left % 60000) / 1000);
-
-      clock.innerHTML = left > 0
-        ? `<div class="ev-unit"><b>${d}</b><span>days</span></div>
-           <div class="ev-unit"><b>${pad(h)}</b><span>hrs</span></div>
-           <div class="ev-unit"><b>${pad(m)}</b><span>min</span></div>
-           <div class="ev-unit"><b>${pad(s)}</b><span>sec</span></div>`
-        : '<div class="ev-unit" style="min-width:auto;padding:10px 16px"><b>closed</b><span>window</span></div>';
-      fill.style.width = (done * 100).toFixed(1) + '%';
-      pct.textContent = Math.round(done * 100) + '% elapsed';
-    };
-    tick();
-    setInterval(tick, 1000);
+  /** Next 00:00 UTC — the Spark rollover. */
+  function nextUtcMidnight(now) {
+    const d = new Date(now);
+    return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1);
   }
 
-  /* ---------- who is live ----------
-   * Twitch and Kick are asked their own way, the same rule /streams uses:
-   * a probe that fails is unknown and simply does not claim a status. */
+  /** Next Monday 00:00 UTC — the ISO week the Sprint and clan season share. */
+  function nextIsoWeekStart(now) {
+    const d = new Date(now);
+    // getUTCDay: Sun=0 … Sat=6. Days until the next Monday, never 0.
+    const ahead = ((8 - d.getUTCDay()) % 7) || 7;
+    return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + ahead);
+  }
+
+  /** Next Friday 20:00 UTC — the Reckoning bell (server/core/reckoning.js). */
+  function nextReckoning(now) {
+    const d = new Date(now);
+    const ahead = (5 - d.getUTCDay() + 7) % 7;
+    let ts = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + ahead, 20);
+    if (ts <= now) ts += 7 * DAY;
+    return ts;
+  }
+
+  /** First of next month, 00:00 UTC — when a Wrapped month closes. */
+  function nextMonth(now) {
+    const d = new Date(now);
+    return Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 1);
+  }
+
+  // Sprint starts on the shared fallback and is overwritten by the API.
+  const deadlines = {
+    spark: nextUtcMidnight,
+    sprint: nextIsoWeekStart,
+    reckoning: nextReckoning,
+    wrapped: nextMonth,
+  };
+  let sprintEnd = 0;   // real endTs once /api/sprint/current answers
+
+  /** "6d 05h", "05h 12m", "12m 40s" — two units is enough to act on. */
+  function countdown(ms) {
+    if (ms <= 0) return 'any moment';
+    const s = Math.floor(ms / 1000);
+    const d = Math.floor(s / 86400);
+    const h = Math.floor((s % 86400) / 3600);
+    const m = Math.floor((s % 3600) / 60);
+    const sec = s % 60;
+    const pad = (n) => String(n).padStart(2, '0');
+    if (d > 0) return d + 'd ' + pad(h) + 'h';
+    if (h > 0) return pad(h) + 'h ' + pad(m) + 'm';
+    return pad(m) + 'm ' + pad(sec) + 's';
+  }
+
+  function tick() {
+    const now = Date.now();
+    for (const el of document.querySelectorAll('[data-cd]')) {
+      const key = el.dataset.cd;
+      const at = (key === 'sprint' && sprintEnd > now)
+        ? sprintEnd
+        : (deadlines[key] ? deadlines[key](now) : 0);
+      el.textContent = at ? countdown(at - now) : '—';
+    }
+  }
+
+  tick();
+  setInterval(tick, 1000);
+
+  /* ---------------- live counts ---------------- */
+
+  (async () => {
+    try {
+      const sprint = await get('/api/sprint/current');
+      const end = Number(sprint && sprint.endTs) || 0;
+      if (end > 0) sprintEnd = end;
+      const n = Array.isArray(sprint && sprint.entries) ? sprint.entries.length : null;
+      if (n !== null) {
+        $('ev-sprint-n').textContent = n === 0 ? 'nobody yet' : String(n);
+      }
+      // A window that has already closed must not still read "Open now".
+      if (end > 0 && end <= Date.now()) {
+        const state = $('ev-sprint-state');
+        state.textContent = 'Between windows';
+        state.className = 'tag';
+      }
+      tick();
+    } catch (_) {
+      // Leave the em-dash. A failed read is not "nobody entered".
+      $('ev-sprint-n').textContent = 'unavailable';
+    }
+  })();
+
+  (async () => {
+    try {
+      const body = await get('/api/clans');
+      const n = Number(body && body.clansTotal);
+      $('ev-clans-n').textContent = Number.isFinite(n) ? String(n) : 'unavailable';
+    } catch (_) {
+      $('ev-clans-n').textContent = 'unavailable';
+    }
+  })();
+
+  /* ---------------- who is streaming ----------------
+   * Same probes /streams uses, and the same rule: a channel we cannot reach
+   * is UNKNOWN, never "offline". Only a positive answer counts as live. */
 
   async function liveTwitch(login) {
     try {
@@ -110,96 +161,47 @@
     } catch (_) { return null; }
   }
 
-  async function renderLive() {
-    const el = $('ev-live');
-    let roster = [];
-    try {
-      const body = await get('/api/streamer/roster');
-      roster = Array.isArray(body && body.streamers) ? body.streamers : [];
-    } catch (_) { roster = []; }
-
+  (async () => {
     // The hand-maintained names on /streams are the floor: an empty or
     // unreachable roster API must not read as "nobody streams here".
     const seeds = [
       { name: 'OnlyTerp', platform: 'twitch', login: 'onlyterp' },
       { name: 'Ark1317', platform: 'kick', channel: 'ark1317' },
     ];
-    for (const row of roster) {
-      const login = String((row && row.login) || '').toLowerCase();
-      if (login && !seeds.some((s) => s.login === login)) {
-        seeds.push({ name: row.name || login, platform: 'twitch', login });
-      }
-    }
-
-    const results = await Promise.all(seeds.map(async (s) => ({
-      s,
-      up: s.platform === 'kick' ? await liveKick(s.channel) : await liveTwitch(s.login),
-    })));
-
-    const live = results.filter((r) => r.up === true);
-    if (!live.length) {
-      el.innerHTML = `<p class="ar-note">Nobody is live this minute.
-        <a href="/streams" style="color:var(--orange2)">The roster →</a></p>`;
-      return;
-    }
-    el.innerHTML = '<div class="ev-list">'
-      + live.map(({ s }) => `
-        <a class="ev-item on" href="/streams">
-          <span class="dot"></span>
-          <span class="nm">${esc(s.name)}</span>
-          <span class="mt">${esc(s.platform)}</span>
-        </a>`).join('')
-      + '</div>';
-  }
-
-  /* ---------- the tape ---------- */
-
-  // Verb only: the subject is printed separately, and rejections deliberately
-  // arrive with no handle, so the row has to read as a sentence either way —
-  // "@someone · verified" and "A record · rejected".
-  const KIND_LABEL = {
-    accepted: 'accepted',
-    rejected: 'rejected',
-    verified: 'verified',
-    joined: 'joined the trench',
-  };
-
-  function ago(ts) {
-    const mins = Math.max(0, Math.round((Date.now() - Number(ts)) / 60000));
-    if (mins < 60) return mins + 'm';
-    const h = Math.round(mins / 60);
-    return h < 48 ? h + 'h' : Math.round(h / 24) + 'd';
-  }
-
-  async function renderTape() {
-    const el = $('ev-tape');
-    let events = [];
     try {
-      const body = await get('/api/activity');
-      events = Array.isArray(body && body.events) ? body.events : [];
-    } catch (_) {
-      note(el, 'The tape is unreachable right now.');
+      const body = await get('/api/streamer/roster');
+      for (const row of (Array.isArray(body && body.streamers) ? body.streamers : [])) {
+        const login = String((row && row.login) || '').toLowerCase();
+        if (login && !seeds.some((s) => s.login === login)) {
+          seeds.push({ name: row.name || login, platform: 'twitch', login });
+        }
+      }
+    } catch (_) { /* seeds stand */ }
+
+    const results = await Promise.all(seeds.map(async (s) => (
+      s.platform === 'kick' ? await liveKick(s.channel) : await liveTwitch(s.login)
+    )));
+    const live = results.filter((up) => up === true).length;
+    const known = results.filter((up) => up !== null).length;
+
+    const nEl = $('ev-live-n');
+    const line = $('ev-live-line');
+    const tags = $('ev-live-tags');
+
+    if (!known) {
+      nEl.textContent = 'unavailable';
+      line.textContent = 'Live status could not be checked from here right now.';
       return;
     }
-    if (!events.length) { note(el, 'Nothing on the tape yet.'); return; }
 
-    el.innerHTML = '<div class="ev-list">'
-      + events.slice(0, 8).map((e) => `
-        <div class="ev-item">
-          <span class="dot"></span>
-          <span class="nm">${e.handle ? '@' + esc(e.handle) : 'A record'}</span>
-          <span class="ev-sub" style="font-size:12px">${esc(KIND_LABEL[e.kind] || e.kind || '')}${e.detail ? ' — ' + esc(e.detail) : ''}</span>
-          <span class="mt">${esc(ago(e.ts))}</span>
-        </div>`).join('')
-      + '</div>';
-  }
-
-  /* ---------- boot ---------- */
-
-  (async () => {
-    try { renderWindow(await get('/api/sprint/current')); }
-    catch (_) { note($('ev-now'), 'The Sprint window is unreachable right now.'); }
+    nEl.textContent = String(live);
+    if (live > 0) {
+      line.textContent = live === 1
+        ? 'Somebody is running the challenge live right now.'
+        : `${live} streamers are running the challenge live right now.`;
+      tags.innerHTML = '<span class="tag live"><span class="dot"></span>Live</span>';
+    } else {
+      line.textContent = 'Nobody is live this minute — the roster and past runs are on the streams page.';
+    }
   })();
-  renderLive();
-  renderTape();
 })();

--- a/site/events.js
+++ b/site/events.js
@@ -1,19 +1,19 @@
 /* PaperTrench — /events.
  *
- * The page is a static list of the recurring things the product actually
- * runs; this file only supplies what has to be live: the clocks, and the
- * three counts (Sprint entrants, clans, who is streaming).
+ * The page is one event and a short strip; this file supplies the two clocks
+ * and the entrant count, and wires the share button.
  *
- * Two rules carried over from the first pass, because they are what stop an
- * events page becoming a page of promises:
+ * Two rules carried from the first pass, because they are what stop an events
+ * page becoming a page of promises:
  *
- *   1. Nothing here invents an event. Every card in events.html maps to code
- *      that exists, and the clocks are derived from the same window math the
- *      server folds — not from a hardcoded date somebody has to remember to
- *      update.
- *   2. A number that cannot be read is not printed as zero. "0 entrants" and
- *      "we could not reach the server" are different claims, and the second
- *      one must never render as the first.
+ *   1. Clocks are DERIVED, never hardcoded. Each deadline is a function of
+ *      now, using the same window rule the server folds, so the page stays
+ *      correct with nobody maintaining it. The Sprint takes the real endTs
+ *      once the API answers and falls back to that shared rule meanwhile —
+ *      the two agree even when the fetch fails.
+ *   2. A number that cannot be READ is not printed as a number. "nobody yet"
+ *      and "the server did not answer" are different claims, and the second
+ *      must never render as the first.
  */
 (() => {
   'use strict';
@@ -27,14 +27,17 @@
     return res.json();
   }
 
-  /* ---------------- clocks ----------------
-   *
-   * Each deadline is a function of NOW rather than a stored date, so the page
-   * stays correct with nobody maintaining it. The Sprint deadline is replaced
-   * by the server's real endTs once that arrives; the fallback below is the
-   * same ISO-week rule the server uses, so the two agree even offline. */
+  /* ---------------- clocks ---------------- */
 
-  const DAY = 86400000;
+  const WEEK_MS = 7 * 86400000;
+  // Thursday 1970-01-01 was an ISO week day 4, so the first Monday of the
+  // epoch anchors the same grid server/core/sprint.js uses.
+  const FIRST_MONDAY_MS = 4 * 86400000;
+
+  /** Next Monday 00:00 UTC — the window rollover, fallback for the Sprint. */
+  function nextWeekStart(now) {
+    return FIRST_MONDAY_MS + (Math.floor((now - FIRST_MONDAY_MS) / WEEK_MS) + 1) * WEEK_MS;
+  }
 
   /** Next 00:00 UTC — the Spark rollover. */
   function nextUtcMidnight(now) {
@@ -42,166 +45,89 @@
     return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1);
   }
 
-  /** Next Monday 00:00 UTC — the ISO week the Sprint and clan season share. */
-  function nextIsoWeekStart(now) {
-    const d = new Date(now);
-    // getUTCDay: Sun=0 … Sat=6. Days until the next Monday, never 0.
-    const ahead = ((8 - d.getUTCDay()) % 7) || 7;
-    return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + ahead);
-  }
-
-  /** Next Friday 20:00 UTC — the Reckoning bell (server/core/reckoning.js). */
-  function nextReckoning(now) {
-    const d = new Date(now);
-    const ahead = (5 - d.getUTCDay() + 7) % 7;
-    let ts = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + ahead, 20);
-    if (ts <= now) ts += 7 * DAY;
-    return ts;
-  }
-
-  /** First of next month, 00:00 UTC — when a Wrapped month closes. */
-  function nextMonth(now) {
-    const d = new Date(now);
-    return Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 1);
-  }
-
-  // Sprint starts on the shared fallback and is overwritten by the API.
-  const deadlines = {
-    spark: nextUtcMidnight,
-    sprint: nextIsoWeekStart,
-    reckoning: nextReckoning,
-    wrapped: nextMonth,
-  };
-  let sprintEnd = 0;   // real endTs once /api/sprint/current answers
-
   /** "6d 05h", "05h 12m", "12m 40s" — two units is enough to act on. */
   function countdown(ms) {
     if (ms <= 0) return 'any moment';
     const s = Math.floor(ms / 1000);
+    const pad = (n) => String(n).padStart(2, '0');
     const d = Math.floor(s / 86400);
     const h = Math.floor((s % 86400) / 3600);
     const m = Math.floor((s % 3600) / 60);
-    const sec = s % 60;
-    const pad = (n) => String(n).padStart(2, '0');
     if (d > 0) return d + 'd ' + pad(h) + 'h';
     if (h > 0) return pad(h) + 'h ' + pad(m) + 'm';
-    return pad(m) + 'm ' + pad(sec) + 's';
+    return pad(m) + 'm ' + pad(s % 60) + 's';
   }
+
+  let sprintEnd = 0;   // real endTs once /api/sprint/current answers
 
   function tick() {
     const now = Date.now();
-    for (const el of document.querySelectorAll('[data-cd]')) {
-      const key = el.dataset.cd;
-      const at = (key === 'sprint' && sprintEnd > now)
-        ? sprintEnd
-        : (deadlines[key] ? deadlines[key](now) : 0);
-      el.textContent = at ? countdown(at - now) : '—';
-    }
+    const end = sprintEnd > now ? sprintEnd : nextWeekStart(now);
+    $('ev-clock').textContent = countdown(end - now);
+    const spark = $('spark-clock');
+    if (spark) spark.textContent = countdown(nextUtcMidnight(now) - now);
   }
-
   tick();
   setInterval(tick, 1000);
 
-  /* ---------------- live counts ---------------- */
+  /* ---------------- the board ---------------- */
 
   (async () => {
     try {
       const sprint = await get('/api/sprint/current');
       const end = Number(sprint && sprint.endTs) || 0;
       if (end > 0) sprintEnd = end;
+
       const n = Array.isArray(sprint && sprint.entries) ? sprint.entries.length : null;
       if (n !== null) {
-        $('ev-sprint-n').textContent = n === 0 ? 'nobody yet' : String(n);
+        $('ev-entrants').textContent = n === 0 ? 'nobody yet' : String(n);
       }
-      // A window that has already closed must not still read "Open now".
+      // A window already past must not still read "Open now".
       if (end > 0 && end <= Date.now()) {
-        const state = $('ev-sprint-state');
-        state.textContent = 'Between windows';
+        const state = $('ev-state');
+        state.textContent = 'Settling';
         state.className = 'tag';
       }
       tick();
     } catch (_) {
-      // Leave the em-dash. A failed read is not "nobody entered".
-      $('ev-sprint-n').textContent = 'unavailable';
+      // Leave it unread. A failed fetch is not "nobody entered".
+      $('ev-entrants').textContent = 'unavailable';
     }
   })();
 
-  (async () => {
+  /* ---------------- share ---------------- */
+
+  let toastTimer = 0;
+  function toast(text) {
+    const el = $('toast');
+    el.textContent = text;
+    el.classList.add('on');
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => el.classList.remove('on'), 2200);
+  }
+
+  $('ev-share').addEventListener('click', async () => {
+    const url = 'https://papertrench.com/events';
+    const share = {
+      title: 'Top of the Trench',
+      text: 'Finish #1 on the weekly PaperTrench board and the tag is yours. Free, paper money, real charts.',
+      url,
+    };
+    // navigator.share is the good path on phones and needs the user gesture
+    // we are already inside. A cancelled sheet rejects with AbortError, which
+    // is a choice rather than a failure — it must not fall through to a
+    // "copied" toast for a link the user just declined to send.
+    if (navigator.share) {
+      try { await navigator.share(share); return; }
+      catch (err) { if (err && err.name === 'AbortError') return; }
+    }
     try {
-      const body = await get('/api/clans');
-      const n = Number(body && body.clansTotal);
-      $('ev-clans-n').textContent = Number.isFinite(n) ? String(n) : 'unavailable';
+      await navigator.clipboard.writeText(url);
+      toast('Link copied — send it to someone');
     } catch (_) {
-      $('ev-clans-n').textContent = 'unavailable';
+      // Clipboard blocked (insecure origin, or permission refused): say what
+      // happened rather than claiming a copy that did not occur.
+      toast('Copy blocked — the link is papertrench.com/events');
     }
-  })();
-
-  /* ---------------- who is streaming ----------------
-   * Same probes /streams uses, and the same rule: a channel we cannot reach
-   * is UNKNOWN, never "offline". Only a positive answer counts as live. */
-
-  async function liveTwitch(login) {
-    try {
-      const r = await fetch(
-        `https://static-cdn.jtvnw.net/previews-ttv/live_user_${encodeURIComponent(login)}-80x45.jpg?t=${Date.now()}`,
-        { mode: 'cors', cache: 'no-store' });
-      if (!r.ok) return null;
-      return !r.url.includes('404_preview');
-    } catch (_) { return null; }
-  }
-
-  async function liveKick(slug) {
-    try {
-      const r = await fetch('https://kick.com/api/v2/channels/' + encodeURIComponent(slug),
-        { mode: 'cors', cache: 'no-store' });
-      if (r.status === 404) return false;
-      if (!r.ok) return null;
-      const body = await r.json();
-      return !!(body && body.livestream && body.livestream.is_live === true);
-    } catch (_) { return null; }
-  }
-
-  (async () => {
-    // The hand-maintained names on /streams are the floor: an empty or
-    // unreachable roster API must not read as "nobody streams here".
-    const seeds = [
-      { name: 'OnlyTerp', platform: 'twitch', login: 'onlyterp' },
-      { name: 'Ark1317', platform: 'kick', channel: 'ark1317' },
-    ];
-    try {
-      const body = await get('/api/streamer/roster');
-      for (const row of (Array.isArray(body && body.streamers) ? body.streamers : [])) {
-        const login = String((row && row.login) || '').toLowerCase();
-        if (login && !seeds.some((s) => s.login === login)) {
-          seeds.push({ name: row.name || login, platform: 'twitch', login });
-        }
-      }
-    } catch (_) { /* seeds stand */ }
-
-    const results = await Promise.all(seeds.map(async (s) => (
-      s.platform === 'kick' ? await liveKick(s.channel) : await liveTwitch(s.login)
-    )));
-    const live = results.filter((up) => up === true).length;
-    const known = results.filter((up) => up !== null).length;
-
-    const nEl = $('ev-live-n');
-    const line = $('ev-live-line');
-    const tags = $('ev-live-tags');
-
-    if (!known) {
-      nEl.textContent = 'unavailable';
-      line.textContent = 'Live status could not be checked from here right now.';
-      return;
-    }
-
-    nEl.textContent = String(live);
-    if (live > 0) {
-      line.textContent = live === 1
-        ? 'Somebody is running the challenge live right now.'
-        : `${live} streamers are running the challenge live right now.`;
-      tags.innerHTML = '<span class="tag live"><span class="dot"></span>Live</span>';
-    } else {
-      line.textContent = 'Nobody is live this minute — the roster and past runs are on the streams page.';
-    }
-  })();
+  });
 })();

--- a/site/profile.html
+++ b/site/profile.html
@@ -144,6 +144,23 @@
    sizing. Colour and hatching stay exactly as arena.css defines them. */
 .ar-prof-chips .ar-chip { font-size: 10.5px; padding: 5px 11px; }
 
+/* The weekly crown: weeks this account finished #1 on the Sprint board.
+   Gold is the board's rank-1 colour everywhere on this site, and that is the
+   one thing the chip borrows. It sits BESIDE the badge case rather than in
+   it — the case is process claims derived from the chain, and a crown is a
+   placement record, which is a different kind of statement. */
+.ar-crown {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 10px 4px 8px; border-radius: 999px; vertical-align: middle;
+  background: linear-gradient(135deg, rgba(255,192,129,0.2), rgba(255,157,69,0.1));
+  border: 1px solid rgba(255,192,129,0.45); cursor: help;
+}
+.ar-crown .n {
+  font-family: var(--mono); font-size: 12.5px; font-weight: 800;
+  color: var(--orange2); letter-spacing: -0.02em;
+}
+.ar-crown .w { font-family: var(--mono); font-size: 10.5px; color: var(--dim); }
+
 .ar-prof .ar-spec { margin-top: 24px; }
 
 @media (max-width: 560px) {
@@ -623,6 +640,30 @@
       Their record above is all-time and is a different figure by design.</p>`;
   }
 
+  /* The weekly crown: weeks this account finished #1 on the Sprint board.
+   *
+   * Deliberately NOT filed with the badges. Every badge in the case is a
+   * process claim derived from the chain (server/core/achievements.js is
+   * explicit that there are no profit, streak or volume badges); a crown is a
+   * record of PLACEMENT on a board that is already public. Mixing the two
+   * would quietly turn the badge case into something it refuses to be, so the
+   * crown sits beside them and its tooltip states exactly what it means. */
+  function crownChip(crowns) {
+    const list = Array.isArray(crowns) ? crowns : [];
+    if (!list.length) return '';
+    const weeks = list.map((c) => c.weekId).filter(Boolean);
+    const shown = weeks.slice(0, 3).join(', ');
+    const more = weeks.length > 3 ? ` +${weeks.length - 3} more` : '';
+    const title = `Finished #1 on the weekly board: ${shown}${more}. `
+      + 'Awarded when the week closes and kept permanently. It records where '
+      + 'this account placed on a public board — it is not a claim about how '
+      + 'well they traded.';
+    return `<span class="ar-crown" title="${esc(title)}">
+      <span class="n">#1</span>
+      <span class="w">&times;${weeks.length}</span>
+    </span>`;
+  }
+
   function renderHero(profile, record) {
     const tier = record ? topTier(record.badges) : null;
     const nameLine = profile.displayName && profile.displayName !== profile.handle
@@ -667,9 +708,13 @@
             <h1 class="ar-prof-handle">@${esc(profile.handle)}</h1>
             ${nameLine}
             <div class="ar-prof-chips">
+              
               ${record ? chipFor(record.status) : '<span class="ar-provisional">No record submitted</span>'}
+              
               ${profile.clan ? L.clanTag(profile.clan.tag, { title: profile.clan.name }) : ''}
+              
               ${record && !(record.stats.rankable && record.status === 'verified') ? '<span class="ar-provisional">Unranked · ' + (record.status === 'verified' ? '5 rounds minimum' : 'verification pending') + '</span>' : ''}
+              
               ${tier ? `<div class="ar-badge t-${esc(tier)}" title="Highest badge tier in this trader's case. The card's edge follows it."><div class="mark" aria-hidden="true">★</div><div><div class="nm">${esc(tier[0].toUpperCase() + tier.slice(1))} case</div><div class="ev">${esc(String((record.badges || []).length))} badge${(record.badges || []).length === 1 ? '' : 's'} earned</div></div></div>` : ''}
             </div>
             ${clanLine(profile.clan, record)}
@@ -841,12 +886,15 @@
           const unit = badge.evidence ? String(badge.evidence.unit || '') : '';
           const evidence = badge.evidence
             ? fmt(badge.evidence.value, Number.isInteger(Number(badge.evidence.value)) ? 0 : 2)
+              
               + (/^[%x]/.test(unit) ? '' : ' ') + unit
             : '';
           return `<div class="ar-badge t-${esc(tier)}" title="${esc(badge.blurb || '')}">
             <div class="mark" aria-hidden="true">${esc(mark)}</div>
             <div>
+              
               <div class="nm">${esc(badge.name)}</div>
+              
               ${evidence ? `<div class="ev">${esc(evidence.trim())}</div>` : ''}
             </div>
           </div>`;

--- a/site/sprint.html
+++ b/site/sprint.html
@@ -256,9 +256,9 @@
         </div>
       </section>
 
-      <section class="ar-pane" aria-labelledby="rules-h">
-        <div class="ar-pane-head"><span class="glyph">§</span>
-          <span id="rules-h">How the sprint works</span></div>
+      <details class="ar-pane ar-doc" aria-labelledby="rules-h">
+        <summary class="ar-pane-head"><span class="glyph">§</span>
+          <span id="rules-h">How the sprint works</span><span class="doc-tag">Reference</span><svg class="doc-chev" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg></summary>
         <div class="pad">
           <p class="ar-note" style="margin-bottom:14px">Four rules. The chain enforces all of
             them, which is why there are only four.</p>
@@ -296,7 +296,7 @@
           <p class="ar-note" style="margin-top:16px">Full protocol:
             <a href="https://github.com/OnlyTerp/papertrench/blob/main/docs/LEADERBOARD.md" target="_blank" rel="noopener">docs/LEADERBOARD.md</a></p>
         </div>
-      </section>
+      </details>
     </div>
 
     <div class="ar-stack">
@@ -308,9 +308,9 @@
         </div>
       </section>
 
-      <section class="ar-pane" aria-labelledby="formula-h">
-        <div class="ar-pane-head"><span class="glyph" style="color:var(--violet)">ƒ</span>
-          <span id="formula-h">The week's slice, scored</span></div>
+      <details class="ar-pane ar-doc" aria-labelledby="formula-h">
+        <summary class="ar-pane-head"><span class="glyph" style="color:var(--violet)">ƒ</span>
+          <span id="formula-h">The week's slice, scored</span><span class="doc-tag">Reference</span><svg class="doc-chev" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m6 9.5 6 6 6-6"/></svg></summary>
         <div class="pad">
           <p class="ar-note" style="margin-bottom:14px">The same three terms the all-time board
             uses, run over seven days instead of a career. Run it yourself over the week's fills
@@ -318,7 +318,7 @@
             whoever currently leads the week:</p>
           <div id="formula"><p class="ar-note">Loading.</p></div>
         </div>
-      </section>
+      </details>
     </div>
 
   </div>


### PR DESCRIPTION
Two things, both the same complaint: the pages put words in front of the thing people came for.

---

## 1 · `/events` — one event, one prize

The page was three panels and the third was the verifier tape: six rows of `rejected — chain-replaced`. That is diagnostic output, not an event, and a wall of red is the worst available read of a healthy product. **The tape stays on `/leaderboard`.**

What is left is the one thing with a deadline and a prize — a single centred card for the weekly board, with art, a countdown, a share button, and the tag it pays out.

### The crown is real

| Piece | What it does |
|---|---|
| `sprint_winners` | one row per **closed** week, `week_id` as the primary key |
| `settleSprintCrown` | a cron lane that claims that row once |
| `#1 ×N` | on the profile, and a count on the leaderboard |

- **Never mid-week.** Only `lastClosedWindow()` settles. A crown handed out while the week runs names a *leader*, not a winner.
- **Never twice.** `week_id` is the PK and the insert is `OR IGNORE` — a retried cron, a restart, or two concurrent ticks all collapse to one row.
- **Never invented.** Eligibility is copied from `handleSprint`, so a pending, banned or disqualified account cannot be crowned by a path that forgot about them. A week with nobody eligible stays **uncrowned**.

### Why it is not a badge

`achievements.js` is explicit that there are **no profit, streak or volume badges**, and the weekly score is ROI-weighted. Filing a crown in the badge case would turn the case into the thing it refuses to be.

So a crown records **placement on a board that is already public**. It sits beside the case, and the hover text says exactly that:

> **Finished #1 on the weekly board.** Awarded when the week closes and kept permanently, with the week it was won for. It records where you placed on a public board — it does not claim you traded well, and it can never be bought or transferred.

Happy to drop the crown and keep just the redesign if you would rather the doctrine stay absolute.

---

## 2 · `/sprint`, `/clans`, `/duels` — reference panes collapse

Same problem, measured. Live content vs reference prose:

| Page | Board / tools | Prose |
|---|---|---|
| `/sprint` | 491 chars | **1,665** |
| `/clans` | 63 chars | **2,541** |
| `/duels` | 648 chars | **3,577** |

On `/clans` that is forty times more rules than board. `/duels` stacked four full prose panes under four small tools.

Reference panes are now collapsed by default. **Nothing is deleted** — every word stays on the page, because a rule you cannot read is a rule you cannot check. It just stops competing with the standings.

`<details>` rather than a JS toggle: keyboard- and screen-reader-operable for free, findable by the browser's in-page search, deep-linkable by id, no state across a re-render. One shared `.ar-doc` in `arena.css`, since all three pages already share `.ar-pane`.

**Deliberately untouched:** each page's hero (title, lede and spec strip are identity, not clutter), and the clan-rules aside — already five compact lines, and carrying a comment explaining why it must not look like a live feed.

---

## Found on the way

- **`.ev-card` is a `<section>`,** and `style.css` sets `section { padding: 110px 0 }` — 110px of dead space between the card border and its own artwork. (`.ar-pane` already documents this exact trap; the new card just wasn't using it.)
- **A self-referential test stub.** `worker.test.js` did `Date.now = () => reckoningBellTs() + 3600000`, and that helper reads `Date.now()`. It survived only because the broken env made both cron lanes throw before either asked the time; the crown lane asks directly and blew the stack.

## Verification

Extension **2148**, server **297** (8 new crown tests), all site guards — nav (30 pages), a11y, URL spelling, sitemap, schema drift (21 tables). Rendered and clicked through locally on all four pages: countdown, tooltip, share fallback, `crownChip` across 0/1/4, and every collapsed pane opened.

> ⚠️ **Run `schema.sql` before deploying.** `/api/leaderboard` counts `sprint_winners` and `/api/profile` selects from it, so an un-migrated database fails *those two routes* at prepare time, not just the crown. Nothing backfills — earlier weeks stay uncrowned because their boards were never frozen.