### PR TITLE
feat(spark): the Daily Spark becomes playable, and practice never runs out

### DIFF
--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -910,22 +910,38 @@
     .spark-head { display: flex; align-items: baseline; gap: 12px; margin: 4px 0 10px; }
     .spark-title { font-size: 13px; font-weight: 800; letter-spacing: 1.4px; color: var(--text); }
     .spark-date { font-size: 12px; color: var(--dim); }
+    .spark-about { font-size: 12.5px; color: var(--muted, #8b93a7); line-height: 1.55;
+      margin: 0 0 12px; max-width: 640px; }
     .spark-body { max-width: 720px; }
     .spark-chart { position: relative; border: 1px solid rgba(255,255,255,0.10);
       border-radius: 10px; padding: 10px; background: rgba(10,13,19,0.5); }
-    .spark-canvas { width: 100%; height: auto; display: block; }
+    .spark-canvas { width: 100%; height: auto; display: block; cursor: crosshair; }
     .spark-chart-legend { display: flex; gap: 14px; margin-top: 8px; font-size: 11px; color: var(--dim); }
     .spark-legend-item { display: inline-flex; align-items: center; gap: 5px; }
     .spark-legend-item i { width: 10px; height: 10px; border-radius: 2px; display: inline-block; }
-    .spark-actions { display: flex; gap: 8px; margin: 12px 0 6px; }
+    .spark-lane-key { background: rgba(255,157,69,0.18);
+      border: 1px dashed rgba(255,157,69,0.55); border-radius: 2px; }
+    .spark-hint { font-size: 12.5px; color: var(--dim); margin: 10px 0 0; line-height: 1.5; min-height: 1.5em; }
+    .spark-picks { display: flex; flex-direction: column; gap: 6px; margin: 10px 0 0; }
+    .spark-pick { display: flex; align-items: center; gap: 10px; font-size: 12.5px;
+      border: 1px solid rgba(255,255,255,0.10); border-radius: 8px; padding: 6px 10px;
+      background: rgba(255,255,255,0.03); max-width: 480px; }
+    .spark-pick-name { display: inline-flex; align-items: center; gap: 6px; font-weight: 750; }
+    .spark-pick-name i { width: 9px; height: 9px; border-radius: 2px; display: inline-block; }
+    .spark-pick-min { color: var(--dim); }
+    .spark-pick-ctl { margin-left: auto; display: inline-flex; gap: 4px; }
+    .spark-pick-ctl button { border: 1px solid rgba(255,255,255,0.16); border-radius: 6px;
+      background: rgba(255,255,255,0.04); color: var(--text); cursor: pointer;
+      min-width: 26px; height: 24px; font-size: 13px; line-height: 1; }
+    .spark-pick-ctl button:hover:not(:disabled) { border-color: var(--accent, #FF9D45); }
+    .spark-pick-ctl button:disabled { opacity: 0.4; cursor: default; }
+    .spark-actions { display: flex; gap: 8px; margin: 12px 0 6px; flex-wrap: wrap; }
     .spark-btn { border: 1px solid rgba(255,255,255,0.18); border-radius: 8px;
       padding: 8px 14px; font-size: 12.5px; font-weight: 750; letter-spacing: 0.8px;
       background: rgba(255,255,255,0.04); color: var(--text); cursor: pointer; }
     .spark-btn:hover:not(:disabled) { border-color: var(--accent, #FF9D45); color: var(--accent, #FF9D45); }
     .spark-btn:disabled { opacity: 0.4; cursor: default; }
     .spark-btn.armed { border-color: var(--green); color: var(--green); }
-    .spark-buy.armed { border-color: var(--green); color: var(--green); }
-    .spark-sell.armed { border-color: var(--red); color: var(--red); }
     .spark-verdict { margin-top: 14px; border: 1px solid rgba(255,255,255,0.12);
       border-radius: 10px; padding: 14px; background: rgba(10,13,19,0.5); }
     .spark-grade { font-size: 64px; font-weight: 800; line-height: 1; }
@@ -933,7 +949,7 @@
     .spark-axis-line { font-size: 12.5px; color: var(--dim); margin-top: 8px; }
     .spark-story { font-size: 12.5px; color: var(--muted, #8b93a7); margin-top: 10px; line-height: 1.5; }
     .spark-share-row { margin-top: 12px; }
-    .spark-error { color: var(--red); font-size: 12.5px; }
+    .spark-error { color: var(--red); font-size: 12.5px; margin: 8px 0 0; }
 
     /* ---- Trench Wrapped (B1) ---- */
     .wr-head { margin: 4px 0 10px; }

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -5434,6 +5434,15 @@ init().catch(renderInitError);
  * The fetch is a blind read: the server truncates bars at the reveal
  * moment, so nothing here can leak the future. */
 let sparkLoaded = false;
+/* Load-failure copy per server reason. The reason is real information —
+ * "the pool is empty until someone trades" and "the network hiccuped" ask
+ * for different patience — and a bare code is for the console, not people. */
+const SPARK_LOAD_COPY = {
+  'no-pool': 'The puzzle pool is empty — it fills as people trade. Check back later.',
+  'no-data': "The grader couldn't pull chart data right now. Try again in a minute.",
+  'no-pick': "Today's candidates couldn't host a puzzle. Try again in a minute.",
+  'no-window': "Today's puzzle hit a snag mid-day. Try again in a minute.",
+};
 function renderSpark(el) {
   const spark = window.PTSpark;
   if (!spark) {
@@ -5443,21 +5452,32 @@ function renderSpark(el) {
   if (sparkLoaded) return; // already rendered this session
   el.innerHTML = '<p class="dim" style="margin:10px 0">Loading today\'s puzzle…</p>';
   fetch(spark.API + '/api/spark/today', { credentials: 'omit', cache: 'no-store' })
-    .then((res) => {
-      if (!res.ok) throw new Error('HTTP ' + res.status);
-      return res.json();
-    })
-    .then((body) => {
+    .then((res) => res.json().then((body) => ({ ok: res.ok, body })).catch(() => ({ ok: res.ok, body: null })))
+    .then(({ ok, body }) => {
+      if (!ok || !body || !body.ok) {
+        throw Object.assign(new Error((body && body.reason) || 'HTTP error'), {
+          sparkReason: (body && body.reason) || 'network',
+        });
+      }
       const model = spark.sparkModel(body);
-      if (!model) throw new Error('unexpected shape');
+      if (!model) throw Object.assign(new Error('unexpected shape'), { sparkReason: 'bad-payload' });
       sparkLoaded = true;
       spark.renderSpark(el, model);
     })
     .catch((err) => {
-      console.warn('PaperTrench: spark unavailable —', err.message);
-      el.innerHTML = `<p class="dim" style="margin:10px 0">Couldn't load today's puzzle just now.
-        <button type="button" class="linkish" id="spark-retry">Try again</button></p>`;
+      console.warn('PaperTrench: spark unavailable —', err.sparkReason || err.message);
+      const why = SPARK_LOAD_COPY[err.sparkReason]
+        || (err.sparkReason === 'network'
+          ? 'Couldn\'t reach the grader — check your connection.'
+          : 'The daily puzzle is unavailable right now.');
+      el.innerHTML = `<p class="dim" style="margin:10px 0">${why}
+        <button type="button" class="linkish" id="spark-retry">Try again</button>
+        · <button type="button" class="linkish" id="spark-practice-anyway">Play a practice round</button></p>`;
       const retry = el.querySelector('#spark-retry');
       if (retry) retry.addEventListener('click', () => { sparkLoaded = false; renderSpark(el); });
+      const anyway = el.querySelector('#spark-practice-anyway');
+      // Practice is a separate pick path — when the daily puzzle is down it
+      // can still be up, and even when it isn't, trying costs nothing.
+      if (anyway) anyway.addEventListener('click', () => spark.loadPractice(el));
     });
 }

--- a/extension/spark.js
+++ b/extension/spark.js
@@ -1,15 +1,20 @@
 /* PaperTrench extension — Daily Spark (DELIGHT-MAP.md A2) client.
  *
  * A blind puzzle: the dashboard shows the day's chart up to the reveal
- * moment T, the player picks a buy/sell moment, then gets a process grade
- * (S/A/B/C/D/F + tone axes) — NEVER a PnL figure. The whole point is the
- * discipline of a call, not the money on it.
+ * moment T, the player marks an entry (and an exit, or neither) INSIDE the
+ * sixty minutes after T — the hour they never get to see — then gets a
+ * process grade (S/A/B/C/D/F + tone axes). NEVER a PnL figure. The whole
+ * point is the discipline of a call, not the money on it.
+ *
+ * How a pick is made: taps (or the +/- steppers) place minutes-after-T, so
+ * every action the server receives is bar-aligned and inside its window by
+ * construction. The wall-clock is never sent — the puzzle's tape is history,
+ * and "now" has nothing to do with it.
  *
  * Two responsibilities, mirroring pnlcard.js:
- *   - sparkModel(api)   — pure: turns the /api/spark/today payload into the
- *                         exact strings/colors/visibility the UI shows.
- *                         No DOM, no canvas.
- *   - renderSpark(el)   — paints that model into the dashboard section.
+ *   - pure helpers (sparkModel, planActions, chartGeom, revealModel,
+ *     gradeErrorCopy) — no DOM, no canvas, behaviour-tested in test/.
+ *   - renderSpark(el) — paints the puzzle and owns its interaction.
  *
  * The share card reuses the existing PTPnlCard painter via
  * sparkCardModel(): it ONLY paints the process-grade story, never a PnL.
@@ -18,6 +23,11 @@
   'use strict';
 
   const API = 'https://papertrench-api.onerobby.workers.dev';
+
+  const MIN_MS = 60000;
+  // The server grades exactly sixty one-minute bars after the cutoff
+  // (core/spark.js AFTERMATH_BARS). The lane is that hour, drawn.
+  const FUTURE_MIN = 60;
 
   const GRADE_STYLE = {
     S: { color: '#7C3AED', label: 'S — flawless read' },
@@ -32,6 +42,8 @@
     yellow: { color: '#FF9D45', label: 'okay' },
     red: { color: '#FF5F56', label: 'bad' },
   };
+  const ENTRY_COLOR = '#34D399';
+  const EXIT_COLOR = '#FFC24B';
 
   function num(value) {
     const parsed = Number(value);
@@ -50,17 +62,21 @@
     return '0.' + '0'.repeat(leadingZeros) + String(Number(significant.toFixed(3))).replace('.', '');
   }
 
-  /** Pure: payload -> display model. Returns null on any invalid shape. */
-  function sparkModel(api) {
-    if (!api || typeof api !== 'object') return null;
-    if (!api.ok || !api.day || !api.mint || !api.tTs) return null;
-    if (!Array.isArray(api.bars) || !api.bars.length) return null;
-    const bars = api.bars
+  /** Normalize an OHLC array: finite numbers only, ascending by ts. */
+  function normBars(arr) {
+    return (Array.isArray(arr) ? arr : [])
       .map((b) => ({
-        ts: num(b.ts), o: num(b.o), h: num(b.h), l: num(b.l), c: num(b.c),
+        ts: num(b && b.ts), o: num(b && b.o), h: num(b && b.h), l: num(b && b.l), c: num(b && b.c),
       }))
       .filter((b) => b.ts !== null && b.o !== null && b.h !== null && b.l !== null && b.c !== null)
       .sort((a, b) => a.ts - b.ts);
+  }
+
+  /** Pure: /api/spark/today payload -> display model. Returns null on any invalid shape. */
+  function sparkModel(api) {
+    if (!api || typeof api !== 'object') return null;
+    if (!api.ok || !api.day || !api.mint || !api.tTs) return null;
+    const bars = normBars(api.bars);
     if (!bars.length) return null;
     const last = bars[bars.length - 1];
     const first = bars[0];
@@ -74,6 +90,118 @@
       changePct: first.c > 0 ? ((last.c - first.c) / first.c) * 100 : 0,
       dateText: new Date(num(api.tTs)).toISOString().slice(0, 10),
     };
+  }
+
+  /** Pure: grade response -> the aftermath the lane reveals. Null on bad shape. */
+  function revealModel(api) {
+    if (!api || typeof api !== 'object' || !api.ok) return null;
+    const bars = normBars(api.reveal && api.reveal.bars);
+    return bars.length ? { bars } : null;
+  }
+
+  /* ---------------- the plan (pure) ----------------
+   *
+   * A plan is { pass, entryMin, exitMin } — minutes AFTER the cutoff, 1..60.
+   * Invariants: exit, when set, is strictly after entry; pass clears picks.
+   * planActions() turns a plan into exactly the action list the server's
+   * validateActions accepts: [{pass}] | [{buy}] | [{buy},{sell}].
+   */
+  function clampMinute(k) {
+    return Math.max(1, Math.min(FUTURE_MIN, Math.round(Number(k) || 0)));
+  }
+
+  /** Place an entry; keeps the exit invariant (clamps it forward, or drops
+   * it when an entry on the last minute leaves no legal exit after it). */
+  function planWithEntry(plan, minute) {
+    const entryMin = clampMinute(minute);
+    const next = { pass: false, entryMin, exitMin: plan.exitMin };
+    if (next.exitMin !== null && next.exitMin <= entryMin) {
+      next.exitMin = entryMin < FUTURE_MIN ? entryMin + 1 : null;
+    }
+    return next;
+  }
+
+  /** Place an exit; ignored (null) when there is no entry to exit from, or
+   * when the entry is on the last minute — there is no legal later exit. */
+  function planWithExit(plan, minute) {
+    if (plan.entryMin === null) return null;
+    if (plan.entryMin >= FUTURE_MIN) return null;
+    const exitMin = clampMinute(Math.max(minute, plan.entryMin + 1));
+    return { pass: false, entryMin: plan.entryMin, exitMin };
+  }
+
+  /** The action list for the grader, or null when the plan has nothing to send. */
+  function planActions(plan, tTs) {
+    if (!plan || !Number.isFinite(tTs)) return null;
+    if (plan.pass) return [{ type: 'pass', ts: tTs + MIN_MS }];
+    if (plan.entryMin === null) return null;
+    const actions = [{ type: 'buy', ts: tTs + plan.entryMin * MIN_MS }];
+    if (plan.exitMin !== null) actions.push({ type: 'sell', ts: tTs + plan.exitMin * MIN_MS });
+    return actions;
+  }
+
+  /* ---------------- geometry (pure) ----------------
+   *
+   * One continuous time axis: the cutoff T sits at 3/4 of the width, the
+   * unknown hour fills the rest. Drawing, hit-testing and markers all read
+   * the same geom, so a tap and its marker can never disagree.
+   */
+  function chartGeom(w, h, nBars) {
+    const pad = 8;
+    const laneFrac = 0.25;
+    const tX = pad + (w - pad * 2) * (1 - laneFrac);
+    return {
+      w, h, pad, tX,
+      minuteX: (k) => tX + (k / FUTURE_MIN) * (w - pad - tX),
+    };
+  }
+
+  /** Canvas x -> minute after the cutoff (1..60), or null when the tap fell
+   * on the seen tape (left of the line) where there is nothing to place. */
+  function xToMinute(px, geom) {
+    const rel = (px - geom.tX) / (geom.w - geom.pad - geom.tX);
+    if (rel < 0) return null;
+    return clampMinute(rel * FUTURE_MIN);
+  }
+
+  /** Price range over seen bars plus aftermath (when revealed) for one y axis. */
+  function priceRange(bars, aftermath) {
+    let min = Infinity;
+    let max = -Infinity;
+    for (const b of bars) {
+      if (b.l < min) min = b.l;
+      if (b.h > max) max = b.h;
+    }
+    for (const b of aftermath || []) {
+      if (b.l < min) min = b.l;
+      if (b.h > max) max = b.h;
+    }
+    if (!Number.isFinite(min) || !Number.isFinite(max)) return { min: 0, max: 1 };
+    return { min, max: max === min ? min + 1 : max };
+  }
+
+  /* ---------------- error copy (pure) ---------------- */
+
+  const GRADE_ERROR = {
+    'wrong-day': "This puzzle has ended — a new day's chart is live. Reload the dashboard to play today's.",
+    'no-data': "The grader couldn't load today's chart. Try again in a minute.",
+    'no-window': "This puzzle has ended — reload the dashboard for today's chart.",
+    'rate-limited': "Too many grades in a row — wait a minute and try again.",
+    'busy': "The grader is busy right now — try again in a moment.",
+  };
+  // Everything the validator can throw at a well-formed plan means the picks
+  // and the window disagreed — one sentence covers them all.
+  const PLAN_MISMATCH = "Your picks didn't line up with the puzzle's window — start over and place them again.";
+  const NETWORK_ERROR = "Couldn't reach the grader — check your connection and try again.";
+  const FALLBACK_ERROR = "Couldn't grade just now — try again in a moment.";
+
+  function gradeErrorCopy(reason) {
+    if (reason === 'network') return NETWORK_ERROR;
+    if (GRADE_ERROR[reason]) return GRADE_ERROR[reason];
+    if (['bad-action', 'action-out-of-window', 'empty', 'pass-not-alone', 'must-open', 'must-close', 'too-many', 'non-monotonic'].includes(reason)) {
+      return PLAN_MISMATCH;
+    }
+    return FALLBACK_ERROR;
   }
 
   /** The share-card model: process-grade story ONLY, never a PnL figure. */
@@ -101,107 +229,291 @@
     };
   }
 
-  /** Render the spark section into `el` (a #spark-section container). */
-  function renderSpark(el, model) {
+  /* ---------------- rendering ---------------- */
+
+  /** A fresh practice-seed: any 31-bit number; the server pins a puzzle to
+   * it, so the same number is always the same chart. */
+  function practiceSeed() {
+    return Math.floor(Math.random() * 2 ** 31);
+  }
+
+  /** Fetch a practice puzzle for `seed` and render it over the section.
+   * Self-contained so BOTH the practice button and the daily view's
+   * load-failure fallback can offer a round without the dashboard mount
+   * knowing practice exists. Returns a promise for testability. */
+  async function loadPractice(el, seed) {
+    const s = Number.isInteger(seed) ? seed : practiceSeed();
+    try {
+      const res = await fetch(API + '/api/spark/practice?seed=' + s, { cache: 'no-store' });
+      const body = await res.json().catch(() => null);
+      if (!res.ok || !body || !body.ok) {
+        throw Object.assign(new Error((body && body.reason) || 'HTTP ' + res.status), {
+          sparkReason: (body && body.reason) || 'HTTP ' + res.status,
+        });
+      }
+      const model = sparkModel(body);
+      if (!model) throw new Error('bad-payload');
+      renderSpark(el, model, { practice: true });
+    } catch (err) {
+      console.warn('PaperTrench: spark practice failed —', err && err.sparkReason ? err.sparkReason : err);
+      if (el) {
+        el.innerHTML = '<p class="spark-error">Practice is unavailable right now — try again in a moment. '
+          + '<button type="button" class="linkish" id="spark-practice-retry">Try again</button></p>';
+        const retry = el.querySelector('#spark-practice-retry');
+        if (retry) retry.addEventListener('click', () => loadPractice(el));
+      }
+    }
+  }
+
+  /** Render the spark section into `el` (a #spark-section container).
+   * opts.practice marks a practice round: the seed becomes the headline and
+   * the loop button reads NEXT PUZZLE. */
+  function renderSpark(el, model, opts) {
     if (!el || !model) return;
+    const practice = !!(opts && opts.practice);
     el.innerHTML = '';
     const head = document.createElement('div');
     head.className = 'spark-head';
     head.innerHTML = `
       <div class="spark-title">DAILY SPARK</div>
-      <div class="spark-date">${model.dateText}</div>
+      <div class="spark-date">${practice
+        ? 'Practice round · seed ' + String(model.day).replace(/^practice-/, '')
+        : model.dateText}</div>
     `;
     el.appendChild(head);
+
+    const about = document.createElement('p');
+    about.className = 'spark-about';
+    about.textContent = practice
+      ? 'Same game as the daily, unlimited: a real launch with the name hidden, played blind. Tap the shaded lane where you\'d get in and out — you\'re graded on entry, exit and nerve, never on money.'
+      : 'One real launch a day, name hidden. The tape stops at the line — the shaded lane is the next hour, which you never get to see. Tap the lane where you\'d get in and out. You\'re graded on entry, exit and nerve — never on money. Want more than one a day? Practice rounds are unlimited.';
+    el.appendChild(about);
 
     const body = document.createElement('div');
     body.className = 'spark-body';
     body.innerHTML = `
       <div class="spark-chart">
-        <canvas class="spark-canvas" width="640" height="220"></canvas>
+        <canvas class="spark-canvas" width="760" height="230" role="img"></canvas>
         <div class="spark-chart-legend">
           <span class="spark-legend-item"><i style="background:${TONE.green.color}"></i> entry</span>
-          <span class="spark-legend-item"><i style="background:${TONE.yellow.color}"></i> exit</span>
+          <span class="spark-legend-item"><i style="background:${EXIT_COLOR}"></i> exit</span>
+          <span class="spark-legend-item"><i class="spark-lane-key"></i> the unknown hour</span>
         </div>
       </div>
+      <p class="spark-hint" role="status" aria-live="polite"></p>
+      <div class="spark-picks"></div>
       <div class="spark-actions">
-        <button type="button" class="spark-btn spark-buy">BUY</button>
-        <button type="button" class="spark-btn spark-sell">SELL</button>
+        <button type="button" class="spark-btn spark-pass">I'D SIT THIS ONE OUT</button>
+        <button type="button" class="spark-btn spark-reset" hidden>START OVER</button>
         <button type="button" class="spark-btn spark-reveal" disabled>REVEAL GRADE</button>
+        <button type="button" class="spark-btn spark-practice" title="${practice ? 'Another random blind chart' : 'Unlimited rounds on random blind charts'}">${practice ? 'NEXT PUZZLE' : 'PRACTICE'}</button>
       </div>
+      <p class="spark-error" hidden></p>
       <div class="spark-verdict" hidden></div>
     `;
     el.appendChild(body);
 
-    drawChart(body.querySelector('.spark-canvas'), model.bars, model.tTs);
-
-    const buyBtn = body.querySelector('.spark-buy');
-    const sellBtn = body.querySelector('.spark-sell');
+    const canvas = body.querySelector('.spark-canvas');
+    const hintEl = body.querySelector('.spark-hint');
+    const picksEl = body.querySelector('.spark-picks');
+    const passBtn = body.querySelector('.spark-pass');
+    const resetBtn = body.querySelector('.spark-reset');
     const revealBtn = body.querySelector('.spark-reveal');
+    const practiceBtn = body.querySelector('.spark-practice');
+    const errorEl = body.querySelector('.spark-error');
     const verdictBox = body.querySelector('.spark-verdict');
 
-    const state = { buy: null, sell: null };
+    const geom = chartGeom(canvas.width, canvas.height, model.bars.length);
+    let plan = { pass: false, entryMin: null, exitMin: null };
+    let aftermath = null; // bars revealed with the verdict
 
-    const updateButtons = () => {
-      buyBtn.classList.toggle('armed', Boolean(state.buy));
-      sellBtn.classList.toggle('armed', Boolean(state.sell));
-      revealBtn.disabled = !(state.buy && state.sell);
+    const paint = () => {
+      drawChart(canvas, model.bars, model.tTs, {
+        futureMin: FUTURE_MIN,
+        aftermath: aftermath ? aftermath.bars : null,
+        entryMin: plan.entryMin,
+        exitMin: plan.exitMin,
+      });
+      const label = `Blind chart: ${model.bars.length} one-minute candles ending at the cutoff line. `
+        + `The shaded lane is the next ${FUTURE_MIN} minutes.`
+        + (plan.pass ? ' You chose to sit this one out.'
+          : plan.entryMin === null ? ''
+            : ` Entry ${plan.entryMin} minutes after the cutoff.`
+              + (plan.exitMin === null ? ' Holding to the end of the window.' : ` Exit ${plan.exitMin} minutes after the cutoff.`));
+      canvas.setAttribute('aria-label', label);
     };
 
-    buyBtn.addEventListener('click', () => {
-      state.buy = Date.now();
-      updateButtons();
+    const hintFor = () => {
+      if (aftermath) return 'The lane now shows the tape you didn\'t get — your call was graded against exactly this.';
+      if (plan.pass) return 'You\'d sit this one out. Reveal to see whether the pass was the right call.';
+      if (plan.entryMin === null) return 'Tap the shaded lane where you\'d get in — minute 1 is just after the line, 60 is the end. The +/- buttons work too.';
+      if (plan.exitMin === null) return `Entry +${plan.entryMin}m. Now tap when you'd get out — or leave it unset to hold to the end of the hour.`;
+      return `Entry +${plan.entryMin}m, exit +${plan.exitMin}m. Tap near a marker to move it, or reveal.`;
+    };
+
+    const setLocked = (locked) => {
+      // The practice button is deliberately NOT locked: the loop is the
+      // feature — a verdict never traps the player, another round is always
+      // one click away.
+      for (const b of [passBtn, revealBtn, ...picksEl.querySelectorAll('button')]) b.disabled = locked;
+      resetBtn.hidden = !locked;
+    };
+
+    const renderPicks = () => {
+      picksEl.innerHTML = '';
+      const mkRow = (name, color, minute, onNudge, onClear) => {
+        const row = document.createElement('div');
+        row.className = 'spark-pick';
+        row.innerHTML = `
+          <span class="spark-pick-name"><i style="background:${color}"></i> ${name}</span>
+          <span class="spark-pick-min">+${minute}m after the line</span>
+          <span class="spark-pick-ctl">
+            <button type="button" aria-label="${name} one minute earlier">−</button>
+            <button type="button" aria-label="${name} one minute later">+</button>
+            <button type="button" aria-label="Clear ${name.toLowerCase()}">×</button>
+          </span>`;
+        const [minus, plus, clear] = row.querySelectorAll('button');
+        minus.addEventListener('click', () => onNudge(-1));
+        plus.addEventListener('click', () => onNudge(1));
+        clear.addEventListener('click', onClear);
+        return row;
+      };
+      if (plan.pass) {
+        const row = document.createElement('div');
+        row.className = 'spark-pick';
+        row.innerHTML = '<span class="spark-pick-name"><i style="background:#8b93a7"></i> No trade</span>'
+          + '<span class="spark-pick-min">sitting this one out</span>';
+        picksEl.appendChild(row);
+        return;
+      }
+      if (plan.entryMin !== null) {
+        picksEl.appendChild(mkRow('Entry', ENTRY_COLOR, plan.entryMin, (d) => {
+          plan = plan.entryMin + d >= 1
+            ? planWithEntry(plan, plan.entryMin + d)
+            : plan;
+          sync();
+        }, () => { plan = { ...plan, entryMin: null, exitMin: null }; sync(); }));
+      }
+      if (plan.exitMin !== null) {
+        picksEl.appendChild(mkRow('Exit', EXIT_COLOR, plan.exitMin, (d) => {
+          const next = planWithExit(plan, plan.exitMin + d);
+          if (next && next.exitMin > plan.entryMin) { plan = next; sync(); }
+        }, () => { plan = { ...plan, exitMin: null }; sync(); }));
+      }
+    };
+
+    const sync = () => {
+      passBtn.classList.toggle('armed', plan.pass);
+      revealBtn.disabled = !(plan.pass || plan.entryMin !== null);
+      hintEl.textContent = hintFor();
+      renderPicks();
+      paint();
+    };
+
+    canvas.addEventListener('click', (e) => {
+      if (aftermath) return;
+      const rect = canvas.getBoundingClientRect();
+      const px = (e.clientX - rect.left) * (canvas.width / rect.width);
+      const minute = xToMinute(px, geom);
+      if (minute === null) {
+        hintEl.textContent = 'Pick a spot in the shaded lane — right of the line. That hour is the puzzle.';
+        return;
+      }
+      if (plan.pass) plan = { pass: false, entryMin: null, exitMin: null };
+      if (plan.entryMin === null) {
+        plan = planWithEntry(plan, minute);
+      } else if (plan.exitMin === null) {
+        const next = planWithExit(plan, minute);
+        if (!next) { sync(); return; }
+        plan = next;
+      } else {
+        // Move whichever marker the tap landed nearest.
+        const dEntry = Math.abs(minute - plan.entryMin);
+        const dExit = Math.abs(minute - plan.exitMin);
+        plan = dEntry <= dExit ? planWithEntry(plan, minute) : (planWithExit(plan, minute) || plan);
+      }
+      sync();
     });
-    sellBtn.addEventListener('click', () => {
-      state.sell = Date.now();
-      updateButtons();
+
+    passBtn.addEventListener('click', () => {
+      if (plan.pass) { plan = { pass: false, entryMin: null, exitMin: null }; } // toggle off
+      else plan = { pass: true, entryMin: null, exitMin: null };
+      sync();
     });
+
+    resetBtn.addEventListener('click', () => {
+      plan = { pass: false, entryMin: null, exitMin: null };
+      aftermath = null;
+      verdictBox.hidden = true;
+      verdictBox.innerHTML = '';
+      errorEl.hidden = true;
+      setLocked(false);
+      revealBtn.textContent = 'REVEAL GRADE';
+      sync();
+    });
+
+    practiceBtn.addEventListener('click', () => loadPractice(el));
+
     revealBtn.addEventListener('click', async () => {
-      if (!state.buy || !state.sell) return;
+      const actions = planActions(plan, model.tTs);
+      if (!actions) return;
+      errorEl.hidden = true;
       revealBtn.disabled = true;
       revealBtn.textContent = 'GRADING…';
       try {
         const res = await fetch(API + '/api/spark/grade', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            day: model.day,
-            mint: model.mint,
-            actions: [
-              { type: 'buy', ts: state.buy },
-              { type: 'sell', ts: state.sell },
-            ],
-          }),
+          body: JSON.stringify({ day: model.day, mint: model.mint, actions }),
         });
-        const bodyJson = await res.json();
-        if (!res.ok) throw new Error((bodyJson && bodyJson.reason) || 'HTTP ' + res.status);
+        const bodyJson = await res.json().catch(() => null);
+        if (!res.ok || !bodyJson || !bodyJson.ok) {
+          throw Object.assign(new Error((bodyJson && bodyJson.reason) || 'HTTP ' + res.status), {
+            sparkReason: (bodyJson && bodyJson.reason) || 'HTTP ' + res.status,
+          });
+        }
         const card = sparkCardModel(bodyJson.verdict, bodyJson.day);
         if (!card) throw new Error('unexpected verdict shape');
+        aftermath = revealModel(bodyJson);
+        setLocked(true);
         showVerdict(verdictBox, card);
+        sync();
       } catch (err) {
-        verdictBox.hidden = false;
-        verdictBox.innerHTML = `<p class="spark-error">Couldn't grade just now — ${String(err.message || err)}</p>`;
+        // The raw reason is for the console; the sentence is for the human.
+        console.warn('PaperTrench: spark grade failed —', err && err.sparkReason ? err.sparkReason : err);
+        const isNetwork = err instanceof TypeError;
+        errorEl.textContent = gradeErrorCopy(isNetwork ? 'network' : (err && err.sparkReason) || '');
+        errorEl.hidden = false;
       } finally {
         revealBtn.textContent = 'REVEAL GRADE';
         revealBtn.disabled = false;
+        sync();
       }
     });
+
+    sync();
   }
 
-  /** Draw the blind chart: bars up to T, with the reveal line at T. */
-  function drawChart(canvas, bars, tTs) {
+  /** Draw the blind chart: candles up to T, the unknown-hour lane after it.
+   * opts: { futureMin, aftermath (bars revealed with the verdict),
+   * entryMin, exitMin } — markers and lane draw only when asked for. */
+  function drawChart(canvas, bars, tTs, opts) {
     if (!canvas || !bars || !bars.length) return;
+    const o = opts || {};
+    const futureMin = o.futureMin || 0;
+    const aftermath = o.aftermath || null;
     const ctx = canvas.getContext('2d');
     const W = canvas.width;
     const H = canvas.height;
-    const pad = 8;
-    const min = Math.min(...bars.map((b) => b.l));
-    const max = Math.max(...bars.map((b) => b.h));
+    const geom = chartGeom(W, H, bars.length);
+    const { min, max } = priceRange(bars, aftermath);
     const span = max - min || 1;
-    const x = (i) => pad + (i / (bars.length - 1)) * (W - pad * 2);
+    const pad = geom.pad;
     const y = (v) => pad + (1 - (v - min) / span) * (H - pad * 2);
+    const xTs = (ts) => geom.minuteX((ts - tTs) / MIN_MS);
 
     ctx.clearRect(0, 0, W, H);
-    // Grid
+    // Grid across the whole width, lane included — one chart, not two.
     ctx.strokeStyle = 'rgba(255,255,255,0.06)';
     ctx.lineWidth = 1;
     for (let g = 0; g < 5; g++) {
@@ -211,43 +523,81 @@
       ctx.lineTo(W - pad, gy);
       ctx.stroke();
     }
-    // Candles
-    for (let i = 0; i < bars.length; i++) {
-      const b = bars[i];
-      const cx = x(i);
-      const bodyTop = y(Math.max(b.o, b.c));
-      const bodyBottom = y(Math.min(b.o, b.c));
-      const wickTop = y(b.h);
-      const wickBottom = y(b.l);
+
+    // The unknown hour: shaded, empty until the verdict hands over its bars.
+    if (futureMin > 0) {
+      ctx.fillStyle = 'rgba(255,157,69,0.05)';
+      ctx.fillRect(geom.tX, pad, W - pad - geom.tX, H - pad * 2);
+    }
+
+    const drawCandle = (x, b, alpha) => {
       const color = b.c >= b.o ? 'rgba(52,211,153,0.85)' : 'rgba(255,95,86,0.85)';
+      ctx.globalAlpha = alpha;
       ctx.strokeStyle = color;
       ctx.fillStyle = color;
       ctx.lineWidth = 1;
       ctx.beginPath();
-      ctx.moveTo(cx, wickTop);
-      ctx.lineTo(cx, wickBottom);
+      ctx.moveTo(x, y(b.h));
+      ctx.lineTo(x, y(b.l));
       ctx.stroke();
-      const bw = Math.max(2, (W - pad * 2) / bars.length * 0.6);
-      ctx.fillRect(cx - bw / 2, bodyTop, bw, Math.max(1, bodyBottom - bodyTop));
-    }
-    // Reveal line at T
-    const tIdx = bars.findIndex((b) => b.ts >= tTs);
-    if (tIdx >= 0) {
-      const tx = x(tIdx);
-      ctx.strokeStyle = 'rgba(255,157,69,0.9)';
-      ctx.setLineDash([4, 4]);
-      ctx.lineWidth = 2;
+      const bw = Math.max(2, ((geom.tX - pad) / bars.length) * 0.6);
+      const bodyTop = y(Math.max(b.o, b.c));
+      const bodyBottom = y(Math.min(b.o, b.c));
+      ctx.fillRect(x - bw / 2, bodyTop, bw, Math.max(1, bodyBottom - bodyTop));
+      ctx.globalAlpha = 1;
+    };
+    for (const b of bars) drawCandle(xTs(b.ts), b, 1);
+    if (aftermath) for (const b of aftermath) drawCandle(xTs(b.ts), b, 0.45);
+
+    // The cutoff line at T.
+    ctx.strokeStyle = 'rgba(255,157,69,0.9)';
+    ctx.setLineDash([4, 4]);
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(geom.tX, pad);
+    ctx.lineTo(geom.tX, H - pad);
+    ctx.stroke();
+    ctx.setLineDash([]);
+
+    // Markers: dotted drop-lines in the lane, triangles on the baseline.
+    const marker = (k, color, up) => {
+      const x = geom.minuteX(k);
+      ctx.strokeStyle = color;
+      ctx.setLineDash([2, 3]);
+      ctx.lineWidth = 1.5;
       ctx.beginPath();
-      ctx.moveTo(tx, pad);
-      ctx.lineTo(tx, H - pad);
+      ctx.moveTo(x, pad);
+      ctx.lineTo(x, H - pad);
       ctx.stroke();
       ctx.setLineDash([]);
-    }
-    // Last close marker
+      ctx.fillStyle = color;
+      ctx.beginPath();
+      const by = up ? H - pad - 2 : pad + 2;
+      if (up) {
+        ctx.moveTo(x, by - 8);
+        ctx.lineTo(x - 5, by);
+        ctx.lineTo(x + 5, by);
+      } else {
+        ctx.moveTo(x, by + 8);
+        ctx.lineTo(x - 5, by);
+        ctx.lineTo(x + 5, by);
+      }
+      ctx.closePath();
+      ctx.fill();
+      ctx.font = '600 11px ui-monospace, Menlo, monospace';
+      ctx.fillStyle = 'rgba(234,239,247,0.9)';
+      ctx.textAlign = 'center';
+      ctx.fillText('+' + k + 'm', x, up ? by - 12 : by + 20);
+      ctx.textAlign = 'left';
+    };
+    if (o.entryMin != null) marker(o.entryMin, ENTRY_COLOR, true);
+    if (o.exitMin != null) marker(o.exitMin, EXIT_COLOR, false);
+
+    // Last seen close, bottom-right of the SEEN tape (not the lane).
     const last = bars[bars.length - 1];
     ctx.fillStyle = 'rgba(234,239,247,0.9)';
     ctx.font = '600 12px ui-monospace, Menlo, monospace';
-    ctx.fillText(fmtPrice(last.c), W - pad - 70, H - pad - 4);
+    ctx.fillText(fmtPrice(last.c), geom.tX - 70, H - pad - 4);
   }
 
   /** Show the verdict card in the section. */
@@ -279,8 +629,18 @@
     API,
     GRADE_STYLE,
     TONE,
+    FUTURE_MIN,
     sparkModel,
+    revealModel,
     sparkCardModel,
+    planWithEntry,
+    planWithExit,
+    planActions,
+    chartGeom,
+    xToMinute,
+    gradeErrorCopy,
+    practiceSeed,
+    loadPractice,
     renderSpark,
     drawChart,
     fmtPrice,

--- a/extension/test/spark.test.js
+++ b/extension/test/spark.test.js
@@ -74,3 +74,81 @@ test('fmtPrice: compact across magnitudes, honest for tiny prices', () => {
   assert.equal(S.fmtPrice(-1), '—');
   assert.equal(S.fmtPrice(0), '—');
 });
+
+/* ---- the plan: minutes-after-the-cutoff picks ---- */
+
+test('planActions: pass / entry-only / entry+exit map to the server contract', () => {
+  const T = 1_700_000_000_000;
+  // A pass still needs an in-window ts (validateActions checks even pass).
+  assert.deepEqual(S.planActions({ pass: true, entryMin: null, exitMin: null }, T),
+    [{ type: 'pass', ts: T + 60000 }]);
+  // Entry only = held to the window end.
+  assert.deepEqual(S.planActions({ pass: false, entryMin: 7, exitMin: null }, T),
+    [{ type: 'buy', ts: T + 7 * 60000 }]);
+  assert.deepEqual(S.planActions({ pass: false, entryMin: 7, exitMin: 23 }, T),
+    [{ type: 'buy', ts: T + 7 * 60000 }, { type: 'sell', ts: T + 23 * 60000 }]);
+  // Nothing placed, or garbage: null, never a request.
+  assert.equal(S.planActions({ pass: false, entryMin: null, exitMin: null }, T), null);
+  assert.equal(S.planActions(null, T), null);
+  assert.equal(S.planActions({ pass: false, entryMin: 7, exitMin: 23 }), null);
+});
+
+test('planWithEntry/Exit: the exit invariant survives every placement', () => {
+  // Entry ahead of the exit pushes the exit after it.
+  let p = S.planWithExit(S.planWithEntry({ pass: false, entryMin: null, exitMin: null }, 10), 5);
+  assert.equal(p.exitMin, 11, 'exit clamps forward of a later entry');
+  // Exit before entry clamps up to entry+1.
+  p = S.planWithExit(S.planWithEntry({ pass: false, entryMin: null, exitMin: null }, 10), 2);
+  assert.equal(p.exitMin, 11);
+  // Entry on the last minute leaves no legal exit — it drops, plan stays valid.
+  p = S.planWithEntry({ pass: false, entryMin: 10, exitMin: 30 }, S.FUTURE_MIN);
+  assert.equal(p.entryMin, 60);
+  assert.equal(p.exitMin, null);
+  assert.equal(S.planWithExit({ pass: false, entryMin: 60, exitMin: null }, 60), null,
+    'no exit can follow an entry on the last minute');
+  // No entry yet: an exit has nothing to exit from.
+  assert.equal(S.planWithExit({ pass: false, entryMin: null, exitMin: null }, 5), null);
+  // Bounds: minutes clamp into 1..60, never outside the graded window.
+  assert.equal(S.planWithEntry({ pass: false, entryMin: null, exitMin: null }, 0).entryMin, 1);
+  assert.equal(S.planWithEntry({ pass: false, entryMin: null, exitMin: null }, 99).entryMin, 60);
+});
+
+test('geometry + hit-testing: a tap in the lane rounds to a legal minute; the seen tape rejects', () => {
+  const geom = S.chartGeom(760, 230, 90);
+  assert.ok(geom.tX > 0 && geom.tX < 760);
+  // Inside the lane -> 1..60, monotonic in x.
+  const m1 = S.xToMinute(geom.tX + 1, geom);
+  const mMid = S.xToMinute((geom.tX + 760 - geom.pad) / 2, geom);
+  const mEnd = S.xToMinute(759, geom);
+  assert.ok(m1 >= 1 && m1 <= 3, 'just past the line is minute ~1');
+  assert.ok(mMid > m1 && mMid < mEnd, 'minutes increase across the lane');
+  assert.equal(mEnd, 60, 'the right edge is the window end');
+  // minuteX is the inverse: the marker lands where the tap read.
+  assert.ok(Math.abs(S.xToMinute(S.chartGeom(760, 230, 90).minuteX(7), geom) - 7) <= 1);
+  // A tap on the seen tape places nothing.
+  assert.equal(S.xToMinute(geom.tX - 5, geom), null);
+  assert.equal(S.xToMinute(0, geom), null);
+});
+
+test('revealModel: aftermath bars arrive only with an ok grade response', () => {
+  const bars = [{ ts: 1, o: 1, h: 2, l: 0.5, c: 1.5 }, { ts: 2, o: 1.5, h: 3, l: 1, c: 2 }];
+  const r = S.revealModel({ ok: true, verdict: { grade: 'B' }, reveal: { bars } });
+  assert.ok(r && r.bars.length === 2);
+  assert.equal(S.revealModel({ ok: false, reveal: { bars } }), null, 'a refused grade reveals nothing');
+  assert.equal(S.revealModel({ ok: true, reveal: {} }), null);
+  assert.equal(S.revealModel(null), null);
+});
+
+test('gradeErrorCopy: every failure speaks a sentence, never a bare reason code', () => {
+  for (const reason of ['bad-body', 'wrong-day', 'no-data', 'no-window', 'rate-limited', 'busy',
+    'bad-action', 'action-out-of-window', 'empty', 'pass-not-alone', 'must-open', 'must-close',
+    'too-many', 'non-monotonic', 'server-error', 'HTTP 500', '']) {
+    const copy = S.gradeErrorCopy(reason);
+    assert.ok(typeof copy === 'string' && copy.length > 10 && /[.!?]$/.test(copy),
+      'reason ' + JSON.stringify(reason) + ' needs a full human sentence');
+    assert.notEqual(copy, reason, 'the copy must never be the bare reason code');
+  }
+  // The two known-but-different situations say their specific thing.
+  assert.ok(S.gradeErrorCopy('wrong-day').includes('Reload'));
+  assert.ok(S.gradeErrorCopy('network').includes('connection'));
+});

--- a/extension/test/sparkmount.test.js
+++ b/extension/test/sparkmount.test.js
@@ -64,6 +64,22 @@ test('pnlcard.js exposes the spark painter (no-PnL card law)', () => {
   }
 });
 
+test('practice loop: spark.js owns it end to end, the mount only offers the door', () => {
+  // The practice fetch, seed generation, and self re-render live in spark.js
+  // (loadPractice), NOT in dashboard.js — the mount stays a daily-puzzle
+  // loader and must keep fetching only /today.
+  assert.match(sparkJs, /\/api\/spark\/practice\?seed='/, 'practice fetch missing from spark.js');
+  assert.match(sparkJs, /function practiceSeed/, 'seed generation missing');
+  assert.match(sparkJs, /function loadPractice/, 'loadPractice missing');
+  assert.match(sparkJs, /spark-practice/, 'practice button class missing');
+  assert.match(sparkJs, /NEXT PUZZLE/, 'practice-mode loop label missing');
+  assert.match(sparkJs, /loadPractice,/, 'loadPractice must be exported');
+  // The mount offers practice as a fallback and never grades.
+  assert.match(js, /spark-practice-anyway/, 'mount lacks the practice fallback door');
+  assert.ok(!/spark\/grade/.test(js.split('renderSpark')[1] || ''),
+    'renderSpark must not fetch the grade endpoint');
+});
+
 test('spark styles exist in dashboard.html', () => {
   assert.match(html, /\.spark-chart \{/, 'spark chart style missing');
   assert.match(html, /\.spark-grade \{/, 'spark grade style missing');

--- a/server/test/spark-worker.test.js
+++ b/server/test/spark-worker.test.js
@@ -56,7 +56,15 @@ function fakeDB(route) {
       sql,
       get args() { return bound; },
       bind(...args) { bound = args; return stmt; },
-      async first() { log.push({ sql, args: bound, via: 'first' }); return route(sql, bound) || null; },
+      async first() {
+        log.push({ sql, args: bound, via: 'first' });
+        const out = route(sql, bound);
+        if (out) return out;
+        // allowRate's upsert: a fake that answered nothing would read as
+        // "limiter broken" and fail open with a console error on every grade.
+        // Default to a permissive count; a test that wants the leash says so.
+        return sql.includes('rate_limits') ? { count: 1 } : null;
+      },
       async all() {
         log.push({ sql, args: bound, via: 'all' });
         const rows = route(sql, bound);
@@ -322,6 +330,133 @@ test('spark/today: no upstream data is an honest 404, not a fabrication', async 
     const res = await worker.fetch(new Request('https://api.test/api/spark/today'), env, { waitUntil: () => {} });
     assert.equal(res.status, 404);
     assert.equal((await res.json()).reason, 'no-data');
+  } finally {
+    upstream.restore();
+    delete globalThis.caches;
+  }
+});
+
+/* ---------------- practice: the same machinery, keyed on a seed ----------------
+ *
+ * The daily ritual stays scarce; practice is infinite. A practice puzzle is
+ * the SAME pick pinned under a synthetic day key ('practice-<seed>'), so the
+ * grade path is shared verbatim — proven here by grading a practice day with
+ * the unmodified grade route.
+ */
+
+test('spark/practice: seed pins a blind puzzle, deterministic across requests', async () => {
+  const chart = shapeChart();
+  const charts = { MintA: chart };
+  const store = { memos: {}, charts: {} };
+  const db = fakeDB((sql, args) => {
+    if (sql.includes('FROM pools')) return [{ mint: 'MintA' }];
+    if (sql.includes('FROM spark_days')) return store.memos[args[0]] || null;
+    if (sql.includes('FROM spark_charts')) {
+      return store.charts[args[0]] ? { chart_json: store.charts[args[0]] } : null;
+    }
+    if (sql.includes('INSERT INTO spark_days')) {
+      store.memos[args[0]] = { day: args[0], mint: args[1], t_ts: args[2] };
+      return { meta: { changes: 1 } };
+    }
+    if (sql.includes('INSERT INTO spark_charts')) {
+      store.charts[args[0]] = args[1];
+      return { meta: { changes: 1 } };
+    }
+    return null;
+  });
+  const upstream = mockUpstream(charts);
+  try {
+    const worker = await loadWorker();
+    const env = makeEnv(db);
+    const url = 'https://api.test/api/spark/practice?seed=4242';
+
+    const res = await worker.fetch(new Request(url), env, { waitUntil: () => {} });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.day, 'practice-4242', 'the seed is the day key');
+    assert.equal(body.mint, 'MintA');
+    for (const bar of body.bars) {
+      assert.ok(bar.ts <= body.tTs, 'practice obeys the blind law: ' + bar.ts);
+    }
+    assert.ok(store.memos['practice-4242'], 'practice puzzle is pinned in D1');
+    assert.ok(store.charts['practice-4242'], 'practice chart is pinned in D1');
+
+    // Second request, same seed: memo path, byte-identical window.
+    const res2 = await worker.fetch(new Request(url), env, { waitUntil: () => {} });
+    const body2 = await res2.json();
+    assert.equal(body2.mint, body.mint);
+    assert.equal(body2.tTs, body.tTs);
+    assert.equal(JSON.stringify(body2.bars), JSON.stringify(body.bars));
+  } finally {
+    upstream.restore();
+    delete globalThis.caches;
+  }
+});
+
+test('spark/practice: no seed still yields a practice puzzle', async () => {
+  const chart = shapeChart();
+  const store = { memos: {}, charts: {} };
+  const db = fakeDB((sql, args) => {
+    if (sql.includes('FROM pools')) return [{ mint: 'MintA' }];
+    if (sql.includes('FROM spark_days')) return store.memos[args[0]] || null;
+    if (sql.includes('FROM spark_charts')) {
+      return store.charts[args[0]] ? { chart_json: store.charts[args[0]] } : null;
+    }
+    if (sql.includes('INSERT INTO spark_days')) {
+      store.memos[args[0]] = { day: args[0], mint: args[1], t_ts: args[2] };
+      return { meta: { changes: 1 } };
+    }
+    if (sql.includes('INSERT INTO spark_charts')) {
+      store.charts[args[0]] = args[1];
+      return { meta: { changes: 1 } };
+    }
+    return null;
+  });
+  const upstream = mockUpstream({ MintA: chart });
+  try {
+    const worker = await loadWorker();
+    const env = makeEnv(db);
+    const res = await worker.fetch(new Request('https://api.test/api/spark/practice'), env, { waitUntil: () => {} });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.ok(/^practice-\d+$/.test(body.day), 'server mints a practice day key: ' + body.day);
+  } finally {
+    upstream.restore();
+    delete globalThis.caches;
+  }
+});
+
+test('spark/practice: the daily grade route grades a practice day unchanged', async () => {
+  const chart = shapeChart();
+  const tTs = chart[90].ts;
+  const db = fakeDB((sql) => {
+    if (sql.includes('FROM spark_days')) return { day: 'practice-77', mint: 'MintA', t_ts: tTs };
+    return null;
+  });
+  const upstream = mockUpstream({ MintA: chart });
+  try {
+    const worker = await loadWorker();
+    const env = makeEnv(db);
+    const res = await worker.fetch(new Request('https://api.test/api/spark/grade', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' }, // no Origin: the grade route is origin-exempt
+      body: JSON.stringify({
+        day: 'practice-77',
+        mint: 'MintA',
+        actions: [{ type: 'buy', ts: tTs + 5 * MIN }, { type: 'sell', ts: tTs + 30 * MIN }],
+      }),
+    }), env, { waitUntil: () => {} });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.ok(['S', 'A', 'B', 'C', 'D', 'F'].includes(body.verdict.grade));
+    assert.ok(body.reveal && Array.isArray(body.reveal.bars) && body.reveal.bars.length > 0,
+      'the verdict carries the aftermath the player was graded against');
+    for (const bar of body.reveal.bars) {
+      assert.ok(bar.ts > tTs, 'reveal bars are strictly after the cutoff');
+    }
   } finally {
     upstream.restore();
     delete globalThis.caches;

--- a/server/worker/index.js
+++ b/server/worker/index.js
@@ -44,6 +44,11 @@ const STREAMER_APPLIES_PER_HOUR = 5;
 // The X feed endpoint: only cache MISSES cost an upstream fetch, so the
 // per-IP leash sits on those, not on reads a cache can answer.
 const XFEED_PER_HOUR = 120;
+// Daily Spark grading is anonymous and origin-exempt (see the POST gate in
+// fetch()): the leash is what stands in for the origin check. Practice mode
+// makes grading a many-times-a-session act, so the leash is generous — two a
+// minute sustained — while still making a hammer pointless.
+const SPARK_GRADES_PER_HOUR = 120;
 const XFEED_FRESH_MS = 20 * 60 * 1000;
 const XFEED_STALE_MS = 7 * 24 * 3600 * 1000;
 /** window_id for a clan's since-join season slice, alongside ISO week ids. */
@@ -2264,7 +2269,17 @@ export default {
 
     // The OAuth callback is a top-level navigation from x.com and carries no
     // Origin; everything else that changes state must prove where it came from.
-    if (request.method === 'POST' && !requireOrigin(request, env)) {
+    //
+    // The one exemption is Daily Spark grading. It is the only POST a shipped
+    // page makes from an origin this gate can never allowlist: the extension
+    // dashboard, whose chrome-extension://<id> origin differs per install and
+    // per unpacked dev copy — so before this exemption the extension's grade
+    // button was a guaranteed 403 'bad-origin' and the feature never worked.
+    // Opening it is sound because the gate's threat (a foreign site riding
+    // the visitor's session cookie) does not exist on that route: grading
+    // reads no session, writes no user state, and is a pure function of the
+    // day's pinned chart. SPARK_GRADES_PER_HOUR bounds it instead.
+    if (request.method === 'POST' && path !== '/api/spark/grade' && !requireOrigin(request, env)) {
       const denied = json({ ok: false, reason: 'bad-origin' }, 403);
       for (const [key, value] of Object.entries(cors)) denied.headers.set(key, value);
       return denied;
@@ -2392,8 +2407,20 @@ export default {
       else if (path === '/api/spark/today') {
         response = await edgeCached(request, ctx, 60, () => sparkWorker.handleSparkToday(request, env));
       }
+      else if (path === '/api/spark/practice') {
+        // NOT edge-cached even with a seed: the first hit on a seed PINS the
+        // puzzle in D1, and that write must happen on the origin isolate.
+        // The memo path after that is one D1 read — cheap enough to skip the
+        // cache dance entirely.
+        response = await sparkWorker.handleSparkPractice(request, env);
+      }
       else if (path === '/api/spark/grade' && request.method === 'POST') {
-        response = await sparkWorker.handleSparkGrade(request, env);
+        const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
+        if (!(await allowRate(env, 'spark-grade:' + ip, SPARK_GRADES_PER_HOUR))) {
+          response = json({ ok: false, reason: 'rate-limited' }, 429);
+        } else {
+          response = await sparkWorker.handleSparkGrade(request, env);
+        }
       }
       // Moderation. Every one of these re-checks `moderator()` itself — the
       // routing table is not the gate, the handler is.

--- a/server/worker/spark.js
+++ b/server/worker/spark.js
@@ -142,15 +142,13 @@ async function sparkChart(env, mint, budget) {
 }
 
 /**
- * GET /api/spark/today
- * Blind puzzle: { day, mint, tTs, bars: [... up to tTs] }.
- * The bars are the ONLY data the client may see before acting. Anything
- * after tTs is a spoiler and must never leave this handler.
+ * The puzzle for a day key: memo -> candidates -> deterministic pick -> pin.
+ * Shared by the daily puzzle (day = UTC date) and practice rounds
+ * (day = 'practice-<seed>') — the ONLY difference between the two is the key,
+ * which is exactly the point: grading needs no special case either.
+ * Returns the json Response: { ok, day, mint, tTs, bars } or an honest error.
  */
-async function handleSparkToday(request, env) {
-  const url = new URL(request.url);
-  const now = Date.now();
-  const day = dayKey(now);
+async function puzzleFor(env, day) {
   const memo = await dayMemo(env, day);
   let mint = memo ? memo.mint : null;
   let tTs = memo ? memo.tTs : 0;
@@ -209,10 +207,45 @@ async function handleSparkToday(request, env) {
 }
 
 /**
+ * GET /api/spark/today
+ * Blind puzzle: { day, mint, tTs, bars: [... up to tTs] }.
+ * The bars are the ONLY data the client may see before acting. Anything
+ * after tTs is a spoiler and must never leave this handler.
+ */
+async function handleSparkToday(request, env) {
+  return puzzleFor(env, dayKey(Date.now()));
+}
+
+/**
+ * GET /api/spark/practice[?seed=N]
+ * The same puzzle machinery keyed on a seed instead of the calendar: the
+ * ritual stays daily, the practice is infinite. Deterministic per seed — the
+ * same seed is the same chart for every player, so a round can be shared by
+ * sharing its number — and pinned in D1 exactly like the daily pick, so the
+ * grade path needs no special case at all. The client supplies a fresh
+ * random seed per round; the server mints one when asked without.
+ */
+async function handleSparkPractice(request, env) {
+  const url = new URL(request.url);
+  const raw = Number(url.searchParams.get('seed'));
+  const seed = Number.isInteger(raw) && raw >= 0 && raw < 2 ** 31
+    ? raw
+    : Math.floor(Math.random() * 2 ** 31);
+  return puzzleFor(env, 'practice-' + seed);
+}
+
+/**
  * POST /api/spark/grade
  * Body: { day, mint, actions: [{type:'buy'|'sell', ts}] }
  * Verdict: the process-grade (S/A/B/C/D/F) + the tone axes + the story.
  * Deterministic: same actions + same day => same grade. No PnL figure ever.
+ *
+ * The response also carries `reveal.bars` — the pinned chart's bars AFTER T,
+ * up to the window end. Until grading these are a spoiler and never leave the
+ * worker; once the verdict is computed the run is committed and showing the
+ * player what they were graded against is the point. (Re-grading a day is
+ * allowed — this is a practice tool, and the share card is self-reported —
+ * but the reveal arrives only WITH a verdict, never before it.)
  */
 async function handleSparkGrade(request, env) {
   const url = new URL(request.url);
@@ -245,7 +278,13 @@ async function handleSparkGrade(request, env) {
   }
   const verdict = spark.gradeRun(valid, chart, memo.tTs);
   if (verdict.error) return json({ ok: false, reason: verdict.error }, 400);
-  return json({ ok: true, day, mint, verdict });
+  return json({
+    ok: true,
+    day,
+    mint,
+    verdict,
+    reveal: { bars: spark.forwardSlice(chart, memo.tTs, 4) },
+  });
 }
 
-module.exports = { handleSparkToday, handleSparkGrade, dayKey, candidateMints, dayMemo, setDayMemo, sparkChart };
+module.exports = { handleSparkToday, handleSparkPractice, handleSparkGrade, dayKey, candidateMints, dayMemo, setDayMemo, sparkChart, puzzleFor };


### PR DESCRIPTION
## The bug, from the player's chair

Open the dashboard's Daily Spark, pick BUY then SELL, hit REVEAL GRADE, and you got:

> Couldn't grade just now — bad-origin

That was not a flake — the feature could never have worked, for three independent reasons:

1. **The grade POST was a guaranteed 403.** The extension dashboard is a `chrome-extension://<id>` page. The worker's origin gate (`requireOrigin`) allowlists the site origins only — and it *can't* allowlist the extension, because the origin id differs per install and per unpacked dev copy. Every grade died at the door. (Load worked; grading was the only network write, so the puzzle rendered and then refused the one thing it exists for.)
2. **The picks were timestamps from the wrong world.** BUY/SELL buttons recorded `Date.now()` — wall-clock click time (2026, evening) — against a historical chart whose graded window lives ~60 minutes after its cutoff `tTs`. Even without the 403, `validateActions` could only answer `action-out-of-window`.
3. **There was nothing on screen to act on.** The blind payload stops at the cutoff by design (blind law), but the client drew only the past and offered no way to place an entry/exit in the unknown hour — the legend promised entry/exit markers that could never exist.

Load failures fared no better: one generic sentence regardless of whether the day rolled over, the pool was empty, or the network hiccuped.

## What this PR does

**Makes the daily playable (client + one route):**
- Picks are made by **tapping the shaded lane**: the chart now draws the unknown hour after the cutoff as a distinct lane. Tap to place an entry (green ▲), tap again for an exit (amber ▼), or use the ± steppers. Markers are bar-aligned and inside the graded window *by construction* — the wall-clock is never sent.
- **PASS is a first-class move** ("I'd sit this one out") — the grader has always supported it (`gradePass`); the client never offered it.
- **The verdict reveals the aftermath**: the grade response now carries `reveal.bars` (the pinned bars after T, `forwardSlice(chart, tTs, 4)`), drawn dimmed in the lane — you finally *see* what you were graded against. Before grading, nothing after T leaves the worker; the blind law holds (test-pinned).
- **Every failure speaks a sentence**, never a bare code: ended day (→ reload for the new puzzle), grader busy, rate-limited, network, and the validator family collapse to one honest "picks didn't line up" line. Load-failure copy names the reason (empty pool vs. bad data vs. network) and offers a way forward.
- Grading is **origin-exempt** on the worker: the route reads no session and writes no user state, so the gate's threat model doesn't apply; a per-IP D1 leash (`allowRate`, 120/hour) stands in its place. Comment at the gate explains all of this.

**Adds practice — the infinite loop (the point of the request):**
- `GET /api/spark/practice?seed=N` runs the *same* deterministic pick, pinned under a synthetic day key `practice-<seed>` in the same `spark_days`/`spark_charts` tables. The grade route needs **no special case** — a practice round *is* a day to it.
- Same seed = same chart for every player, so a round can be shared by sharing its number. No seed → the server mints one.
- The client gets a persistent **PRACTICE** button (becomes **NEXT PUZZLE** in practice mode), deliberately never disabled — a verdict never traps the player. The daily ritual stays scarce; the practice is unlimited.
- When the daily puzzle can't load at all, the error state offers "play a practice round" — a separate pick path that can be up when the daily isn't.

## Deploy notes
- **Worker deploy required** for the fix to reach players (the 403 is server-side). No D1 migration — practice reuses the existing tables; rows under `practice-*` keys are tiny and inert.
- Extension ships on the next release as usual. Until the worker deploys, an updated extension still sees `bad-origin` — the two halves should land together (worker first).

## Tests
- Server suite: **292 passed, 0 failed** (adds 3: practice pin + determinism + blind law; no-seed fallback; practice day graded through the unmodified route *without* an Origin header, asserting the reveal arrives and is strictly post-T).
- Extension suite: **2154 passed, 0 failed** (adds plan/invariant tests — exit clamps, last-minute entry drops the exit, minutes never leave 1–60 — hit-testing inverse, reveal gating on `ok`, and the "every failure is a full sentence" contract; plus a source-contract test keeping the practice loop in spark.js and the mount grade-free).
- All grading math (`core/spark.js`) is untouched — no PnL ever leaves the worker; the share-card painter's no-PnL law is re-pinned.

Closes the "Couldn't grade just now — bad-origin" report; practice mode per the same request.