### PR TITLE
feat(quote): price fresh pairs from the host page's own payloads

### DIFF
--- a/docs/DESIGN-host-facts.md
+++ b/docs/DESIGN-host-facts.md
@@ -1,0 +1,102 @@
+# Design — price fresh pairs from the host page's own payloads
+
+Status: proposal. Target: kill the "Fetching live price" class of complaint at the root
+rather than making the RPC pool more resilient one fault at a time.
+
+## Why the extension re-fetches today
+
+The panel is not scraping-blind — the page's own frames are already the primary live price
+path (`price-bridge.js` hooks `fetch`/`XHR`/`WebSocket` in the MAIN world and forwards every
+JSON frame to `collect()`). On an established coin the panel prices with zero RPC.
+
+RPC is only load-bearing for the facts a chart tick cannot carry:
+
+| Fact | Where it comes from now | Needed for |
+| --- | --- | --- |
+| What the on-screen number *is* (USD price / SOL price / market cap) | threshold heuristics in `quote.js` (`BOOTSTRAP_*`), else refuse | any fill on an unindexed coin |
+| Token supply (turns an mcap reading into a price) | `getMultipleAccounts`/`getAccountInfo` on the mint (`onchainPrewatch`) or the pump.fun 1e9 constant | mcap-mode charts (Axiom, Padre, GMGN) |
+| Which mint a **pair-address** page is showing | same RPC probe, or an aggregator | Axiom `/meme/<pair>`, BullX `terminal?address=<pair>` |
+| Pool reserves | RPC | slippage / fill price |
+
+So the starvation report is precisely: *pair page + unindexed coin + throttled RPC = no
+identity, no supply, no fill*. Aggregators need 20–30 s; the terminal already knew all of it
+at page load.
+
+## The gap
+
+`collect()` extracts prices, market caps, mints, symbols and names from host frames. It does
+**not** extract `supply` / `decimals` / the pool↔mint association — the three facts that would
+make the page self-sufficient. Padre and GMGN get named fast paths
+(`padre-chart-bar`, `gmgn-ws-trade`, `gmgn-mcap-candle`); Axiom and BullX only get the generic
+walk, whose ticks are `untrusted-source` for `bootstrapTick` on a pair page because the mint is
+unknown.
+
+## Proposal — a "host facts" layer under the tick layer
+
+### 1. Extraction (`price-bridge.js`)
+
+Extend the per-record walk with `SUPPLY_KEY` (`supply|totalSupply|circulatingSupply|tokenSupply`),
+`DECIMALS_KEY`, and pool-ish address keys (`pairAddress|poolAddress|lpAddress|pool|pairId`).
+Emit a **new** message type `facts` — never a `tick` — when a record ties the page's own
+`srcAddress` to any of: a different mint, a supply, decimals, a pool address.
+
+`facts` is identity/metadata only. It can never move a price by itself.
+
+### 2. Adoption rules (`content.js`, pending token only)
+
+These are the correctness core. Host payloads are untrusted input; each rule makes a fact
+*self-checking* rather than believed.
+
+- **R1 identity.** Adopt a mint from a `facts` message only when the same record also carries
+  the page's own `srcAddress` (the pair address from the URL), the mint is base58 32–44 and is
+  not the `srcAddress` itself. Reuse the existing `rekeyLiveState` path so an armed buy and any
+  fill survive the rename, exactly as the RPC prewatch does today.
+- **R2 supply.** Accept a supply only when the payload corroborates it *arithmetically*:
+  the same record carries an unambiguously-united price (`priceUsd`-family key) **and** a
+  market cap, and `|mcap / priceUsd − declaredSupply| / declaredSupply <= 1%`.
+  - No declared supply field: the implied `mcap / priceUsd` may be used, but only when both
+    keys are explicitly united (never an `unknown`-unit chart close).
+  - Anything else: refuse. No new thresholds, no unit guessing — a refusal costs seconds,
+    a wrong supply costs a 200x-wrong fill.
+- **R3 provenance + reconciliation.** A fill priced through host facts records
+  `priceSource: 'site-facts'` and a witness holding the frame URL, the keys read and their
+  values. When the on-chain probe later returns a measured supply, reconcile: agreement within
+  2% upgrades the provenance to `onchain`; disagreement stops all host-supply use for that
+  token and flags the position, rather than silently re-pricing it.
+- **R4 precedence.** Host facts never override a trusted anchor. Once the resolver or the
+  chain probe has answered, `validateTick`'s band stays in charge and facts only fill gaps.
+
+### 3. Quote layer (`quote.js`)
+
+`bootstrapSupply` gains a third source, `t.hostSupplyUi`, ranked below the pump.fun protocol
+constant and below `t.supplyUi` (measured on-chain), and subject to the same
+`mcapUnitBand` sanity band. `bootstrapTick` needs no new trusted source: R1 makes
+`tick.mint === pendingToken.mint` true on pair pages, which is already the trusted case.
+
+### 4. Result
+
+Four independent paths to a fillable price, none able to block the others:
+
+```
+host payload facts  (0 ms, needs the site's frame)
+page chart tick     (validated against an anchor)
+aggregator anchor   (Dexscreener / Jupiter / venue APIs, 20-30 s on a fresh coin)
+on-chain read       (RPC pool, now throttle-tolerant)
+```
+
+"Fetching live price" then means *every* source is silent, which is an honest state rather
+than a single throttled endpoint.
+
+## What this does not do
+
+- It does not trust a number because the site printed it. Every host fact is either tied to the
+  page's own address (identity) or checked against a second number in the same payload (supply).
+- It does not remove the RPC pool. Reserves, rug checks and reconciliation still need it.
+- It does not change fill maths or the fee model.
+
+## Work needed
+
+1. Capture real logged-in frames from Axiom `/meme/<pair>` and BullX `terminal?address=<pair>`
+   (which keys actually carry mint/supply/pool) — blocked on credentials.
+2. Implement extraction + rules + tests using those captures as fixtures.
+3. Reconciliation and provenance plumbing.

--- a/extension/content.js
+++ b/extension/content.js
@@ -533,14 +533,8 @@
   }
   window.addEventListener('message', onBridgeMessage);
 
-  const HOST_FACT_ADDRESS_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
-  // Quote/native pool assets must never become the tracked token identity.
-  const HOST_FACT_QUOTE_MINTS = new Set([
-    'So11111111111111111111111111111111111111112',
-    'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
-    'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
-  ]);
   const hostSupplyRefusals = new Set();
+  const hostSupplyRefusalCounts = new Map();
 
   function recordHostFactsDiagnostic(message, kind, details) {
     const EL = window.PTErrors;
@@ -551,8 +545,23 @@
   }
 
   function refuseHostSupply(mint, facts) {
-    if (hostSupplyRefusals.has(mint)) return;
-    hostSupplyRefusals.add(mint);
+    const keyPart = (value) => {
+      const number = Number(value);
+      return Number.isFinite(number) ? number.toPrecision(12) : String(value);
+    };
+    const key = [
+      mint,
+      facts && facts.source,
+      keyPart(facts && facts.priceUsd),
+      keyPart(facts && facts.mcap),
+      keyPart(facts && facts.supply),
+      keyPart(facts && facts.decimals),
+    ].join('|');
+    if (hostSupplyRefusals.has(key)) return;
+    const count = hostSupplyRefusalCounts.get(mint) || 0;
+    if (count >= 8) return;
+    hostSupplyRefusals.add(key);
+    hostSupplyRefusalCounts.set(mint, count + 1);
     recordHostFactsDiagnostic('refused host supply for ' + mint
       + ' (no supply reading agreed with mcap/priceUsd within 1%)', 'host-facts-supply-refused', {
       source: facts && facts.source,
@@ -566,53 +575,21 @@
 
   function handleHostFacts(facts) {
     if (!facts || !token || !token.pending) return;
-
-    const addresses = Array.isArray(facts.addresses) ? facts.addresses : [];
-    const srcAddress = typeof token.srcAddress === 'string' ? token.srcAddress : '';
-    const factMint = typeof facts.mint === 'string' ? facts.mint : '';
-    if (addresses.indexOf(srcAddress) !== -1
-      && HOST_FACT_ADDRESS_RE.test(factMint)
-      && !HOST_FACT_QUOTE_MINTS.has(factMint)
-      && factMint !== srcAddress
-      && token.mint !== factMint) {
+    const decision = Q.hostFactsDecision(token, facts);
+    if (decision.adoptMint) {
       const oldMint = token.mint;
-      if (armedBuy && armedBuy.mint === oldMint) armedBuy.mint = factMint;
-      rekeyLiveState(oldMint, factMint);
-      token.mint = factMint;
-      token.pairAddress = facts.poolAddress || token.pairAddress || null;
+      if (armedBuy && armedBuy.mint === oldMint) armedBuy.mint = decision.adoptMint;
+      rekeyLiveState(oldMint, decision.adoptMint);
+      token.mint = decision.adoptMint;
+      token.pairAddress = decision.poolAddress || token.pairAddress || null;
       sendPadreMarker('paper-axis', { pairAddress: token.pairAddress, mint: token.mint });
     }
-
-    if (factMint !== token.mint && addresses.indexOf(srcAddress) === -1) return;
-    if (token.hostSupplyRejected) return;
-    const priceUsd = Number(facts.priceUsd);
-    const mcap = Number(facts.mcap);
-    if (!(priceUsd > 0) || !(mcap > 0)) return;
-    const implied = mcap / priceUsd;
-    if (!(implied > 0) || !Number.isFinite(implied)) return;
-
-    const hasSupply = facts.supply !== null && facts.supply !== undefined;
-    const rawSupply = Number(facts.supply);
-    let declaredUi = null;
-    if (hasSupply) {
-      if (!(rawSupply > 0) || !Number.isFinite(rawSupply)) {
-        refuseHostSupply(token.mint, facts);
-        return;
-      }
-      const decimals = Number(facts.decimals);
-      const readings = [rawSupply];
-      if (Number.isInteger(decimals) && decimals >= 0) {
-        readings.push(rawSupply / (10 ** decimals));
-      }
-      declaredUi = readings.find((reading) => reading > 0 && Number.isFinite(reading)
-        && Math.abs(implied - reading) / reading <= 0.01) || null;
-      if (!(declaredUi > 0)) {
-        refuseHostSupply(token.mint, facts);
-        return;
-      }
+    if (decision.refused) {
+      refuseHostSupply(token.mint, facts);
+      return;
     }
-
-    token.hostSupplyUi = declaredUi || implied;
+    if (!(decision.supplyUi > 0)) return;
+    token.hostSupplyUi = decision.supplyUi;
     token.hostSupplyWitness = {
       source: facts.source || null,
       url: facts.url || null,
@@ -827,11 +804,10 @@
     if (verdict.priceUsd) token.priceUsd = verdict.priceUsd;
     if (verdict.mcap) token.mcap = verdict.mcap;
     token.priceSource = payload.source || 'page-feed';
-    if (verdict.supplyBasis === 'host') {
-      token.hostSupplySource = 'site-facts';
-      token.hostSupplyFillWitness = token.hostSupplyWitness
-        ? JSON.parse(JSON.stringify(token.hostSupplyWitness)) : null;
-    }
+    token.hostSupplySource = verdict.supplyBasis === 'host' ? 'site-facts' : null;
+    token.hostSupplyFillWitness = verdict.supplyBasis === 'host'
+      && token.hostSupplyWitness
+      ? JSON.parse(JSON.stringify(token.hostSupplyWitness)) : null;
     // Market evidence for the fill witness (F-47): only prices the validator
     // actually ACCEPTED count — never a resolver adoption, which is exactly
     // the source class that once resurrected a pre-crash price.
@@ -1431,6 +1407,7 @@
       lastMcapTickAt = 0;
       oobRejects = 0;
       hostSupplyRefusals.clear();
+      hostSupplyRefusalCounts.clear();
     }
     token = data;
     // Keep a separate resolver anchor for validation. This is the price we
@@ -2028,6 +2005,20 @@
       supplySource: token.hostSupplySource || null,
       hostSupplyWitness: token.hostSupplyFillWitness || null,
     };
+  }
+
+  function refuseDisprovedHostFill(fillQuote) {
+    lastQuoteRefusal = 'Host supply disagreed with measured supply'
+      + ' — paper fill refused. Try again in a moment.';
+    recordHostFactsDiagnostic('paper fill refused after host supply discrepancy',
+      'host-facts-fill-refused', {
+        mint: fillQuote && fillQuote.mint,
+        source: fillQuote && fillQuote.supplySource,
+      });
+    console.debug('PaperTrench: fill witness refused', {
+      reason: 'host supply disagreed with measured supply',
+      mint: fillQuote && fillQuote.mint,
+    });
   }
 
   function waitForNewPageQuote(afterSeq, timeoutMs) {
@@ -3390,6 +3381,11 @@
         let filled = null;
         const mutate = () => {
           if (!token || token.mint !== fillQuote.mint) throw new Error('Token changed before the paper buy could be filled');
+          if (fillQuote.supplySource === 'site-facts' && token.hostSupplyRejected) {
+            refuseDisprovedHostFill(fillQuote);
+            filled = null;
+            return;
+          }
           const hadPosition = Boolean(state.positions[token.mint]);
           filled = E.buy(state, settings, {
             ts: Date.now(), mint: token.mint, pairAddress: token.pairAddress,
@@ -3420,7 +3416,9 @@
           drawnFillIds.add(filled.trade.id);
         };
         mutate();
+        if (!filled) return null;
         await persistStateNow(mutate);
+        if (!filled) return null;
         const { trade, position, opened } = filled;
         // The evidence chain is appended AFTER the wallet commit: a chained
         // link for a fill the CAS could still reject would be a permanent
@@ -3444,6 +3442,9 @@
         return { trade, position, opened };
       });
       const tCommitted = perfNow();
+      if (!result && fillQuote.supplySource === 'site-facts' && token && token.hostSupplyRejected) {
+        toast(lastQuoteRefusal);
+      }
       if (result) {
         // A committed fill is money evidence for the witness (F-47).
         lastAcceptedMarket = { priceNative: result.trade.priceNative, at: Date.now() };
@@ -3633,6 +3634,11 @@
         let filled = null;
         const mutate = () => {
           if (!token || token.mint !== fillQuote.mint) throw new Error('Token changed before the paper sell could be filled');
+          if (fillQuote.supplySource === 'site-facts' && token.hostSupplyRejected) {
+            refuseDisprovedHostFill(fillQuote);
+            filled = null;
+            return;
+          }
           filled = E.sell(state, settings, {
             ts: Date.now(), mint: token.mint, site: site.id,
             qtyFraction: fraction, priceNative: fillQuote.priceNative, priceUsd: fillQuote.priceUsd, mcap: fillQuote.mcap,
@@ -3647,7 +3653,9 @@
           drawnFillIds.add(filled.trade.id);
         };
         mutate();
+        if (!filled) return null;
         await persistStateNow(mutate);
+        if (!filled) return null;
         const { trade, position, round } = filled;
         // Chain append after the wallet commit — see doBuy for the ordering.
         await commitFill(trade);
@@ -3667,6 +3675,9 @@
         return { trade, position, round };
       });
       const tCommitted = perfNow();
+      if (!result && fillQuote.supplySource === 'site-facts' && token && token.hostSupplyRejected) {
+        toast(lastQuoteRefusal);
+      }
       if (result) {
         // A committed fill is money evidence for the witness (F-47).
         lastAcceptedMarket = { priceNative: result.trade.priceNative, at: Date.now() };

--- a/extension/content.js
+++ b/extension/content.js
@@ -1061,8 +1061,6 @@
       onchainLive = true;
       if (Number(found.supplyUi) > 0) {
         reconcileHostSupply(found.supplyUi);
-        token.supplyUi = Number(found.supplyUi);
-        token.decimals = Number(found.decimals);
       }
       renderSiteStatus();
       refreshRugVerdict(found.mint);

--- a/extension/content.js
+++ b/extension/content.js
@@ -534,6 +534,12 @@
   window.addEventListener('message', onBridgeMessage);
 
   const HOST_FACT_ADDRESS_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+  // Quote/native pool assets must never become the tracked token identity.
+  const HOST_FACT_QUOTE_MINTS = new Set([
+    'So11111111111111111111111111111111111111112',
+    'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+    'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
+  ]);
   const hostSupplyRefusals = new Set();
 
   function recordHostFactsDiagnostic(message, kind, details) {
@@ -548,7 +554,7 @@
     if (hostSupplyRefusals.has(mint)) return;
     hostSupplyRefusals.add(mint);
     recordHostFactsDiagnostic('refused host supply for ' + mint
-      + ' (mcap/priceUsd disagreed by more than 1%)', 'host-facts-supply-refused', {
+      + ' (no supply reading agreed with mcap/priceUsd within 1%)', 'host-facts-supply-refused', {
       source: facts && facts.source,
       url: facts && facts.url,
       values: facts ? {
@@ -566,6 +572,7 @@
     const factMint = typeof facts.mint === 'string' ? facts.mint : '';
     if (addresses.indexOf(srcAddress) !== -1
       && HOST_FACT_ADDRESS_RE.test(factMint)
+      && !HOST_FACT_QUOTE_MINTS.has(factMint)
       && factMint !== srcAddress
       && token.mint !== factMint) {
       const oldMint = token.mint;
@@ -593,10 +600,13 @@
         return;
       }
       const decimals = Number(facts.decimals);
-      declaredUi = Number.isInteger(decimals) && decimals >= 0
-        ? rawSupply / (10 ** decimals) : rawSupply;
-      if (!(declaredUi > 0) || !Number.isFinite(declaredUi)
-        || Math.abs(implied - declaredUi) / declaredUi > 0.01) {
+      const readings = [rawSupply];
+      if (Number.isInteger(decimals) && decimals >= 0) {
+        readings.push(rawSupply / (10 ** decimals));
+      }
+      declaredUi = readings.find((reading) => reading > 0 && Number.isFinite(reading)
+        && Math.abs(implied - reading) / reading <= 0.01) || null;
+      if (!(declaredUi > 0)) {
         refuseHostSupply(token.mint, facts);
         return;
       }
@@ -817,6 +827,11 @@
     if (verdict.priceUsd) token.priceUsd = verdict.priceUsd;
     if (verdict.mcap) token.mcap = verdict.mcap;
     token.priceSource = payload.source || 'page-feed';
+    if (verdict.supplyBasis === 'host') {
+      token.hostSupplySource = 'site-facts';
+      token.hostSupplyFillWitness = token.hostSupplyWitness
+        ? JSON.parse(JSON.stringify(token.hostSupplyWitness)) : null;
+    }
     // Market evidence for the fill witness (F-47): only prices the validator
     // actually ACCEPTED count — never a resolver adoption, which is exactly
     // the source class that once resurrected a pre-crash price.
@@ -1362,11 +1377,20 @@
     if (Math.abs(measured - host) / host <= 0.02) {
       token.hostSupplyUi = null;
       token.hostSupplyWitness = null;
+      token.hostSupplySource = null;
+      token.hostSupplyFillWitness = null;
       return;
     }
     token.hostSupplyUi = null;
     token.hostSupplyWitness = null;
+    token.hostSupplySource = null;
+    token.hostSupplyFillWitness = null;
     token.hostSupplyRejected = true;
+    const pos = state.positions && state.positions[token.mint];
+    if (pos) {
+      pos.hostSupplyDiscrepancy = true;
+      persistSoon();
+    }
     recordHostFactsDiagnostic('host supply disagrees with measured supply',
       'host-facts-supply-mismatch', {
       mint: token.mint,
@@ -2001,6 +2025,8 @@
       mcap: Number(token.mcap) > 0 ? Number(token.mcap) : null,
       source: token.priceSource || 'unknown',
       receivedAt: lastPriceAt,
+      supplySource: token.hostSupplySource || null,
+      hostSupplyWitness: token.hostSupplyFillWitness || null,
     };
   }
 
@@ -3375,6 +3401,8 @@
             // report into a journal lookup instead of a screenshot forensic.
             priceSource: fillQuote.source || null,
             priceAgeMs: fillQuote.receivedAt > 0 ? Date.now() - fillQuote.receivedAt : null,
+            supplySource: fillQuote.supplySource || null,
+            hostSupplyWitness: fillQuote.hostSupplyWitness || null,
             chain: token.chain || 'solana',
             solAmount,
             // The dollar amount the trader actually tapped on a foreign-chain
@@ -3612,6 +3640,8 @@
             // F-48: fill price provenance — see doBuy.
             priceSource: fillQuote.source || null,
             priceAgeMs: fillQuote.receivedAt > 0 ? Date.now() - fillQuote.receivedAt : null,
+            supplySource: fillQuote.supplySource || null,
+            hostSupplyWitness: fillQuote.hostSupplyWitness || null,
           });
           // F-41: claimed before the journal can be observed (see doBuy).
           drawnFillIds.add(filled.trade.id);
@@ -7674,6 +7704,9 @@
     // Armed levels change from the chart (a drag, a cancel) and from the
     // wallet (an order firing), neither of which rebuilds the card.
     renderOrderList();
+    posEls.pnl.title = pos.hostSupplyDiscrepancy
+      ? 'Warning: entry price and P&L use a host supply that disagreed with measured supply.'
+      : '';
 
     const mark = Q.positionMark(pos, token.priceNative, token.priceUsd);
     if (!mark) return;
@@ -7797,6 +7830,7 @@
     posEls.entry.textContent = DASH;
     posEls.value.textContent = DASH;
     posEls.pnl.textContent = DASH;
+    posEls.pnl.title = '';
     posEls.pnl.classList.remove('pt-green', 'pt-red', 'pt-flash-up', 'pt-flash-down');
 
     if (posEls.ledger) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -544,12 +544,12 @@
     } catch (_) { /* diagnostics must never affect the trading path */ }
   }
 
-  function refuseHostSupply(mint, facts) {
+  function hostSupplyEvidenceKey(mint, facts) {
     const keyPart = (value) => {
       const number = Number(value);
       return Number.isFinite(number) ? number.toPrecision(12) : String(value);
     };
-    const key = [
+    return [
       mint,
       facts && facts.source,
       keyPart(facts && facts.priceUsd),
@@ -557,20 +557,41 @@
       keyPart(facts && facts.supply),
       keyPart(facts && facts.decimals),
     ].join('|');
+  }
+
+  function recordHostSupplyDiagnostic(mint, facts, message, kind, details) {
+    const key = hostSupplyEvidenceKey(mint, facts);
     if (hostSupplyRefusals.has(key)) return;
     const count = hostSupplyRefusalCounts.get(mint) || 0;
     if (count >= 8) return;
     hostSupplyRefusals.add(key);
     hostSupplyRefusalCounts.set(mint, count + 1);
-    recordHostFactsDiagnostic('refused host supply for ' + mint
-      + ' (no supply reading agreed with mcap/priceUsd within 1%)', 'host-facts-supply-refused', {
+    recordHostFactsDiagnostic(message, kind, {
       source: facts && facts.source,
       url: facts && facts.url,
       values: facts ? {
         priceUsd: facts.priceUsd, mcap: facts.mcap,
         supply: facts.supply, decimals: facts.decimals,
       } : null,
+      ...(details || {}),
     });
+  }
+
+  function refuseHostSupply(mint, facts) {
+    recordHostSupplyDiagnostic(mint, facts, 'refused host supply for ' + mint
+      + ' (no supply reading agreed with mcap/priceUsd within 1%)',
+    'host-facts-supply-refused');
+  }
+
+  function noteUncorroboratedHostSupply(mint, facts) {
+    recordHostSupplyDiagnostic(mint, facts,
+      'host supply for ' + mint + ' lacks corroborating USD price and live market cap',
+      'host-facts-supply-uncorroborated', {
+        missing: {
+          priceUsd: !(Number(facts && facts.priceUsd) > 0),
+          mcap: !(Number(facts && facts.mcap) > 0),
+        },
+      });
   }
 
   function handleHostFacts(facts) {
@@ -586,6 +607,10 @@
     }
     if (decision.refused) {
       refuseHostSupply(token.mint, facts);
+      return;
+    }
+    if (decision.reason === 'no-united-price') {
+      noteUncorroboratedHostSupply(token.mint, facts);
       return;
     }
     if (!(decision.supplyUi > 0)) return;

--- a/extension/content.js
+++ b/extension/content.js
@@ -1644,7 +1644,6 @@
       if (!token || token.mint !== forMint) return;
       if (!fresh || !(fresh.priceNative > 0)) return;
       if (fresh.mint && fresh.mint !== token.mint) return;
-      clearHostSupplyLineage();
       // F-61: a refresh re-quotes /tokens/<mint> — EVERY pool for this base
       // mint, including graduated bonding-era pairs. An initial resolve via
       // /pairs/<addr> carried only that one pool; adopt the full list so the
@@ -1687,6 +1686,7 @@
         return;
       }
 
+      clearHostSupplyLineage();
       token.priceNative = fresh.priceNative;
       if (fresh.priceUsd) token.priceUsd = fresh.priceUsd;
       if (fresh.mcap) token.mcap = fresh.mcap;

--- a/extension/content.js
+++ b/extension/content.js
@@ -471,6 +471,7 @@
     if (event.origin && event.origin !== location.origin) return;
     const ev = event.data;
     if (ev.type === 'tick') { noteRowPrice(ev.payload); handlePageTick(ev.payload); }
+    else if (ev.type === 'facts') handleHostFacts(ev.payload);
     else if (ev.type === 'row-buy') {
       // A quick-buy chip injected by the MAIN-world bridge was tapped; the
       // fill pipeline itself lives here. The done-signal lets the bridge
@@ -531,6 +532,76 @@
     }
   }
   window.addEventListener('message', onBridgeMessage);
+
+  const HOST_FACT_ADDRESS_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+  const hostSupplyRefusals = new Set();
+
+  function refuseHostSupply(mint, facts) {
+    if (hostSupplyRefusals.has(mint)) return;
+    hostSupplyRefusals.add(mint);
+    console.debug('PaperTrench: refused host supply for ' + mint
+      + ' (mcap/priceUsd disagreed by more than 1%)', {
+      source: facts && facts.source,
+      url: facts && facts.url,
+    });
+  }
+
+  function handleHostFacts(facts) {
+    if (!facts || !token || !token.pending) return;
+
+    const addresses = Array.isArray(facts.addresses) ? facts.addresses : [];
+    const srcAddress = typeof token.srcAddress === 'string' ? token.srcAddress : '';
+    const factMint = typeof facts.mint === 'string' ? facts.mint : '';
+    if (addresses.indexOf(srcAddress) !== -1
+      && HOST_FACT_ADDRESS_RE.test(factMint)
+      && factMint !== srcAddress
+      && token.mint !== factMint) {
+      const oldMint = token.mint;
+      if (armedBuy && armedBuy.mint === oldMint) armedBuy.mint = factMint;
+      rekeyLiveState(oldMint, factMint);
+      token.mint = factMint;
+      token.pairAddress = facts.poolAddress || token.pairAddress || null;
+      sendPadreMarker('paper-axis', { pairAddress: token.pairAddress, mint: token.mint });
+    }
+
+    if (token.hostSupplyRejected) return;
+    const priceUsd = Number(facts.priceUsd);
+    const mcap = Number(facts.mcap);
+    if (!(priceUsd > 0) || !(mcap > 0)) return;
+    const implied = mcap / priceUsd;
+    if (!(implied > 0) || !Number.isFinite(implied)) return;
+
+    const hasSupply = facts.supply !== null && facts.supply !== undefined;
+    const rawSupply = Number(facts.supply);
+    let declaredUi = null;
+    if (hasSupply) {
+      if (!(rawSupply > 0) || !Number.isFinite(rawSupply)) {
+        refuseHostSupply(token.mint || factMint, facts);
+        return;
+      }
+      const decimals = Number(facts.decimals);
+      declaredUi = Number.isInteger(decimals) && decimals >= 0
+        ? rawSupply / (10 ** decimals) : rawSupply;
+      if (!(declaredUi > 0) || !Number.isFinite(declaredUi)
+        || Math.abs(implied - declaredUi) / declaredUi > 0.01) {
+        refuseHostSupply(factMint || token.mint, facts);
+        return;
+      }
+    }
+
+    token.hostSupplyUi = declaredUi || implied;
+    token.hostSupplyWitness = {
+      source: facts.source || null,
+      url: facts.url || null,
+      keys: {
+        priceUsd: facts.priceUsd,
+        mcap: facts.mcap,
+        supply: facts.supply,
+        decimals: facts.decimals,
+      },
+      atMs: Date.now(),
+    };
+  }
 
   function sendPadreMarker(type, payload) {
     window.postMessage({ source: 'papertrench-content', type, payload: payload || null }, '*');
@@ -953,6 +1024,7 @@
           sendPadreMarker('paper-axis', { pairAddress: token.pairAddress, mint: token.mint });
         }
         if (Number(found.supplyUi) > 0) {
+          reconcileHostSupply(found.supplyUi);
           token.supplyUi = Number(found.supplyUi);
           token.decimals = Number(found.decimals);
         }
@@ -1264,6 +1336,26 @@
       (k) => k !== tokenRecord.mint && tokenRecord.poolAddresses.indexOf(k) !== -1
     );
     for (const standIn of stranded) rekeyLiveState(standIn, tokenRecord.mint);
+  }
+
+  function reconcileHostSupply(measuredSupplyUi) {
+    if (!token || !(Number(token.hostSupplyUi) > 0)) return;
+    const measured = Number(measuredSupplyUi);
+    const host = Number(token.hostSupplyUi);
+    if (!(measured > 0) || !Number.isFinite(measured)) return;
+    if (Math.abs(measured - host) / host <= 0.02) {
+      token.hostSupplyUi = null;
+      token.hostSupplyWitness = null;
+      return;
+    }
+    token.hostSupplyUi = null;
+    token.hostSupplyWitness = null;
+    token.hostSupplyRejected = true;
+    console.debug('PaperTrench: host supply disagrees with measured supply', {
+      mint: token.mint,
+      hostSupplyUi: host,
+      measuredSupplyUi: measured,
+    });
   }
 
   function rekeyLiveState(oldMint, newMint) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -804,10 +804,13 @@
     if (verdict.priceUsd) token.priceUsd = verdict.priceUsd;
     if (verdict.mcap) token.mcap = verdict.mcap;
     token.priceSource = payload.source || 'page-feed';
-    token.hostSupplySource = verdict.supplyBasis === 'host' ? 'site-facts' : null;
-    token.hostSupplyFillWitness = verdict.supplyBasis === 'host'
-      && token.hostSupplyWitness
-      ? JSON.parse(JSON.stringify(token.hostSupplyWitness)) : null;
+    if (verdict.supplyBasis === 'host') {
+      token.hostSupplySource = 'site-facts';
+      token.hostSupplyFillWitness = token.hostSupplyWitness
+        ? JSON.parse(JSON.stringify(token.hostSupplyWitness)) : null;
+    } else if (verdict.supplyBasis) {
+      clearHostSupplyLineage();
+    }
     // Market evidence for the fill witness (F-47): only prices the validator
     // actually ACCEPTED count — never a resolver adoption, which is exactly
     // the source class that once resurrected a pre-crash price.
@@ -1058,6 +1061,7 @@
       // Re-anchor the bridge with the full identity so chart ticks match.
       sendPadreMarker('paper-axis', { pairAddress: token.pairAddress, mint: token.mint });
       if (Number(found.priceNative) > 0) {
+        clearHostSupplyLineage();
         handlePageTick({
           mint: found.mint,
           source: 'onchain-prewatch',
@@ -1375,6 +1379,12 @@
     });
   }
 
+  function clearHostSupplyLineage() {
+    if (!token) return;
+    token.hostSupplySource = null;
+    token.hostSupplyFillWitness = null;
+  }
+
   function rekeyLiveState(oldMint, newMint) {
     if (!oldMint || !newMint || oldMint === newMint) return;
     const cached = livePositionPrices[oldMint];
@@ -1410,6 +1420,9 @@
       hostSupplyRefusalCounts.clear();
     }
     token = data;
+    // Resolver adoption is an independent price basis. Do not carry a
+    // host-derived fill label onto the newly resolved token record.
+    if (token && Number(token.priceNative) > 0) clearHostSupplyLineage();
     // Keep a separate resolver anchor for validation. This is the price we
     // trust until a newer resolver quote or a first on-chain observation
     // confirms the live level. Live chart ticks validate against this, so one
@@ -1631,6 +1644,7 @@
       if (!token || token.mint !== forMint) return;
       if (!fresh || !(fresh.priceNative > 0)) return;
       if (fresh.mint && fresh.mint !== token.mint) return;
+      clearHostSupplyLineage();
       // F-61: a refresh re-quotes /tokens/<mint> — EVERY pool for this base
       // mint, including graduated bonding-era pairs. An initial resolve via
       // /pairs/<addr> carried only that one pool; adopt the full list so the
@@ -3256,6 +3270,10 @@
       if (token.srcAddress !== token.mint && token.pairAddress && token.pairAddress !== freshMint) return null;
       token.mint = freshMint;
     }
+    if (data.priceSource === 'resolver' || data.priceSource === 'chain'
+      || data.priceSource === 'row-onchain') {
+      clearHostSupplyLineage();
+    }
     token.priceNative = Number(data.priceNative);
     if (data.priceUsd) token.priceUsd = Number(data.priceUsd);
     if (data.mcap) token.mcap = Number(data.mcap);
@@ -3634,11 +3652,6 @@
         let filled = null;
         const mutate = () => {
           if (!token || token.mint !== fillQuote.mint) throw new Error('Token changed before the paper sell could be filled');
-          if (fillQuote.supplySource === 'site-facts' && token.hostSupplyRejected) {
-            refuseDisprovedHostFill(fillQuote);
-            filled = null;
-            return;
-          }
           filled = E.sell(state, settings, {
             ts: Date.now(), mint: token.mint, site: site.id,
             qtyFraction: fraction, priceNative: fillQuote.priceNative, priceUsd: fillQuote.priceUsd, mcap: fillQuote.mcap,
@@ -3653,9 +3666,7 @@
           drawnFillIds.add(filled.trade.id);
         };
         mutate();
-        if (!filled) return null;
         await persistStateNow(mutate);
-        if (!filled) return null;
         const { trade, position, round } = filled;
         // Chain append after the wallet commit — see doBuy for the ordering.
         await commitFill(trade);
@@ -3675,9 +3686,6 @@
         return { trade, position, round };
       });
       const tCommitted = perfNow();
-      if (!result && fillQuote.supplySource === 'site-facts' && token && token.hostSupplyRejected) {
-        toast(lastQuoteRefusal);
-      }
       if (result) {
         // A committed fill is money evidence for the witness (F-47).
         lastAcceptedMarket = { priceNative: result.trade.priceNative, at: Date.now() };

--- a/extension/content.js
+++ b/extension/content.js
@@ -536,13 +536,25 @@
   const HOST_FACT_ADDRESS_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
   const hostSupplyRefusals = new Set();
 
+  function recordHostFactsDiagnostic(message, kind, details) {
+    const EL = window.PTErrors;
+    if (!EL || typeof EL.record !== 'function') return;
+    try {
+      EL.record(message, { scope: 'content', kind, ...(details || {}) });
+    } catch (_) { /* diagnostics must never affect the trading path */ }
+  }
+
   function refuseHostSupply(mint, facts) {
     if (hostSupplyRefusals.has(mint)) return;
     hostSupplyRefusals.add(mint);
-    console.debug('PaperTrench: refused host supply for ' + mint
-      + ' (mcap/priceUsd disagreed by more than 1%)', {
+    recordHostFactsDiagnostic('refused host supply for ' + mint
+      + ' (mcap/priceUsd disagreed by more than 1%)', 'host-facts-supply-refused', {
       source: facts && facts.source,
       url: facts && facts.url,
+      values: facts ? {
+        priceUsd: facts.priceUsd, mcap: facts.mcap,
+        supply: facts.supply, decimals: facts.decimals,
+      } : null,
     });
   }
 
@@ -564,6 +576,7 @@
       sendPadreMarker('paper-axis', { pairAddress: token.pairAddress, mint: token.mint });
     }
 
+    if (factMint !== token.mint && addresses.indexOf(srcAddress) === -1) return;
     if (token.hostSupplyRejected) return;
     const priceUsd = Number(facts.priceUsd);
     const mcap = Number(facts.mcap);
@@ -576,7 +589,7 @@
     let declaredUi = null;
     if (hasSupply) {
       if (!(rawSupply > 0) || !Number.isFinite(rawSupply)) {
-        refuseHostSupply(token.mint || factMint, facts);
+        refuseHostSupply(token.mint, facts);
         return;
       }
       const decimals = Number(facts.decimals);
@@ -584,7 +597,7 @@
         ? rawSupply / (10 ** decimals) : rawSupply;
       if (!(declaredUi > 0) || !Number.isFinite(declaredUi)
         || Math.abs(implied - declaredUi) / declaredUi > 0.01) {
-        refuseHostSupply(factMint || token.mint, facts);
+        refuseHostSupply(token.mint, facts);
         return;
       }
     }
@@ -1046,6 +1059,11 @@
       // coin would price mcap ticks against a supply nobody measured.
       token.pumpCurve = found.poolKind === 'pump-curve';
       onchainLive = true;
+      if (Number(found.supplyUi) > 0) {
+        reconcileHostSupply(found.supplyUi);
+        token.supplyUi = Number(found.supplyUi);
+        token.decimals = Number(found.decimals);
+      }
       renderSiteStatus();
       refreshRugVerdict(found.mint);
       // Re-anchor the bridge with the full identity so chart ticks match.
@@ -1351,7 +1369,8 @@
     token.hostSupplyUi = null;
     token.hostSupplyWitness = null;
     token.hostSupplyRejected = true;
-    console.debug('PaperTrench: host supply disagrees with measured supply', {
+    recordHostFactsDiagnostic('host supply disagrees with measured supply',
+      'host-facts-supply-mismatch', {
       mint: token.mint,
       hostSupplyUi: host,
       measuredSupplyUi: measured,
@@ -1386,7 +1405,11 @@
     // Per-token feed counters must not leak across a token switch: stale mcap
     // activity could hold a NEW token's armed buy alive (F-16), and stale
     // out-of-band tallies could trigger a premature re-anchor (F-10).
-    if (!data || data.mint !== prevMint) { lastMcapTickAt = 0; oobRejects = 0; }
+    if (!data || data.mint !== prevMint) {
+      lastMcapTickAt = 0;
+      oobRejects = 0;
+      hostSupplyRefusals.clear();
+    }
     token = data;
     // Keep a separate resolver anchor for validation. This is the price we
     // trust until a newer resolver quote or a first on-chain observation
@@ -1492,14 +1515,17 @@
    * Sent only on change; the bridge's boot default is "wanted", so a missed
    * first message costs correctness nothing (it merely parses as before). */
   let lastWantsTicks = null;
+  let lastFactsWanted = null;
   function publishPageState() {
     const chipPage = Boolean(site && site.rowBuy
       && settings.listQuickBuyEnabled !== false
       && site.rowBuy.listPaths.test(location.pathname));
     const wants = Boolean(token) || chipPage;
-    if (wants === lastWantsTicks) return;
+    const facts = Boolean(token && token.pending);
+    if (wants === lastWantsTicks && facts === lastFactsWanted) return;
     lastWantsTicks = wants;
-    sendPadreMarker('page-state', { wantsTicks: wants });
+    lastFactsWanted = facts;
+    sendPadreMarker('page-state', { wantsTicks: wants, factsWanted: facts });
   }
 
   /**

--- a/extension/engine.js
+++ b/extension/engine.js
@@ -655,6 +655,8 @@
     // (the solNet pattern) — the attestation preimage is untouched.
     if (o.priceSource) trade.priceSource = String(o.priceSource);
     if (Number.isFinite(o.priceAgeMs)) trade.priceAgeMs = Math.max(0, Math.round(o.priceAgeMs));
+    if (o.supplySource) trade.supplySource = String(o.supplySource);
+    if (o.hostSupplyWitness) trade.hostSupplyWitness = o.hostSupplyWitness;
     state.journal.unshift(trade);
     pruneJournal(state);
     return { trade, position: pos };
@@ -744,6 +746,8 @@
     // F-48: price provenance — see buy().
     if (o.priceSource) trade.priceSource = String(o.priceSource);
     if (Number.isFinite(o.priceAgeMs)) trade.priceAgeMs = Math.max(0, Math.round(o.priceAgeMs));
+    if (o.supplySource) trade.supplySource = String(o.supplySource);
+    if (o.hostSupplyWitness) trade.hostSupplyWitness = o.hostSupplyWitness;
     state.journal.unshift(trade);
     pruneJournal(state);
 

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -498,12 +498,16 @@
     const emitFacts = () => {
       if (!factsWanted) return;
       let emitted = 0;
-      for (const rec of records.values()) {
-        if (emitted >= 3) break;
+      const watched = (currentSymbolInfo.mint && records.get(currentSymbolInfo.mint))
+        || (currentSymbolInfo.pairAddress && records.get(currentSymbolInfo.pairAddress))
+        || [...records.values()].find((candidate) => currentSymbolInfo.pairAddress
+          && candidate.addresses.indexOf(currentSymbolInfo.pairAddress) !== -1);
+      const emitRecord = (rec) => {
+        if (!rec) return false;
         const hasDifferentAddress = rec.mint
           && rec.addresses.some((address) => address !== rec.mint);
         if (!hasDifferentAddress && rec.supply === null
-          && rec.decimals === null && !rec.poolAddress) continue;
+          && rec.decimals === null && !rec.poolAddress) return false;
         const usdCandidate = rec.candidates.find((candidate) => candidate.unit === 'usd');
         emit('facts', {
           mint: rec.mint,
@@ -519,6 +523,12 @@
           url: url || null,
         });
         emitted++;
+        return true;
+      };
+      if (watched) emitRecord(watched);
+      for (const rec of records.values()) {
+        if (emitted >= 3) break;
+        if (rec !== watched) emitRecord(rec);
       }
     };
     let emittedTick = false;

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -194,6 +194,11 @@
   // positions-of-SOMEONE either way, and prices inside them are entries,
   // not the market.
   const POSITION_SUBTREE_KEY = /^(positions?|holdings?|portfolio|userPositions?|myPositions?|openOrders?|hodlers?|holders?|topHolders?|toptraders?|balances?)$/i;
+  // Historical snapshots are not the live market. Padre's pump.fun
+  // `callouts[0].marketCap` ($204.53M) showed $204.53M while the live BONK
+  // cap was about $263M (captured defect), so these subtrees must not feed
+  // prices, caps, or host-facts arithmetic.
+  const HISTORICAL_SUBTREE_KEY = /^(callouts?|history|historical|snapshots?|previous|prev|ath|candles?|bars?|ohlc|past)$/i;
   const MCAP_KEY = /^(marketCap|marketCapInUsd|mcap|mcapInUsd|fdv|fullyDilutedValuation)$/i;
   const SUPPLY_KEY = /^(supply|totalSupply|circulatingSupply|tokenSupply)$/i;
   const DECIMALS_KEY = /^decimals$/i;
@@ -344,7 +349,8 @@
           // USER, not the market: entry averages and cost bases inside it
           // must never tick the price (DEFECT F-30). Identity fields still
           // flow; prices and caps do not.
-          walk(value, depth + 1, target, tainted || POSITION_SUBTREE_KEY.test(key));
+          walk(value, depth + 1, target,
+            tainted || POSITION_SUBTREE_KEY.test(key) || HISTORICAL_SUBTREE_KEY.test(key));
           continue;
         }
         const rec = target || top;
@@ -358,10 +364,10 @@
         } else if (!tainted && MCAP_KEY.test(key)) {
           const n = numberValue(value);
           if (n > 0 && rec.mcap === null) rec.mcap = n;
-          if (n > 0 && nodeSnapshot && nodeSnapshot.mcap === null) {
+          if (!tainted && n > 0 && nodeSnapshot && nodeSnapshot.mcap === null) {
             nodeSnapshot.mcap = n;
           }
-        } else if (SUPPLY_KEY.test(key)) {
+        } else if (!tainted && SUPPLY_KEY.test(key)) {
           const n = numberValue(value);
           if (n > 0 && rec.supply === null) rec.supply = n;
           if (n > 0 && nodeSnapshot && nodeSnapshot.supply === null) {

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -266,7 +266,7 @@
     // in `top` (frames with no identifier at all), which downstream
     // anchor-banding still validates before use.
     const records = new Map();
-    const factSnapshots = [];
+    const factSnapshots = factsWanted ? [] : null;
     const top = { candidates: [], mcap: null, mint: null, symbol: null, name: null };
     const seen = new WeakSet();
     let budget = NODE_BUDGET;
@@ -319,7 +319,7 @@
           }
           target.addresses = Array.from(addresses);
         }
-        if (!Array.isArray(node) && target) {
+        if (factsWanted && !Array.isArray(node) && target) {
           nodeSnapshot = {
             candidates: [], mcap: null, mint: target.mint, symbol: null, name: null,
             supply: null, decimals: null, poolAddress: null, addresses: [],

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -266,6 +266,7 @@
     // in `top` (frames with no identifier at all), which downstream
     // anchor-banding still validates before use.
     const records = new Map();
+    const factSnapshots = [];
     const top = { candidates: [], mcap: null, mint: null, symbol: null, name: null };
     const seen = new WeakSet();
     let budget = NODE_BUDGET;
@@ -299,6 +300,7 @@
         && (looksLikeTradeEvent(node) || looksLikePositionRecord(node))) tainted = true;
 
       let target = ctx;
+      let nodeSnapshot = null;
       if (!Array.isArray(node)) {
         let bestRank = 0;
         let bestMint = null;
@@ -311,9 +313,23 @@
           target = recordFor(bestMint);
           const addresses = new Set(target.addresses);
           for (const value of Object.values(node)) {
-            if (typeof value === 'string' && BASE58_RE.test(value)) addresses.add(value);
+            if (typeof value === 'string' && BASE58_RE.test(value)) {
+              addresses.add(value);
+            }
           }
           target.addresses = Array.from(addresses);
+        }
+        if (!Array.isArray(node) && target) {
+          nodeSnapshot = {
+            candidates: [], mcap: null, mint: target.mint, symbol: null, name: null,
+            supply: null, decimals: null, poolAddress: null, addresses: [],
+          };
+          for (const value of Object.values(node)) {
+            if (typeof value === 'string' && BASE58_RE.test(value)) {
+              nodeSnapshot.addresses.push(value);
+            }
+          }
+          factSnapshots.push(nodeSnapshot);
         }
       }
 
@@ -337,29 +353,43 @@
           if (n > 0) {
             const unit = USD_HINT.test(key) ? 'usd' : NATIVE_HINT.test(key) ? 'native' : 'unknown';
             pushCandidate(rec, { value: n, unit, key });
+            if (nodeSnapshot) nodeSnapshot.candidates.push({ value: n, unit, key });
           }
         } else if (!tainted && MCAP_KEY.test(key)) {
           const n = numberValue(value);
           if (n > 0 && rec.mcap === null) rec.mcap = n;
+          if (n > 0 && nodeSnapshot && nodeSnapshot.mcap === null) {
+            nodeSnapshot.mcap = n;
+          }
         } else if (SUPPLY_KEY.test(key)) {
           const n = numberValue(value);
           if (n > 0 && rec.supply === null) rec.supply = n;
+          if (n > 0 && nodeSnapshot && nodeSnapshot.supply === null) {
+            nodeSnapshot.supply = n;
+          }
         } else if (DECIMALS_KEY.test(key)) {
           const n = numberValue(value);
           if (Number.isInteger(n) && n >= 0 && n <= 18 && rec.decimals === null) {
             rec.decimals = n;
           }
+          if (Number.isInteger(n) && n >= 0 && n <= 18
+            && nodeSnapshot && nodeSnapshot.decimals === null) {
+            nodeSnapshot.decimals = n;
+          }
         } else if (POOL_KEY.test(key) && typeof value === 'string' && BASE58_RE.test(value)) {
           if (!rec.poolAddress) rec.poolAddress = value;
+          if (nodeSnapshot && !nodeSnapshot.poolAddress) nodeSnapshot.poolAddress = value;
         } else if (SYMBOL_KEY.test(key) && typeof value === 'string' && value.length <= 24) {
           rec.symbol = rec.symbol || value;
+          if (nodeSnapshot && !nodeSnapshot.symbol) nodeSnapshot.symbol = value;
         } else if (NAME_KEY.test(key) && typeof value === 'string' && value.length <= 64) {
           rec.name = rec.name || value;
+          if (nodeSnapshot && !nodeSnapshot.name) nodeSnapshot.name = value;
         }
       }
     })(obj, 0, null, false);
 
-    return { records, top };
+    return { records, top, factSnapshots };
   }
 
   // GMGN's realtime WebSocket publishes every venue trade on the
@@ -493,21 +523,25 @@
       }
     }
 
-    const { records, top } = collect(parsed);
+    const { records, top, factSnapshots } = collect(parsed);
     const hasContent = (rec) => rec.candidates.length || rec.mcap !== null;
     const emitFacts = () => {
       if (!factsWanted) return;
       let emitted = 0;
-      const watched = (currentSymbolInfo.mint && records.get(currentSymbolInfo.mint))
-        || (currentSymbolInfo.pairAddress && records.get(currentSymbolInfo.pairAddress))
-        || [...records.values()].find((candidate) => currentSymbolInfo.pairAddress
-          && candidate.addresses.indexOf(currentSymbolInfo.pairAddress) !== -1);
-      const emitRecord = (rec) => {
+      const canEmit = (rec) => {
         if (!rec) return false;
         const hasDifferentAddress = rec.mint
           && rec.addresses.some((address) => address !== rec.mint);
-        if (!hasDifferentAddress && rec.supply === null
-          && rec.decimals === null && !rec.poolAddress) return false;
+        return hasDifferentAddress || rec.supply !== null
+          || rec.decimals !== null || rec.poolAddress;
+      };
+      const watched = factSnapshots.find((candidate) => canEmit(candidate)
+        && ((currentSymbolInfo.mint && candidate.mint === currentSymbolInfo.mint)
+        || (currentSymbolInfo.pairAddress && candidate.mint === currentSymbolInfo.pairAddress)
+        || (currentSymbolInfo.pairAddress
+          && candidate.addresses.indexOf(currentSymbolInfo.pairAddress) !== -1)));
+      const emitRecord = (rec) => {
+        if (!canEmit(rec)) return false;
         const usdCandidate = rec.candidates.find((candidate) => candidate.unit === 'usd');
         emit('facts', {
           mint: rec.mint,
@@ -526,11 +560,12 @@
         return true;
       };
       if (watched) emitRecord(watched);
-      for (const rec of records.values()) {
+      for (const rec of factSnapshots) {
         if (emitted >= 3) break;
         if (rec !== watched) emitRecord(rec);
       }
     };
+    emitFacts();
     let emittedTick = false;
     if (records.size) {
       // Watched token first — the GMGN fast-path contract, now generic — then
@@ -560,7 +595,6 @@
     if (!emittedTick && (top.candidates.length || top.mcap !== null)) {
       emit('tick', { ...top, source });
     }
-    emitFacts();
   }
 
   /* ---------------- SPA navigation signal ----------------

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -148,6 +148,7 @@
    * the instant it is thrown, not five minutes later.
    */
   let feedWanted = true;
+  let factsWanted = true;
 
   function feedActive() {
     return feedWanted && Date.now() - lastContentMessageAt <= CONTENT_SILENCE_LIMIT_MS;
@@ -495,6 +496,7 @@
     const { records, top } = collect(parsed);
     const hasContent = (rec) => rec.candidates.length || rec.mcap !== null;
     const emitFacts = () => {
+      if (!factsWanted) return;
       let emitted = 0;
       for (const rec of records.values()) {
         if (emitted >= 3) break;
@@ -2919,6 +2921,8 @@
     // chip scan is proof of a consumer regardless of message ordering.
     if (type === 'page-state') {
       feedWanted = Boolean(payload && payload.wantsTicks);
+      factsWanted = !payload || !Object.prototype.hasOwnProperty.call(payload, 'factsWanted')
+        ? true : Boolean(payload.factsWanted);
       return;
     }
     if (type === 'paper-axis' || type === 'row-scan') feedWanted = true;

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -194,6 +194,9 @@
   // not the market.
   const POSITION_SUBTREE_KEY = /^(positions?|holdings?|portfolio|userPositions?|myPositions?|openOrders?|hodlers?|holders?|topHolders?|toptraders?|balances?)$/i;
   const MCAP_KEY = /^(marketCap|marketCapInUsd|mcap|mcapInUsd|fdv|fullyDilutedValuation)$/i;
+  const SUPPLY_KEY = /^(supply|totalSupply|circulatingSupply|tokenSupply)$/i;
+  const DECIMALS_KEY = /^decimals$/i;
+  const POOL_KEY = /^(pairAddress|poolAddress|lpAddress|pool|pairId)$/i;
   // A record that IS a trade event — an id-carrying or user-attributed
   // swap/trade object (fomo's social feed, tx-hash trade tapes). Its price
   // and cap fields describe the moment that trade happened, minutes to
@@ -269,7 +272,10 @@
     const recordFor = (mint) => {
       let rec = records.get(mint);
       if (!rec) {
-        rec = { candidates: [], mcap: null, mint, symbol: null, name: null };
+        rec = {
+          candidates: [], mcap: null, mint, symbol: null, name: null,
+          supply: null, decimals: null, poolAddress: null, addresses: [],
+        };
         records.set(mint, rec);
       }
       return rec;
@@ -300,7 +306,14 @@
           const rank = mintKeyRank(key);
           if (rank > bestRank) { bestRank = rank; bestMint = value; }
         }
-        if (bestMint) target = recordFor(bestMint);
+        if (bestMint) {
+          target = recordFor(bestMint);
+          const addresses = new Set(target.addresses);
+          for (const value of Object.values(node)) {
+            if (typeof value === 'string' && BASE58_RE.test(value)) addresses.add(value);
+          }
+          target.addresses = Array.from(addresses);
+        }
       }
 
       const entries = Array.isArray(node)
@@ -327,6 +340,16 @@
         } else if (!tainted && MCAP_KEY.test(key)) {
           const n = numberValue(value);
           if (n > 0 && rec.mcap === null) rec.mcap = n;
+        } else if (SUPPLY_KEY.test(key)) {
+          const n = numberValue(value);
+          if (n > 0 && rec.supply === null) rec.supply = n;
+        } else if (DECIMALS_KEY.test(key)) {
+          const n = numberValue(value);
+          if (Number.isInteger(n) && n >= 0 && n <= 18 && rec.decimals === null) {
+            rec.decimals = n;
+          }
+        } else if (POOL_KEY.test(key) && typeof value === 'string' && BASE58_RE.test(value)) {
+          if (!rec.poolAddress) rec.poolAddress = value;
         } else if (SYMBOL_KEY.test(key) && typeof value === 'string' && value.length <= 24) {
           rec.symbol = rec.symbol || value;
         } else if (NAME_KEY.test(key) && typeof value === 'string' && value.length <= 64) {
@@ -471,6 +494,32 @@
 
     const { records, top } = collect(parsed);
     const hasContent = (rec) => rec.candidates.length || rec.mcap !== null;
+    const emitFacts = () => {
+      let emitted = 0;
+      for (const rec of records.values()) {
+        if (emitted >= 3) break;
+        const hasDifferentAddress = rec.mint
+          && rec.addresses.some((address) => address !== rec.mint);
+        if (!hasDifferentAddress && rec.supply === null
+          && rec.decimals === null && !rec.poolAddress) continue;
+        const usdCandidate = rec.candidates.find((candidate) => candidate.unit === 'usd');
+        emit('facts', {
+          mint: rec.mint,
+          symbol: rec.symbol,
+          name: rec.name,
+          supply: rec.supply,
+          decimals: rec.decimals,
+          poolAddress: rec.poolAddress,
+          addresses: rec.addresses.slice(),
+          priceUsd: usdCandidate ? usdCandidate.value : null,
+          mcap: rec.mcap,
+          source,
+          url: url || null,
+        });
+        emitted++;
+      }
+    };
+    let emittedTick = false;
     if (records.size) {
       // Watched token first — the GMGN fast-path contract, now generic — then
       // a bounded top-up so screener row chips keep their mint-tagged prices.
@@ -478,18 +527,28 @@
         || (currentSymbolInfo.pairAddress && records.get(currentSymbolInfo.pairAddress))
         || null;
       let emitted = 0;
-      if (watched && hasContent(watched)) { emit('tick', { ...watched, source }); emitted++; }
+      const emitTick = (rec) => emit('tick', {
+        candidates: rec.candidates,
+        mcap: rec.mcap,
+        mint: rec.mint,
+        symbol: rec.symbol,
+        name: rec.name,
+        source,
+      });
+      if (watched && hasContent(watched)) { emitTick(watched); emitted++; }
       for (const rec of records.values()) {
         if (rec === watched || !hasContent(rec)) continue;
         if (emitted++ >= 5) break;
-        emit('tick', { ...rec, source });
+        emitTick(rec);
       }
-      if (emitted) return;
+      emittedTick = emitted > 0;
       // Records existed but carried no prices; fall through to the
       // unattributed finds so a lone top-level price still ticks.
     }
-    if (!top.candidates.length && top.mcap === null) return;
-    emit('tick', { ...top, source });
+    if (!emittedTick && (top.candidates.length || top.mcap !== null)) {
+      emit('tick', { ...top, source });
+    }
+    emitFacts();
   }
 
   /* ---------------- SPA navigation signal ----------------

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -194,9 +194,9 @@
   // positions-of-SOMEONE either way, and prices inside them are entries,
   // not the market.
   const POSITION_SUBTREE_KEY = /^(positions?|holdings?|portfolio|userPositions?|myPositions?|openOrders?|hodlers?|holders?|topHolders?|toptraders?|balances?)$/i;
-  // Historical snapshots are not the live market. Padre's pump.fun
-  // `callouts[0].marketCap` ($204.53M) showed $204.53M while the live BONK
-  // cap was about $263M (captured defect), so these subtrees must not feed
+  // Historical snapshots are not the live market. On Padre, pump.fun's
+  // `callouts[0].marketCap` put $204.53M in the header while BONK's live cap
+  // was about $263M (captured defect), so these subtrees must not feed
   // prices, caps, or host-facts arithmetic.
   const HISTORICAL_SUBTREE_KEY = /^(callouts?|history|historical|snapshots?|previous|prev|ath|candles?|bars?|ohlc|past)$/i;
   const MCAP_KEY = /^(marketCap|marketCapInUsd|mcap|mcapInUsd|fdv|fullyDilutedValuation)$/i;

--- a/extension/quote.js
+++ b/extension/quote.js
@@ -486,7 +486,9 @@
     if (!t) return null;
     var measured = Number(t.supplyUi);
     if (measured > 0) return measured;
-    return isPumpFamily(t) ? PUMP_FAMILY_SUPPLY : null;
+    if (isPumpFamily(t)) return PUMP_FAMILY_SUPPLY;
+    var host = Number(t.hostSupplyUi);
+    return host > 0 ? host : null;
   }
 
   /** The unit-price band an mcap reading must land in to be credible. The

--- a/extension/quote.js
+++ b/extension/quote.js
@@ -470,6 +470,91 @@
     return typeof t.mint === 'string' && /pump$/.test(t.mint);
   }
 
+  var HOST_FACT_ADDRESS_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+  // Quote/native pool assets must never become the tracked token identity.
+  var HOST_FACT_QUOTE_MINTS = new Set([
+    'So11111111111111111111111111111111111111112',
+    'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+    'Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB',
+  ]);
+
+  function hostFactsDecision(t, facts) {
+    var result = {
+      adoptMint: null,
+      poolAddress: null,
+      supplyUi: null,
+      refused: false,
+      reason: null,
+    };
+    if (!t || !t.pending) {
+      result.reason = 'not-our-record';
+      return result;
+    }
+
+    var payload = facts && typeof facts === 'object' ? facts : {};
+    var addresses = Array.isArray(payload.addresses) ? payload.addresses : [];
+    var srcAddress = typeof t.srcAddress === 'string' ? t.srcAddress : '';
+    var factMint = typeof payload.mint === 'string' ? payload.mint : '';
+    var tiedToPage = factMint === t.mint
+      || (srcAddress && addresses.indexOf(srcAddress) !== -1);
+    if (!tiedToPage) {
+      result.reason = 'not-our-record';
+      return result;
+    }
+
+    var tiedToPageAddress = srcAddress && addresses.indexOf(srcAddress) !== -1;
+    var validMint = HOST_FACT_ADDRESS_RE.test(factMint);
+    if (tiedToPageAddress && validMint && factMint !== srcAddress && factMint !== t.mint) {
+      if (HOST_FACT_QUOTE_MINTS.has(factMint)) {
+        result.reason = 'quote-mint';
+      } else {
+        result.adoptMint = factMint;
+        result.poolAddress = typeof payload.poolAddress === 'string'
+          ? payload.poolAddress : null;
+      }
+    }
+
+    if (t.hostSupplyRejected) return result;
+
+    var priceUsd = Number(payload.priceUsd);
+    var mcap = Number(payload.mcap);
+    var hasSupply = payload.supply !== null && payload.supply !== undefined;
+    if (!(priceUsd > 0) || !(mcap > 0)) {
+      if (hasSupply) result.reason = result.reason || 'no-united-price';
+      return result;
+    }
+    var implied = mcap / priceUsd;
+    if (!(implied > 0) || !Number.isFinite(implied)) {
+      if (hasSupply) result.reason = result.reason || 'no-united-price';
+      return result;
+    }
+    if (!hasSupply) {
+      result.supplyUi = implied;
+      return result;
+    }
+
+    var rawSupply = Number(payload.supply);
+    if (!(rawSupply > 0) || !Number.isFinite(rawSupply)) {
+      result.refused = true;
+      result.reason = 'no-reading-agreed';
+      return result;
+    }
+    var decimals = Number(payload.decimals);
+    var readings = [rawSupply];
+    if (Number.isInteger(decimals) && decimals >= 0) {
+      readings.push(rawSupply / (10 ** decimals));
+    }
+    result.supplyUi = readings.find(function (reading) {
+      return reading > 0 && Number.isFinite(reading)
+        && Math.abs(implied - reading) / reading <= 0.01;
+    }) || null;
+    if (!(result.supplyUi > 0)) {
+      result.refused = true;
+      result.reason = 'no-reading-agreed';
+    }
+    return result;
+  }
+
   /**
    * The supply an mcap-scale reading may honestly be divided by, or null.
    *
@@ -1583,6 +1668,7 @@
     SCALE_STEP_RATIO,
     SCALE_STEP_WINDOW_MS,
     isPumpFamily,
+    hostFactsDecision,
     bootstrapSupply,
     bootstrapSupplyInfo,
     rugVerdict,

--- a/extension/quote.js
+++ b/extension/quote.js
@@ -482,13 +482,17 @@
    * No supply from either source means mcap readings stay unpriceable, which
    * is the honest answer, not a gap.
    */
-  function bootstrapSupply(t) {
-    if (!t) return null;
+  function bootstrapSupplyInfo(t) {
+    if (!t) return { supplyUi: null, basis: null };
     var measured = Number(t.supplyUi);
-    if (measured > 0) return measured;
-    if (isPumpFamily(t)) return PUMP_FAMILY_SUPPLY;
+    if (measured > 0) return { supplyUi: measured, basis: 'measured' };
+    if (isPumpFamily(t)) return { supplyUi: PUMP_FAMILY_SUPPLY, basis: 'pump-constant' };
     var host = Number(t.hostSupplyUi);
-    return host > 0 ? host : null;
+    return host > 0 ? { supplyUi: host, basis: 'host' } : { supplyUi: null, basis: null };
+  }
+
+  function bootstrapSupply(t) {
+    return bootstrapSupplyInfo(t).supplyUi;
   }
 
   /** The unit-price band an mcap reading must land in to be credible. The
@@ -520,6 +524,7 @@
         priceUsd: null,
         mcap: null,
         basis: null,
+        supplyBasis: null,
       };
     };
 
@@ -540,7 +545,7 @@
       || tick.source === 'gmgn-mcap-candle';
     if (!trusted) return reject('untrusted-source');
 
-    var accept = function (native, usd, mcap, basis) {
+    var accept = function (native, usd, mcap, basis, supplyBasis) {
       return {
         accepted: true,
         reason: 'ok',
@@ -548,6 +553,7 @@
         priceUsd: usd > 0 ? usd : null,
         mcap: mcap > 0 ? mcap : null,
         basis: basis,
+        supplyBasis: supplyBasis || null,
       };
     };
 
@@ -611,7 +617,8 @@
         // mcap, USD mcap — are judged against the same sane band, and the
         // tick is priced only when EXACTLY ONE fits (the F-25 discipline,
         // extended).
-        var supply = bootstrapSupply(pendingToken);
+        var supplyInfo = bootstrapSupplyInfo(pendingToken);
+        var supply = supplyInfo.supplyUi;
         if (rate && supply) {
           var band = mcapUnitBand(pendingToken);
           var readings = [
@@ -629,7 +636,8 @@
           });
           if (sane.length > 1) return reject('ambiguous-unit');
           if (sane.length === 1) {
-            return accept(sane[0].native, sane[0].usd, sane[0].mcap, sane[0].basis);
+            return accept(sane[0].native, sane[0].usd, sane[0].mcap, sane[0].basis,
+              supplyInfo.basis);
           }
           return reject('implausible-unit');
         }
@@ -673,7 +681,8 @@
     // A market-cap-only tick (GMGN/Axiom pre-index) can price any coin whose
     // supply is KNOWN — pump's protocol constant or a supply measured off the
     // mint account — through the same exactly-one-sane discipline.
-    var mcSupply = bootstrapSupply(pendingToken);
+    var mcSupplyInfo = bootstrapSupplyInfo(pendingToken);
+    var mcSupply = mcSupplyInfo.supplyUi;
     if (tickMcap > 0 && rate && mcSupply) {
       var mcBand = mcapUnitBand(pendingToken);
       var usdMc = tickMcap / mcSupply;
@@ -681,8 +690,9 @@
       var usdOk = usdMc >= mcBand.min && usdMc <= mcBand.max;
       var solOk = solMc >= mcBand.min && solMc <= mcBand.max;
       if (usdOk && solOk) return reject('ambiguous-unit');
-      if (usdOk) return accept(usdMc / rate, usdMc, tickMcap, 'mcap');
-      if (solOk) return accept(tickMcap / mcSupply, solMc, tickMcap * rate, 'native-mcap');
+      if (usdOk) return accept(usdMc / rate, usdMc, tickMcap, 'mcap', mcSupplyInfo.basis);
+      if (solOk) return accept(tickMcap / mcSupply, solMc, tickMcap * rate, 'native-mcap',
+        mcSupplyInfo.basis);
     }
     // A market-cap-only tick has no token price, so nothing can be filled yet.
     if (tickMcap > 0) return reject('mcap-only-no-supply');
@@ -1574,6 +1584,7 @@
     SCALE_STEP_WINDOW_MS,
     isPumpFamily,
     bootstrapSupply,
+    bootstrapSupplyInfo,
     rugVerdict,
     parsePresetList,
     positionMark,

--- a/extension/test/engine.test.js
+++ b/extension/test/engine.test.js
@@ -64,6 +64,26 @@ test('F-48: a fill records its price provenance — source and age ride the jour
   assert.equal(sell.trade.priceAgeMs, 95);
 });
 
+test('host supply provenance rides buy and sell journal rows', () => {
+  const settings = freshSettings();
+  const state = E.defaultState(settings);
+  const witness = { source: 'axiom', url: 'https://axiom.trade/meme/MintSupply' };
+  const buy = E.buy(state, settings, {
+    ts: 1_800_000_000_000, mint: 'MintSupply', symbol: 'SUP', site: 'axiom',
+    priceNative: 1e-7, solAmount: 1, supplySource: 'site-facts',
+    hostSupplyWitness: witness,
+  });
+  assert.equal(buy.trade.supplySource, 'site-facts');
+  assert.deepEqual(buy.trade.hostSupplyWitness, witness);
+  const sell = E.sell(state, settings, {
+    ts: 1_800_000_001_000, mint: 'MintSupply', site: 'axiom',
+    qtyFraction: 0.5, priceNative: 1e-7,
+    supplySource: 'site-facts', hostSupplyWitness: witness,
+  });
+  assert.equal(sell.trade.supplySource, 'site-facts');
+  assert.deepEqual(sell.trade.hostSupplyWitness, witness);
+});
+
 test('F-48: absent provenance stays absent — no invented fields, no negative ages', () => {
   const settings = freshSettings();
   const state = E.defaultState(settings);

--- a/extension/test/hostfacts.test.js
+++ b/extension/test/hostfacts.test.js
@@ -37,6 +37,9 @@ function loadContentHarness() {
         ' getState: () => state,',
         ' setArmed: (value) => { armedBuy = value; },',
         ' getArmed: () => armedBuy,',
+        ' pageTick: (payload) => handlePageTick(payload),',
+        ' doBuy: (amount, quotedUsd) => doBuy(amount, quotedUsd),',
+        ' reconcile: (measured) => reconcileHostSupply(measured),',
         ' prewatch: (candidate) => prewatchPending(candidate),',
         ' resetPrewatch: () => { prewatchedAddress = null; prewatchAttempts = 0; prewatchLastTryAt = 0; prewatchBackoffFor = null; }',
         ' };',
@@ -168,7 +171,9 @@ test('facts extraction keeps descendant addresses off the parent record', async 
   await env.fetch();
   const facts = env.emitted.find((message) => message.type === 'facts');
   assert.ok(facts);
-  assert.deepEqual(facts.payload.addresses, [MINT]);
+  assert.equal(facts.payload.addresses.length, 1);
+  assert.equal(facts.payload.addresses[0], PAIR);
+  assert.equal(facts.payload.mint, MINT);
   assert.equal(facts.payload.poolAddress, PAIR);
 });
 
@@ -214,6 +219,56 @@ test('watched facts are emitted before unrelated records consume the cap', async
   assert.equal(facts[0].payload.mint, MINT);
 });
 
+test('facts arrive before a same-response tick so a one-shot page can bootstrap', async () => {
+  const env = runBridge({
+    pair: {
+      baseMint: MINT, pairAddress: PAIR, priceNative: 0.00001,
+      priceUsd: 0.002, marketCap: 0.2, supply: 100, decimals: 0,
+    },
+  });
+  env.sendContent('paper-axis', { mint: PAIR, pairAddress: PAIR });
+  await env.fetch();
+  const messages = env.emitted.filter((message) => message.type === 'facts'
+    || message.type === 'tick');
+  const factsIndex = messages.findIndex((message) => message.type === 'facts');
+  const tickIndex = messages.findIndex((message) => message.type === 'tick');
+  assert.ok(factsIndex >= 0 && factsIndex < tickIndex);
+
+  const loader = loadContentHarness();
+  try {
+    const ov = loader.runOverlay([0.0001], { url: 'https://axiom.trade/meme/' + PAIR });
+    await settleOverlay(ov);
+    for (const message of messages) ov.dispatchBridge(message.type, message.payload);
+    assert.equal(ov.win.__hostFactsTest.getToken().mint, MINT);
+    assert.ok(ov.win.__hostFactsTest.getToken().priceNative > 0);
+  } finally {
+    loader.restore();
+  }
+});
+
+test('host facts do not merge arithmetic evidence across same-mint sibling nodes', async () => {
+  const env = runBridge({
+    quote: { mint: MINT, pairAddress: PAIR, priceUsd: 2 },
+    stats: { mint: MINT, pairAddress: PAIR, mcap: 200, supply: 100, decimals: 0 },
+  });
+  env.sendContent('paper-axis', { mint: PAIR, pairAddress: PAIR });
+  await env.fetch();
+  const facts = env.emitted.filter((message) => message.type === 'facts');
+  assert.equal(facts.length, 2);
+  assert.ok(facts.every((message) => !(message.payload.priceUsd > 0
+    && message.payload.mcap > 0 && message.payload.supply > 0)));
+
+  const loader = loadContentHarness();
+  try {
+    const ov = loader.runOverlay([0.0001], { url: 'https://axiom.trade/meme/' + PAIR });
+    await settleOverlay(ov);
+    for (const message of facts) ov.dispatchBridge('facts', message.payload);
+    assert.equal(ov.win.__hostFactsTest.getToken().hostSupplyUi, undefined);
+  } finally {
+    loader.restore();
+  }
+});
+
 test('pending content adopts a pair-tied mint and rewrites an armed buy', async () => {
   const loader = loadContentHarness();
   try {
@@ -250,6 +305,49 @@ test('pending content adopts a pair-tied mint and rewrites an armed buy', async 
   } finally {
     loader.restore();
   }
+});
+
+test('host-facts decisions are pure and preserve the R1/R2 rules', () => {
+  global.window = global.window || {};
+  const Q = require('../quote.js');
+  const token = { mint: PAIR, srcAddress: PAIR, pending: true };
+  const tied = {
+    mint: MINT, addresses: [PAIR, MINT], poolAddress: PAIR,
+    priceUsd: 2, mcap: 200, supply: 1000000, decimals: 4,
+  };
+  assert.deepEqual(Q.hostFactsDecision(token, tied), {
+    adoptMint: MINT, poolAddress: PAIR, supplyUi: 100,
+    refused: false, reason: null,
+  });
+  assert.deepEqual(Q.hostFactsDecision(token, {
+    mint: MINT, addresses: [OTHER], priceUsd: 2, mcap: 200, supply: 1000000,
+  }), {
+    adoptMint: null, poolAddress: null, supplyUi: null,
+    refused: false, reason: 'not-our-record',
+  });
+  assert.deepEqual(Q.hostFactsDecision(token, {
+    mint: 'So11111111111111111111111111111111111111112',
+    addresses: [PAIR], poolAddress: PAIR,
+  }), {
+    adoptMint: null, poolAddress: null, supplyUi: null,
+    refused: false, reason: 'quote-mint',
+  });
+  assert.deepEqual(Q.hostFactsDecision(token, {
+    mint: MINT, addresses: [PAIR], priceUsd: 2, mcap: 200,
+  }), {
+    adoptMint: MINT, poolAddress: null, supplyUi: 100,
+    refused: false, reason: null,
+  });
+  assert.deepEqual(Q.hostFactsDecision(token, {
+    mint: MINT, addresses: [PAIR], priceUsd: 2, mcap: 200,
+    supply: 1000000, decimals: 2,
+  }), {
+    adoptMint: MINT, poolAddress: null, supplyUi: null,
+    refused: true, reason: 'no-reading-agreed',
+  });
+  assert.equal(Q.hostFactsDecision(
+    { mint: PAIR, srcAddress: PAIR, pending: false }, tied
+  ).reason, 'not-our-record');
 });
 
 test('pending content ignores screener facts not tied to the page address', async () => {
@@ -358,6 +456,103 @@ test('pending content refuses mismatched host supply and unknown-unit prices', a
       supply: 1000000, decimals: 4,
     });
     assert.equal(api.getToken().hostSupplyUi, undefined);
+  } finally {
+    loader.restore();
+  }
+});
+
+test('refusal diagnostics dedupe by evidence and cap at eight per token', async () => {
+  const loader = loadContentHarness();
+  try {
+    const ov = loader.runOverlay([0.0001], { url: 'https://axiom.trade/meme/' + PAIR });
+    await settleOverlay(ov);
+    const records = [];
+    ov.win.PTErrors = { record: (message, details) => records.push({ message, details }) };
+    for (let i = 0; i < 10; i++) {
+      ov.dispatchBridge('facts', {
+        mint: MINT, addresses: [PAIR, MINT], source: 'source-' + i,
+        priceUsd: 2 + i, mcap: 200, supply: 1000000, decimals: 2,
+      });
+    }
+    ov.dispatchBridge('facts', {
+      mint: MINT, addresses: [PAIR, MINT], source: 'source-0',
+      priceUsd: 2, mcap: 200, supply: 1000000, decimals: 2,
+    });
+    assert.equal(records.length, 8);
+  } finally {
+    loader.restore();
+  }
+});
+
+test('accepted bootstrap basis resets stale host provenance', async () => {
+  const loader = loadContentHarness();
+  try {
+    const ov = loader.runOverlay([0.0001], { url: 'https://axiom.trade/meme/' + PAIR });
+    await settleOverlay(ov);
+    const api = ov.win.__hostFactsTest;
+    const Q = ov.win.PaperQuote;
+    const originalBootstrap = Q.bootstrapTick;
+    api.getToken().mint = MINT;
+    api.getToken().hostSupplyUi = 100;
+    api.getToken().hostSupplyWitness = { source: 'axiom', url: 'page' };
+    Q.bootstrapTick = () => ({
+      accepted: true, priceNative: 0.00001, priceUsd: 0.002,
+      mcap: 0.2, basis: 'mcap', supplyBasis: 'host',
+    });
+    api.pageTick({ mint: MINT, source: 'padre-chart-bar', candidates: [] });
+    assert.equal(api.getToken().hostSupplySource, 'site-facts');
+    assert.ok(api.getToken().hostSupplyFillWitness);
+
+    api.getToken().anchor = null;
+    api.getToken().priceNative = null;
+    api.getToken().priceUsd = null;
+    api.getToken().mcap = null;
+    Q.bootstrapTick = () => ({
+      accepted: true, priceNative: 0.00002, priceUsd: 0.004,
+      mcap: 0.4, basis: 'mcap', supplyBasis: 'pump-constant',
+    });
+    api.pageTick({ mint: MINT, source: 'padre-chart-bar', candidates: [] });
+    assert.equal(api.getToken().hostSupplySource, null);
+    assert.equal(api.getToken().hostSupplyFillWitness, null);
+    Q.bootstrapTick = originalBootstrap;
+  } finally {
+    loader.restore();
+  }
+});
+
+test('an in-flight host-supply buy is refused after reconciliation disproves it', async () => {
+  const loader = loadContentHarness();
+  try {
+    const ov = loader.runOverlay([0.0001], { url: 'https://axiom.trade/meme/' + PAIR });
+    await settleOverlay(ov);
+    const api = ov.win.__hostFactsTest;
+    const diagnostics = [];
+    ov.win.PTErrors = { record(message, details) { diagnostics.push({ message, details }); } };
+    const Q = ov.win.PaperQuote;
+    const originalBootstrap = Q.bootstrapTick;
+    const originalNeedsWitness = Q.needsFillWitness;
+    const originalWitnessAgrees = Q.witnessAgrees;
+    api.getToken().mint = MINT;
+    api.getToken().hostSupplyUi = 100;
+    api.getToken().hostSupplyWitness = { source: 'axiom', url: 'page' };
+    Q.bootstrapTick = () => ({
+      accepted: true, priceNative: 0.0001, priceUsd: 0.002,
+      mcap: 0.2, basis: 'mcap', supplyBasis: 'host',
+    });
+    api.pageTick({ mint: MINT, source: 'padre-chart-bar', candidates: [] });
+    Q.needsFillWitness = () => true;
+    Q.witnessAgrees = () => {
+      api.reconcile(110);
+      return true;
+    };
+    await api.doBuy(1, null);
+    await settleOverlay(ov);
+    const state = api.getState();
+    assert.equal(state.journal.filter((trade) => trade.mint === MINT).length, 0);
+    assert.ok(diagnostics.some((entry) => entry.details && entry.details.kind === 'host-facts-fill-refused'));
+    Q.bootstrapTick = originalBootstrap;
+    Q.needsFillWitness = originalNeedsWitness;
+    Q.witnessAgrees = originalWitnessAgrees;
   } finally {
     loader.restore();
   }

--- a/extension/test/hostfacts.test.js
+++ b/extension/test/hostfacts.test.js
@@ -375,6 +375,7 @@ test('measured prewatch supply reconciles host supply and latches discrepancies'
       await settleOverlay(ov2);
       assert.equal(api2.getToken().hostSupplyUi, null);
       assert.equal(api2.getToken().hostSupplyRejected, true);
+      assert.equal(api2.getToken().supplyUi, undefined);
       assert.ok(records2.some((record) => record.details.kind === 'host-facts-supply-mismatch'));
       ov2.dispatchBridge('facts', {
         mint: MINT, addresses: [PAIR, MINT], priceUsd: 2, mcap: 200,

--- a/extension/test/hostfacts.test.js
+++ b/extension/test/hostfacts.test.js
@@ -34,6 +34,7 @@ function loadContentHarness() {
       text = text.replace('\n})();\n', [
         '\n  window.__hostFactsTest = {',
         ' getToken: () => token,',
+        ' getState: () => state,',
         ' setArmed: (value) => { armedBuy = value; },',
         ' getArmed: () => armedBuy,',
         ' prewatch: (candidate) => prewatchPending(candidate),',
@@ -133,6 +134,28 @@ test('host identity facts are emitted for a pair-tied record', async () => {
   assert.equal(facts.payload.priceUsd, 0.000001);
 });
 
+test('quote-side host facts cannot rekey the page token', async () => {
+  const loader = loadContentHarness();
+  try {
+    const ov = loader.runOverlay([0.0001], { url: 'https://axiom.trade/meme/' + PAIR });
+    await settleOverlay(ov);
+    const api = ov.win.__hostFactsTest;
+    const wsol = 'So11111111111111111111111111111111111111112';
+    ov.dispatchBridge('facts', {
+      mint: wsol, addresses: [PAIR, wsol], poolAddress: PAIR,
+      priceUsd: null, mcap: null, supply: null, decimals: null,
+    });
+    assert.equal(api.getToken().mint, PAIR);
+    ov.dispatchBridge('facts', {
+      mint: MINT, addresses: [PAIR, MINT], poolAddress: PAIR,
+      priceUsd: null, mcap: null, supply: null, decimals: null,
+    });
+    assert.equal(api.getToken().mint, MINT);
+  } finally {
+    loader.restore();
+  }
+});
+
 test('facts extraction keeps descendant addresses off the parent record', async () => {
   const env = runBridge({
     token: {
@@ -175,6 +198,20 @@ test('facts are bounded to three records per frame and never become ticks', asyn
   const facts = env.emitted.filter((message) => message.type === 'facts');
   assert.equal(facts.length, 3);
   assert.equal(env.emitted.filter((message) => message.type === 'tick').length, 0);
+});
+
+test('watched facts are emitted before unrelated records consume the cap', async () => {
+  const body = {};
+  for (const mint of [OTHER, '4444444444444444444444444444444444444444444', '5555555555555555555555555555555555555555555']) {
+    body[mint] = { mint, supply: 1000000000, decimals: 9 };
+  }
+  body[MINT] = { mint: MINT, pairAddress: PAIR, supply: 1000000000, decimals: 9 };
+  const env = runBridge(body);
+  env.sendContent('paper-axis', { mint: MINT, pairAddress: PAIR });
+  await env.fetch();
+  const facts = env.emitted.filter((message) => message.type === 'facts');
+  assert.equal(facts.length, 3);
+  assert.equal(facts[0].payload.mint, MINT);
 });
 
 test('pending content adopts a pair-tied mint and rewrites an armed buy', async () => {
@@ -264,8 +301,39 @@ test('pending content accepts corroborated declared and implied host supply', as
     } finally {
       loader2.restore();
     }
+    const loader3 = loadContentHarness();
+    try {
+      const ov3 = loader3.runOverlay([0.0001], { url: 'https://axiom.trade/meme/' + PAIR });
+      await settleOverlay(ov3);
+      const api3 = ov3.win.__hostFactsTest;
+      ov3.dispatchBridge('facts', {
+        mint: MINT, addresses: [PAIR, MINT], priceUsd: 2, mcap: 200,
+        supply: 100, decimals: 9,
+      });
+      assert.equal(api3.getToken().hostSupplyUi, 100);
+    } finally {
+      loader3.restore();
+    }
   } finally {
     loader.restore();
+  }
+});
+
+test('host supply accepts atomic and already-scaled readings', async () => {
+  for (const supply of [100000000000, 100]) {
+    const loader = loadContentHarness();
+    try {
+      const ov = loader.runOverlay([0.0001], { url: 'https://axiom.trade/meme/' + PAIR });
+      await settleOverlay(ov);
+      const api = ov.win.__hostFactsTest;
+      ov.dispatchBridge('facts', {
+        mint: MINT, addresses: [PAIR, MINT], priceUsd: 2, mcap: 200,
+        supply, decimals: 9,
+      });
+      assert.equal(api.getToken().hostSupplyUi, 100);
+    } finally {
+      loader.restore();
+    }
   }
 });
 
@@ -352,6 +420,7 @@ test('measured prewatch supply reconciles host supply and latches discrepancies'
     await settleOverlay(ov);
     assert.equal(api.getToken().supplyUi, 101);
     assert.equal(api.getToken().hostSupplyUi, null);
+    assert.equal(api.getToken().hostSupplyRejected, undefined);
 
     const loader2 = loadContentHarness();
     try {
@@ -363,6 +432,8 @@ test('measured prewatch supply reconciles host supply and latches discrepancies'
       });
       await settleOverlay(ov2);
       const api2 = ov2.win.__hostFactsTest;
+      api2.getState().positions[MINT] = { mint: MINT };
+      api2.getState().journal.push({ mint: MINT, supplySource: 'site-facts' });
       const records2 = [];
       ov2.win.PTErrors = { record: (message, details) => records2.push({ message, details }) };
       ov2.dispatchBridge('facts', {
@@ -376,6 +447,8 @@ test('measured prewatch supply reconciles host supply and latches discrepancies'
       assert.equal(api2.getToken().hostSupplyUi, null);
       assert.equal(api2.getToken().hostSupplyRejected, true);
       assert.equal(api2.getToken().supplyUi, undefined);
+      assert.equal(api2.getState().positions[MINT].hostSupplyDiscrepancy, true);
+      assert.equal(api2.getState().journal[0].supplySource, 'site-facts');
       assert.ok(records2.some((record) => record.details.kind === 'host-facts-supply-mismatch'));
       ov2.dispatchBridge('facts', {
         mint: MINT, addresses: [PAIR, MINT], priceUsd: 2, mcap: 200,
@@ -412,4 +485,19 @@ test('bootstrapSupply precedence is measured, pump constant, then host', () => {
   assert.equal(Q.bootstrapSupply(pump), 1e9);
   const host = { mint: 'plain-mint', hostSupplyUi: 34 };
   assert.equal(Q.bootstrapSupply(host), 34);
+  assert.deepEqual(Q.bootstrapSupplyInfo(measured), { supplyUi: 12, basis: 'measured' });
+  assert.deepEqual(Q.bootstrapSupplyInfo(pump), { supplyUi: 1e9, basis: 'pump-constant' });
+  assert.deepEqual(Q.bootstrapSupplyInfo(host), { supplyUi: 34, basis: 'host' });
+});
+
+test('host-supply bootstrap reports its supply provenance', () => {
+  global.window = global.window || {};
+  const Q = require('../quote.js');
+  const verdict = Q.bootstrapTick(
+    { mint: 'plain-mint', hostSupplyUi: 100 },
+    { mint: 'plain-mint', mcap: 0.006, source: 'padre-chart-bar' },
+    2
+  );
+  assert.equal(verdict.accepted, true);
+  assert.equal(verdict.supplyBasis, 'host');
 });

--- a/extension/test/hostfacts.test.js
+++ b/extension/test/hostfacts.test.js
@@ -40,6 +40,7 @@ function loadContentHarness() {
         ' setArmed: (value) => { armedBuy = value; },',
         ' getArmed: () => armedBuy,',
         ' pageTick: (payload) => handlePageTick(payload),',
+        ' setLastPriceAt: (value) => { lastPriceAt = value; },',
         ' doBuy: (amount, quotedUsd) => doBuy(amount, quotedUsd),',
         ' doSell: (fraction) => doSell(fraction),',
         ' reconcile: (measured) => reconcileHostSupply(measured),',
@@ -548,11 +549,61 @@ test('resolver replacement clears host-supply lineage', async () => {
     api.pageTick({ mint: MINT, source: 'padre-chart-bar', candidates: [] });
     assert.equal(api.getToken().hostSupplySource, 'site-facts');
 
+    api.setLastPriceAt(0);
     await api.requote();
     await settleOverlay(ov);
     assert.equal(api.getToken().hostSupplySource, null);
     assert.equal(api.getToken().hostSupplyFillWitness, null);
     Q.bootstrapTick = originalBootstrap;
+  } finally {
+    loader.restore();
+  }
+});
+
+test('live-feed requote preserves host-supply lineage through later rejection', async () => {
+  const loader = loadContentHarness();
+  try {
+    const ov = loader.runOverlay([0.0001], {
+      url: 'https://axiom.trade/meme/' + PAIR,
+      refresh: () => ({
+        mint: MINT, priceNative: 0.00002, priceUsd: 0.004,
+        mcap: 0.4, priceSource: 'resolver',
+      }),
+    });
+    await settleOverlay(ov);
+    const api = ov.win.__hostFactsTest;
+    const diagnostics = [];
+    ov.win.PTErrors = { record(message, details) { diagnostics.push({ message, details }); } };
+    const Q = ov.win.PaperQuote;
+    const originalBootstrap = Q.bootstrapTick;
+    const originalNeedsWitness = Q.needsFillWitness;
+    const originalWitnessAgrees = Q.witnessAgrees;
+    api.getToken().mint = MINT;
+    api.getToken().hostSupplyUi = 100;
+    api.getToken().hostSupplyWitness = { source: 'axiom', url: 'page' };
+    Q.bootstrapTick = () => ({
+      accepted: true, priceNative: 0.00001, priceUsd: 0.002,
+      mcap: 0.2, basis: 'mcap', supplyBasis: 'host',
+    });
+    api.pageTick({ mint: MINT, source: 'padre-chart-bar', candidates: [] });
+    assert.equal(api.getToken().hostSupplySource, 'site-facts');
+
+    await api.requote();
+    await settleOverlay(ov);
+    assert.equal(api.getToken().hostSupplySource, 'site-facts');
+
+    Q.needsFillWitness = () => true;
+    Q.witnessAgrees = () => {
+      api.reconcile(110);
+      return true;
+    };
+    await api.doBuy(1, null);
+    await settleOverlay(ov);
+    assert.equal(api.getState().journal.filter((trade) => trade.mint === MINT).length, 0);
+    assert.ok(diagnostics.some((entry) => entry.details && entry.details.kind === 'host-facts-fill-refused'));
+    Q.bootstrapTick = originalBootstrap;
+    Q.needsFillWitness = originalNeedsWitness;
+    Q.witnessAgrees = originalWitnessAgrees;
   } finally {
     loader.restore();
   }

--- a/extension/test/hostfacts.test.js
+++ b/extension/test/hostfacts.test.js
@@ -22,6 +22,8 @@ function loadContentHarness() {
       "const url = options.url || `https://axiom.trade/meme/${BONK}`;")
     .replace("if (msg.type === 'pt_resolve') return R.resolve(msg.address);",
       "if (msg.type === 'pt_resolve') return Promise.resolve(null);")
+    .replace("if (msg.type === 'pt_refresh') return R.refresh(msg.token);",
+      "if (msg.type === 'pt_refresh') return Promise.resolve(typeof options.refresh === 'function' ? options.refresh(msg.token) : R.refresh(msg.token));")
     .replace("if (msg.type === 'pt_sol_usd') return R.solUsd();",
       "if (msg.type === 'pt_sol_usd') return R.solUsd();\n"
         + "          if (msg.type === 'pt_onchain_prewatch') return Promise.resolve(typeof options.onchainPrewatch === 'function' ? options.onchainPrewatch(msg) : null);")
@@ -39,8 +41,10 @@ function loadContentHarness() {
         ' getArmed: () => armedBuy,',
         ' pageTick: (payload) => handlePageTick(payload),',
         ' doBuy: (amount, quotedUsd) => doBuy(amount, quotedUsd),',
+        ' doSell: (fraction) => doSell(fraction),',
         ' reconcile: (measured) => reconcileHostSupply(measured),',
         ' prewatch: (candidate) => prewatchPending(candidate),',
+        ' requote: () => requote(),',
         ' resetPrewatch: () => { prewatchedAddress = null; prewatchAttempts = 0; prewatchLastTryAt = 0; prewatchBackoffFor = null; }',
         ' };',
         '\n})();\n',
@@ -520,6 +524,40 @@ test('accepted bootstrap basis resets stale host provenance', async () => {
   }
 });
 
+test('resolver replacement clears host-supply lineage', async () => {
+  const loader = loadContentHarness();
+  try {
+    const ov = loader.runOverlay([0.0001], {
+      url: 'https://axiom.trade/meme/' + PAIR,
+      refresh: () => ({
+        mint: MINT, priceNative: 0.00002, priceUsd: 0.004,
+        mcap: 0.4, priceSource: 'resolver',
+      }),
+    });
+    await settleOverlay(ov);
+    const api = ov.win.__hostFactsTest;
+    const Q = ov.win.PaperQuote;
+    const originalBootstrap = Q.bootstrapTick;
+    api.getToken().mint = MINT;
+    api.getToken().hostSupplyUi = 100;
+    api.getToken().hostSupplyWitness = { source: 'axiom', url: 'page' };
+    Q.bootstrapTick = () => ({
+      accepted: true, priceNative: 0.00001, priceUsd: 0.002,
+      mcap: 0.2, basis: 'mcap', supplyBasis: 'host',
+    });
+    api.pageTick({ mint: MINT, source: 'padre-chart-bar', candidates: [] });
+    assert.equal(api.getToken().hostSupplySource, 'site-facts');
+
+    await api.requote();
+    await settleOverlay(ov);
+    assert.equal(api.getToken().hostSupplySource, null);
+    assert.equal(api.getToken().hostSupplyFillWitness, null);
+    Q.bootstrapTick = originalBootstrap;
+  } finally {
+    loader.restore();
+  }
+});
+
 test('an in-flight host-supply buy is refused after reconciliation disproves it', async () => {
   const loader = loadContentHarness();
   try {
@@ -540,6 +578,8 @@ test('an in-flight host-supply buy is refused after reconciliation disproves it'
       mcap: 0.2, basis: 'mcap', supplyBasis: 'host',
     });
     api.pageTick({ mint: MINT, source: 'padre-chart-bar', candidates: [] });
+    api.pageTick({ mint: MINT, source: 'padre-chart-bar', mcap: 0.2, candidates: [] });
+    assert.equal(api.getToken().hostSupplySource, 'site-facts');
     Q.needsFillWitness = () => true;
     Q.witnessAgrees = () => {
       api.reconcile(110);
@@ -550,6 +590,51 @@ test('an in-flight host-supply buy is refused after reconciliation disproves it'
     const state = api.getState();
     assert.equal(state.journal.filter((trade) => trade.mint === MINT).length, 0);
     assert.ok(diagnostics.some((entry) => entry.details && entry.details.kind === 'host-facts-fill-refused'));
+    Q.bootstrapTick = originalBootstrap;
+    Q.needsFillWitness = originalNeedsWitness;
+    Q.witnessAgrees = originalWitnessAgrees;
+  } finally {
+    loader.restore();
+  }
+});
+
+test('an in-flight host-supply sell still commits after reconciliation disproves it', async () => {
+  const loader = loadContentHarness();
+  try {
+    const ov = loader.runOverlay([0.0001], { url: 'https://axiom.trade/meme/' + PAIR });
+    await settleOverlay(ov);
+    const api = ov.win.__hostFactsTest;
+    const E = ov.win.PaperEngine;
+    const Q = ov.win.PaperQuote;
+    const originalBootstrap = Q.bootstrapTick;
+    const originalNeedsWitness = Q.needsFillWitness;
+    const originalWitnessAgrees = Q.witnessAgrees;
+    api.getToken().mint = MINT;
+    api.getToken().hostSupplyUi = 100;
+    api.getToken().hostSupplyWitness = { source: 'axiom', url: 'page' };
+    Q.bootstrapTick = () => ({
+      accepted: true, priceNative: 0.0001, priceUsd: 0.002,
+      mcap: 0.2, basis: 'mcap', supplyBasis: 'host',
+    });
+    api.pageTick({ mint: MINT, source: 'padre-chart-bar', candidates: [] });
+    const settings = E.defaultSettings();
+    E.buy(api.getState(), settings, {
+      ts: Date.now(), mint: MINT, symbol: 'FACT', site: 'axiom',
+      priceNative: 0.0001, priceUsd: 0.002, solAmount: 1,
+    });
+    ov.storage().pt_state = JSON.parse(JSON.stringify(api.getState()));
+    Q.needsFillWitness = () => true;
+    Q.witnessAgrees = () => {
+      api.reconcile(110);
+      return true;
+    };
+    await api.doSell(1);
+    await settleOverlay(ov);
+    const trades = api.getState().journal.filter((trade) => trade.mint === MINT);
+    const sell = trades.find((trade) => trade.side === 'sell');
+    assert.ok(sell);
+    assert.equal(sell.supplySource, 'site-facts');
+    assert.ok(sell.hostSupplyWitness);
     Q.bootstrapTick = originalBootstrap;
     Q.needsFillWitness = originalNeedsWitness;
     Q.witnessAgrees = originalWitnessAgrees;
@@ -669,6 +754,8 @@ test('bridge stops emitting facts after content publishes factsWanted false', as
   env.sendContent('page-state', { wantsTicks: true, factsWanted: false });
   await env.fetch();
   assert.equal(env.emitted.filter((message) => message.type === 'facts').length, 0);
+  assert.ok(env.emitted.some((message) => message.type === 'tick'),
+    'tick collection must remain active when facts are not wanted');
 });
 
 test('bootstrapSupply precedence is measured, pump constant, then host', () => {

--- a/extension/test/hostfacts.test.js
+++ b/extension/test/hostfacts.test.js
@@ -97,15 +97,17 @@ function runBridge(body) {
   for (const fn of timers.slice()) fn();
   return {
     emitted,
+    sendContent(type, payload) {
+      listeners.message({
+        source: win,
+        data: { source: 'papertrench-content', type, payload },
+      });
+    },
     async fetch() {
       await win.fetch('https://axiom.trade/api/frame');
       for (let i = 0; i < 10; i++) await Promise.resolve();
     },
   };
-}
-
-function contentSource() {
-  return fs.readFileSync(path.join(ROOT, 'content.js'), 'utf8');
 }
 
 test('host identity facts are emitted for a pair-tied record', async () => {
@@ -223,12 +225,13 @@ test('pending content ignores screener facts not tied to the page address', asyn
       mint: MINT,
       addresses: [OTHER],
       poolAddress: OTHER,
-      priceUsd: null,
-      mcap: null,
-      supply: null,
-      decimals: null,
+      priceUsd: 2,
+      mcap: 200,
+      supply: 1000000,
+      decimals: 4,
     });
     assert.equal(api.getToken().mint, PAIR);
+    assert.equal(api.getToken().hostSupplyUi, undefined);
   } finally {
     loader.restore();
   }
@@ -272,16 +275,38 @@ test('pending content refuses mismatched host supply and unknown-unit prices', a
     const ov = loader.runOverlay([0.0001], { url: 'https://axiom.trade/meme/' + PAIR });
     await settleOverlay(ov);
     const api = ov.win.__hostFactsTest;
+    const records = [];
+    ov.win.PTErrors = { record: (message, details) => records.push({ message, details }) };
     ov.dispatchBridge('facts', {
       mint: MINT, addresses: [PAIR, MINT], priceUsd: 2, mcap: 200,
       supply: 1000000, decimals: 2,
     });
     assert.equal(api.getToken().hostSupplyUi, undefined);
+    assert.equal(records.length, 1);
+    assert.equal(records[0].details.scope, 'content');
+    assert.equal(records[0].details.kind, 'host-facts-supply-refused');
     ov.dispatchBridge('facts', {
       mint: MINT, addresses: [PAIR, MINT], priceUsd: null, mcap: 200,
       supply: 1000000, decimals: 4,
     });
     assert.equal(api.getToken().hostSupplyUi, undefined);
+  } finally {
+    loader.restore();
+  }
+});
+
+test('facts do not move the pending token price by themselves', async () => {
+  const loader = loadContentHarness();
+  try {
+    const ov = loader.runOverlay([0.0001], { url: 'https://axiom.trade/meme/' + PAIR });
+    await settleOverlay(ov);
+    const api = ov.win.__hostFactsTest;
+    ov.dispatchBridge('facts', {
+      mint: MINT, addresses: [PAIR, MINT], priceUsd: 2, mcap: 200,
+      supply: null, decimals: null,
+    });
+    assert.equal(api.getToken().priceNative, null);
+    assert.equal(api.getToken().priceUsd, null);
   } finally {
     loader.restore();
   }
@@ -333,11 +358,13 @@ test('measured prewatch supply reconciles host supply and latches discrepancies'
       const ov2 = loader2.runOverlay([0.0001], {
         url: 'https://axiom.trade/meme/' + PAIR,
         onchainPrewatch: () => measured && {
-          mint: MINT, supplyUi: measured, decimals: 4, pool: null, poolKind: null,
+          mint: MINT, supplyUi: measured, decimals: 4, pool: PAIR, poolKind: 'pump-curve',
         },
       });
       await settleOverlay(ov2);
       const api2 = ov2.win.__hostFactsTest;
+      const records2 = [];
+      ov2.win.PTErrors = { record: (message, details) => records2.push({ message, details }) };
       ov2.dispatchBridge('facts', {
         mint: MINT, addresses: [PAIR, MINT], priceUsd: 2, mcap: 200,
         supply: 1000000, decimals: 4,
@@ -348,6 +375,7 @@ test('measured prewatch supply reconciles host supply and latches discrepancies'
       await settleOverlay(ov2);
       assert.equal(api2.getToken().hostSupplyUi, null);
       assert.equal(api2.getToken().hostSupplyRejected, true);
+      assert.ok(records2.some((record) => record.details.kind === 'host-facts-supply-mismatch'));
       ov2.dispatchBridge('facts', {
         mint: MINT, addresses: [PAIR, MINT], priceUsd: 2, mcap: 200,
         supply: 1000000, decimals: 4,
@@ -361,46 +389,17 @@ test('measured prewatch supply reconciles host supply and latches discrepancies'
   }
 });
 
-test('content host-facts contract gates on pending and ties identity to srcAddress', () => {
-  const source = contentSource();
-  assert.match(source, /else if \(ev\.type === 'facts'\) handleHostFacts\(ev\.payload\)/);
-  assert.match(source, /if \(!facts \|\| !token \|\| !token\.pending\) return;/);
-  assert.match(source, /addresses\.indexOf\(srcAddress\) !== -1/);
-  assert.match(source, /rekeyLiveState\(oldMint, factMint\)/);
-  assert.match(source, /armedBuy && armedBuy\.mint === oldMint/);
-  assert.match(source, /factMint !== srcAddress/);
-  assert.match(source, /token\.pairAddress = facts\.poolAddress \|\| token\.pairAddress \|\| null/);
-  assert.doesNotMatch(source.slice(source.indexOf('function handleHostFacts'), source.indexOf('\n  function ', source.indexOf('function handleHostFacts') + 1)), /pumpCurve|onchainLive/);
-  assert.match(source, /token\.hostSupplyRejected/);
-  assert.match(source, /token\.hostSupplyWitness/);
-});
-
-test('content host-facts contract never routes facts through tick handling', () => {
-  const source = contentSource();
-  const branch = source.slice(source.indexOf("ev.type === 'facts'"), source.indexOf("ev.type === 'row-buy'"));
-  assert.doesNotMatch(branch, /handlePageTick/);
-});
-
-test('content host-facts contract refuses disagreement and uses the stated 1% rule', () => {
-  const source = contentSource();
-  assert.match(source, /Math\.abs\(implied - declaredUi\) \/ declaredUi > 0\.01/);
-  assert.match(source, /refuseHostSupply\(token\.mint \|\| factMint, facts\)/);
-  assert.match(source, /token\.hostSupplyUi = declaredUi \|\| implied/);
-});
-
-test('content host-facts reconciliation uses measured supply and the stated 2% rule', () => {
-  const source = contentSource();
-  assert.match(source, /Math\.abs\(measured - host\) \/ host <= 0\.02/);
-  assert.match(source, /token\.hostSupplyRejected = true/);
-  assert.match(source, /host supply disagrees with measured supply/);
-});
-
-test('facts cannot be accepted after pending resolves', () => {
-  const source = contentSource();
-  const start = source.indexOf('function handleHostFacts');
-  const end = source.indexOf('\n  function ', start + 1);
-  assert.ok(start >= 0 && end > start);
-  assert.match(source.slice(start, end), /!token\.pending/);
+test('bridge stops emitting facts after content publishes factsWanted false', async () => {
+  const env = runBridge({
+    token: MINT,
+    supply: 1000000000,
+    decimals: 9,
+    priceUsd: 0.000001,
+    marketCap: 1000,
+  });
+  env.sendContent('page-state', { wantsTicks: true, factsWanted: false });
+  await env.fetch();
+  assert.equal(env.emitted.filter((message) => message.type === 'facts').length, 0);
 });
 
 test('bootstrapSupply precedence is measured, pump constant, then host', () => {
@@ -412,15 +411,4 @@ test('bootstrapSupply precedence is measured, pump constant, then host', () => {
   assert.equal(Q.bootstrapSupply(pump), 1e9);
   const host = { mint: 'plain-mint', hostSupplyUi: 34 };
   assert.equal(Q.bootstrapSupply(host), 34);
-});
-
-test('content source preserves host supply witness fields and does not set a price', () => {
-  const source = contentSource();
-  const start = source.indexOf('function handleHostFacts');
-  const end = source.indexOf('\n  function ', start + 1);
-  const branch = source.slice(start, end);
-  assert.match(branch, /token\.hostSupplyWitness = \{/);
-  assert.match(branch, /priceUsd: facts\.priceUsd/);
-  assert.doesNotMatch(branch, /token\.priceUsd\s*=/);
-  assert.doesNotMatch(branch, /handlePageTick/);
 });

--- a/extension/test/hostfacts.test.js
+++ b/extension/test/hostfacts.test.js
@@ -142,6 +142,23 @@ test('host identity facts are emitted for a pair-tied record', async () => {
   assert.equal(facts.payload.priceUsd, 0.000001);
 });
 
+test('historical callout caps do not tick or become fact evidence', async () => {
+  const historical = runBridge({
+    mint: MINT,
+    callouts: [{ marketCap: 204526509 }],
+  });
+  await historical.fetch();
+  assert.equal(historical.emitted.filter((message) => message.type === 'tick').length, 0);
+  assert.equal(historical.emitted.filter((message) => message.type === 'facts'
+    && message.payload.mcap !== null).length, 0);
+
+  const current = runBridge({ mint: MINT, marketCap: 204526509 });
+  await current.fetch();
+  const tick = current.emitted.find((message) => message.type === 'tick');
+  assert.ok(tick);
+  assert.equal(tick.payload.mcap, 204526509);
+});
+
 test('quote-side host facts cannot rekey the page token', async () => {
   const loader = loadContentHarness();
   try {
@@ -372,6 +389,39 @@ test('pending content ignores screener facts not tied to the page address', asyn
     });
     assert.equal(api.getToken().mint, PAIR);
     assert.equal(api.getToken().hostSupplyUi, undefined);
+  } finally {
+    loader.restore();
+  }
+});
+
+test('uncorroborated host supply emits a bounded diagnostic', async () => {
+  const loader = loadContentHarness();
+  try {
+    const ov = loader.runOverlay([0.0001], { url: 'https://axiom.trade/meme/' + PAIR });
+    await settleOverlay(ov);
+    const api = ov.win.__hostFactsTest;
+    const records = [];
+    ov.win.PTErrors = { record: (message, details) => records.push({ message, details }) };
+    const facts = {
+      mint: MINT, addresses: [PAIR, MINT], supply: 1000000000, decimals: 9,
+      priceUsd: null, mcap: null, source: 'axiom', url: 'https://api6.axiom.trade/pair-info',
+    };
+    ov.dispatchBridge('facts', facts);
+    ov.dispatchBridge('facts', facts);
+    assert.equal(api.getToken().hostSupplyUi, undefined);
+    assert.equal(records.length, 1);
+    assert.equal(records[0].details.kind, 'host-facts-supply-uncorroborated');
+    assert.equal(records[0].details.missing.priceUsd, true);
+    assert.equal(records[0].details.missing.mcap, true);
+
+    ov.dispatchBridge('facts', {
+      ...facts,
+      source: 'gmgn',
+      mcap: 100,
+    });
+    assert.equal(records.length, 2);
+    assert.equal(records[1].details.missing.priceUsd, true);
+    assert.equal(records[1].details.missing.mcap, false);
   } finally {
     loader.restore();
   }

--- a/extension/test/hostfacts.test.js
+++ b/extension/test/hostfacts.test.js
@@ -1,0 +1,426 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const PAIR = '1111111111111111111111111111111111111111111';
+const MINT = '2222222222222222222222222222222222222222222';
+const OTHER = '3333333333333333333333333333333333333333333';
+
+function loadContentHarness() {
+  global.window = {};
+  require('../engine.js');
+  const E = global.window.PaperEngine;
+  const source = fs.readFileSync(path.join(__dirname, 'statepersist.test.js'), 'utf8');
+  const start = source.indexOf('function runOverlay');
+  const end = source.indexOf('\n}\n\ntest(', start);
+  const originalRead = fs.readFileSync;
+  const runOverlaySource = source.slice(start, end + 2)
+    .replace("const url = `https://trade.padre.gg/trade/${BONK}`;",
+      "const url = options.url || `https://axiom.trade/meme/${BONK}`;")
+    .replace("if (msg.type === 'pt_resolve') return R.resolve(msg.address);",
+      "if (msg.type === 'pt_resolve') return Promise.resolve(null);")
+    .replace("if (msg.type === 'pt_sol_usd') return R.solUsd();",
+      "if (msg.type === 'pt_sol_usd') return R.solUsd();\n"
+        + "          if (msg.type === 'pt_onchain_prewatch') return Promise.resolve(typeof options.onchainPrewatch === 'function' ? options.onchainPrewatch(msg) : null);")
+    .replace('return {\n    advance,', 'return {\n    win,\n    advance,');
+  const runOverlay = new Function('ROOT', 'fs', 'path', 'vm', 'E', 'BONK',
+    `${runOverlaySource}; return runOverlay;`)(ROOT, fs, path, vm, E, PAIR);
+  fs.readFileSync = function (file, ...args) {
+    let text = originalRead.call(fs, file, ...args);
+    if (String(file).endsWith(path.join('extension', 'content.js'))) {
+      text = text.replace('\n})();\n', [
+        '\n  window.__hostFactsTest = {',
+        ' getToken: () => token,',
+        ' setArmed: (value) => { armedBuy = value; },',
+        ' getArmed: () => armedBuy,',
+        ' prewatch: (candidate) => prewatchPending(candidate),',
+        ' resetPrewatch: () => { prewatchedAddress = null; prewatchAttempts = 0; prewatchLastTryAt = 0; prewatchBackoffFor = null; }',
+        ' };',
+        '\n})();\n',
+      ].join(''));
+    }
+    return text;
+  };
+  return { runOverlay, restore() { fs.readFileSync = originalRead; } };
+}
+
+async function settleOverlay(overlay) {
+  for (let i = 0; i < 400; i++) await Promise.resolve();
+  return overlay;
+}
+
+function runBridge(body) {
+  const timers = [];
+  const emitted = [];
+  const listeners = {};
+  const responseBody = JSON.stringify(body);
+  const win = {
+    fetch(url) {
+      return Promise.resolve({
+        url: String(url),
+        headers: { get: () => 'application/json' },
+        clone: () => ({ text: () => Promise.resolve(responseBody) }),
+      });
+    },
+    XMLHttpRequest: function FakeXHR() {},
+    WebSocket: function FakeWebSocket() {},
+    SharedWorker: function FakeSharedWorker() {},
+    EventSource: undefined,
+    addEventListener(type, fn) { listeners[type] = fn; },
+    postMessage(message) { emitted.push(message); },
+  };
+  win.XMLHttpRequest.prototype.send = function () {};
+  win.XMLHttpRequest.prototype.addEventListener = function () {};
+  win.WebSocket.prototype.addEventListener = function () {};
+  win.SharedWorker.prototype.port = {
+    addEventListener() {},
+    start() {},
+  };
+  win.window = win;
+  const sandbox = {
+    window: win,
+    location: { href: 'https://axiom.trade/meme/' + PAIR, hostname: 'axiom.trade' },
+    console,
+    Date, Math, Number, String, Array, Object, Boolean, RegExp, Error,
+    Set, WeakSet, Symbol, JSON, Promise, isFinite,
+    setInterval(fn) { timers.push(fn); return timers.length; },
+    clearInterval() {},
+    setTimeout(fn) { fn(); return 1; },
+  };
+  const ctx = vm.createContext(sandbox);
+  vm.runInContext(fs.readFileSync(path.join(ROOT, 'price-bridge.js'), 'utf8'), ctx, {
+    filename: 'price-bridge.js',
+  });
+  for (const fn of timers.slice()) fn();
+  return {
+    emitted,
+    async fetch() {
+      await win.fetch('https://axiom.trade/api/frame');
+      for (let i = 0; i < 10; i++) await Promise.resolve();
+    },
+  };
+}
+
+function contentSource() {
+  return fs.readFileSync(path.join(ROOT, 'content.js'), 'utf8');
+}
+
+test('host identity facts are emitted for a pair-tied record', async () => {
+  const env = runBridge({
+    token: {
+      mint: MINT,
+      pairAddress: PAIR,
+      symbol: 'FACT',
+      supply: '1000000000',
+      decimals: 9,
+      priceUsd: 0.000001,
+      marketCap: 1000,
+    },
+  });
+  await env.fetch();
+  const facts = env.emitted.find((message) => message.type === 'facts');
+  assert.ok(facts);
+  assert.equal(facts.payload.mint, MINT);
+  assert.ok(facts.payload.addresses.includes(PAIR));
+  assert.equal(facts.payload.poolAddress, PAIR);
+  assert.equal(facts.payload.supply, 1000000000);
+  assert.equal(facts.payload.decimals, 9);
+  assert.equal(facts.payload.priceUsd, 0.000001);
+});
+
+test('facts extraction keeps descendant addresses off the parent record', async () => {
+  const env = runBridge({
+    token: {
+      mint: MINT,
+      priceUsd: 0.000001,
+      marketCap: 1000,
+      nested: { pairAddress: PAIR },
+    },
+  });
+  await env.fetch();
+  const facts = env.emitted.find((message) => message.type === 'facts');
+  assert.ok(facts);
+  assert.deepEqual(facts.payload.addresses, [MINT]);
+  assert.equal(facts.payload.poolAddress, PAIR);
+});
+
+test('unknown-unit chart closes never become priceUsd facts', async () => {
+  const env = runBridge({
+    token: {
+      mint: MINT,
+      marketCap: 1000,
+      close: 0.000001,
+      supply: 1000000000,
+      decimals: 9,
+    },
+  });
+  await env.fetch();
+  const facts = env.emitted.find((message) => message.type === 'facts');
+  assert.ok(facts);
+  assert.equal(facts.payload.priceUsd, null);
+});
+
+test('facts are bounded to three records per frame and never become ticks', async () => {
+  const body = {};
+  for (const mint of [MINT, OTHER, '4444444444444444444444444444444444444444444', '5555555555555555555555555555555555555555555']) {
+    body[mint] = { mint, supply: 1000000000, decimals: 9 };
+  }
+  const env = runBridge(body);
+  await env.fetch();
+  const facts = env.emitted.filter((message) => message.type === 'facts');
+  assert.equal(facts.length, 3);
+  assert.equal(env.emitted.filter((message) => message.type === 'tick').length, 0);
+});
+
+test('pending content adopts a pair-tied mint and rewrites an armed buy', async () => {
+  const loader = loadContentHarness();
+  try {
+    const ov = loader.runOverlay([0.0001], {
+      url: 'https://axiom.trade/meme/' + PAIR,
+    });
+    await settleOverlay(ov);
+    const api = ov.win.__hostFactsTest;
+    assert.equal(api.getToken().pending, true);
+    api.setArmed({ mint: PAIR });
+    const originalRekey = ov.win.PaperEngine.rekeyMint;
+    let rekeys = 0;
+    ov.win.PaperEngine.rekeyMint = function (state, oldMint, newMint) {
+      if (oldMint === PAIR && newMint === MINT) rekeys++;
+      return originalRekey(state, oldMint, newMint);
+    };
+    ov.dispatchBridge('facts', {
+      mint: MINT,
+      addresses: [PAIR, MINT],
+      poolAddress: PAIR,
+      priceUsd: null,
+      mcap: null,
+      supply: null,
+      decimals: null,
+    });
+    assert.equal(api.getToken().mint, MINT);
+    assert.equal(api.getArmed().mint, MINT);
+    assert.ok(rekeys >= 1);
+    assert.deepEqual(JSON.parse(JSON.stringify(ov.posted.find((message) => message.type === 'paper-axis'
+      && message.payload && message.payload.mint === MINT).payload)), {
+      pairAddress: PAIR,
+      mint: MINT,
+    });
+  } finally {
+    loader.restore();
+  }
+});
+
+test('pending content ignores screener facts not tied to the page address', async () => {
+  const loader = loadContentHarness();
+  try {
+    const ov = loader.runOverlay([0.0001], { url: 'https://axiom.trade/meme/' + PAIR });
+    await settleOverlay(ov);
+    const api = ov.win.__hostFactsTest;
+    ov.dispatchBridge('facts', {
+      mint: MINT,
+      addresses: [OTHER],
+      poolAddress: OTHER,
+      priceUsd: null,
+      mcap: null,
+      supply: null,
+      decimals: null,
+    });
+    assert.equal(api.getToken().mint, PAIR);
+  } finally {
+    loader.restore();
+  }
+});
+
+test('pending content accepts corroborated declared and implied host supply', async () => {
+  const loader = loadContentHarness();
+  try {
+    const ov = loader.runOverlay([0.0001], { url: 'https://axiom.trade/meme/' + PAIR });
+    await settleOverlay(ov);
+    const api = ov.win.__hostFactsTest;
+    ov.dispatchBridge('facts', {
+      mint: MINT, addresses: [PAIR, MINT], priceUsd: 2, mcap: 200,
+      supply: 1000000, decimals: 4, source: 'axiom', url: 'https://axiom.trade/meme/' + PAIR,
+    });
+    assert.equal(api.getToken().hostSupplyUi, 100);
+    assert.equal(api.getToken().hostSupplyWitness.source, 'axiom');
+    assert.equal(api.getToken().priceUsd, null);
+
+    const loader2 = loadContentHarness();
+    try {
+      const ov2 = loader2.runOverlay([0.0001], { url: 'https://axiom.trade/meme/' + PAIR });
+      await settleOverlay(ov2);
+      const api2 = ov2.win.__hostFactsTest;
+      ov2.dispatchBridge('facts', {
+        mint: MINT, addresses: [PAIR, MINT], priceUsd: 2, mcap: 200,
+        supply: null, decimals: null,
+      });
+      assert.equal(api2.getToken().hostSupplyUi, 100);
+    } finally {
+      loader2.restore();
+    }
+  } finally {
+    loader.restore();
+  }
+});
+
+test('pending content refuses mismatched host supply and unknown-unit prices', async () => {
+  const loader = loadContentHarness();
+  try {
+    const ov = loader.runOverlay([0.0001], { url: 'https://axiom.trade/meme/' + PAIR });
+    await settleOverlay(ov);
+    const api = ov.win.__hostFactsTest;
+    ov.dispatchBridge('facts', {
+      mint: MINT, addresses: [PAIR, MINT], priceUsd: 2, mcap: 200,
+      supply: 1000000, decimals: 2,
+    });
+    assert.equal(api.getToken().hostSupplyUi, undefined);
+    ov.dispatchBridge('facts', {
+      mint: MINT, addresses: [PAIR, MINT], priceUsd: null, mcap: 200,
+      supply: 1000000, decimals: 4,
+    });
+    assert.equal(api.getToken().hostSupplyUi, undefined);
+  } finally {
+    loader.restore();
+  }
+});
+
+test('resolved content does not adopt later host facts', async () => {
+  const loader = loadContentHarness();
+  try {
+    const ov = loader.runOverlay([0.0001], { url: 'https://axiom.trade/meme/' + PAIR });
+    await settleOverlay(ov);
+    const api = ov.win.__hostFactsTest;
+    api.getToken().pending = false;
+    ov.dispatchBridge('facts', {
+      mint: MINT, addresses: [PAIR, MINT], poolAddress: PAIR,
+      priceUsd: 2, mcap: 200, supply: null, decimals: null,
+    });
+    assert.equal(api.getToken().mint, PAIR);
+    assert.equal(api.getToken().hostSupplyUi, undefined);
+  } finally {
+    loader.restore();
+  }
+});
+
+test('measured prewatch supply reconciles host supply and latches discrepancies', async () => {
+  let measured = null;
+  const loader = loadContentHarness();
+  try {
+    const ov = loader.runOverlay([0.0001], {
+      url: 'https://axiom.trade/meme/' + PAIR,
+      onchainPrewatch: () => measured && {
+        mint: MINT, supplyUi: measured, decimals: 4, pool: null, poolKind: null,
+      },
+    });
+    await settleOverlay(ov);
+    const api = ov.win.__hostFactsTest;
+    ov.dispatchBridge('facts', {
+      mint: MINT, addresses: [PAIR, MINT], priceUsd: 2, mcap: 200,
+      supply: 1000000, decimals: 4,
+    });
+    measured = 101;
+    api.resetPrewatch();
+    api.prewatch({ kind: 'pair', address: PAIR });
+    await settleOverlay(ov);
+    assert.equal(api.getToken().supplyUi, 101);
+    assert.equal(api.getToken().hostSupplyUi, null);
+
+    const loader2 = loadContentHarness();
+    try {
+      const ov2 = loader2.runOverlay([0.0001], {
+        url: 'https://axiom.trade/meme/' + PAIR,
+        onchainPrewatch: () => measured && {
+          mint: MINT, supplyUi: measured, decimals: 4, pool: null, poolKind: null,
+        },
+      });
+      await settleOverlay(ov2);
+      const api2 = ov2.win.__hostFactsTest;
+      ov2.dispatchBridge('facts', {
+        mint: MINT, addresses: [PAIR, MINT], priceUsd: 2, mcap: 200,
+        supply: 1000000, decimals: 4,
+      });
+      measured = 200;
+      api2.resetPrewatch();
+      api2.prewatch({ kind: 'pair', address: PAIR });
+      await settleOverlay(ov2);
+      assert.equal(api2.getToken().hostSupplyUi, null);
+      assert.equal(api2.getToken().hostSupplyRejected, true);
+      ov2.dispatchBridge('facts', {
+        mint: MINT, addresses: [PAIR, MINT], priceUsd: 2, mcap: 200,
+        supply: 1000000, decimals: 4,
+      });
+      assert.equal(api2.getToken().hostSupplyUi, null);
+    } finally {
+      loader2.restore();
+    }
+  } finally {
+    loader.restore();
+  }
+});
+
+test('content host-facts contract gates on pending and ties identity to srcAddress', () => {
+  const source = contentSource();
+  assert.match(source, /else if \(ev\.type === 'facts'\) handleHostFacts\(ev\.payload\)/);
+  assert.match(source, /if \(!facts \|\| !token \|\| !token\.pending\) return;/);
+  assert.match(source, /addresses\.indexOf\(srcAddress\) !== -1/);
+  assert.match(source, /rekeyLiveState\(oldMint, factMint\)/);
+  assert.match(source, /armedBuy && armedBuy\.mint === oldMint/);
+  assert.match(source, /factMint !== srcAddress/);
+  assert.match(source, /token\.pairAddress = facts\.poolAddress \|\| token\.pairAddress \|\| null/);
+  assert.doesNotMatch(source.slice(source.indexOf('function handleHostFacts'), source.indexOf('\n  function ', source.indexOf('function handleHostFacts') + 1)), /pumpCurve|onchainLive/);
+  assert.match(source, /token\.hostSupplyRejected/);
+  assert.match(source, /token\.hostSupplyWitness/);
+});
+
+test('content host-facts contract never routes facts through tick handling', () => {
+  const source = contentSource();
+  const branch = source.slice(source.indexOf("ev.type === 'facts'"), source.indexOf("ev.type === 'row-buy'"));
+  assert.doesNotMatch(branch, /handlePageTick/);
+});
+
+test('content host-facts contract refuses disagreement and uses the stated 1% rule', () => {
+  const source = contentSource();
+  assert.match(source, /Math\.abs\(implied - declaredUi\) \/ declaredUi > 0\.01/);
+  assert.match(source, /refuseHostSupply\(token\.mint \|\| factMint, facts\)/);
+  assert.match(source, /token\.hostSupplyUi = declaredUi \|\| implied/);
+});
+
+test('content host-facts reconciliation uses measured supply and the stated 2% rule', () => {
+  const source = contentSource();
+  assert.match(source, /Math\.abs\(measured - host\) \/ host <= 0\.02/);
+  assert.match(source, /token\.hostSupplyRejected = true/);
+  assert.match(source, /host supply disagrees with measured supply/);
+});
+
+test('facts cannot be accepted after pending resolves', () => {
+  const source = contentSource();
+  const start = source.indexOf('function handleHostFacts');
+  const end = source.indexOf('\n  function ', start + 1);
+  assert.ok(start >= 0 && end > start);
+  assert.match(source.slice(start, end), /!token\.pending/);
+});
+
+test('bootstrapSupply precedence is measured, pump constant, then host', () => {
+  global.window = global.window || {};
+  const Q = require('../quote.js');
+  const measured = { mint: 'plain-mint', supplyUi: 12, hostSupplyUi: 34 };
+  assert.equal(Q.bootstrapSupply(measured), 12);
+  const pump = { mint: 'anythingpump', supplyUi: null, hostSupplyUi: 34 };
+  assert.equal(Q.bootstrapSupply(pump), 1e9);
+  const host = { mint: 'plain-mint', hostSupplyUi: 34 };
+  assert.equal(Q.bootstrapSupply(host), 34);
+});
+
+test('content source preserves host supply witness fields and does not set a price', () => {
+  const source = contentSource();
+  const start = source.indexOf('function handleHostFacts');
+  const end = source.indexOf('\n  function ', start + 1);
+  const branch = source.slice(start, end);
+  assert.match(branch, /token\.hostSupplyWitness = \{/);
+  assert.match(branch, /priceUsd: facts\.priceUsd/);
+  assert.doesNotMatch(branch, /token\.priceUsd\s*=/);
+  assert.doesNotMatch(branch, /handlePageTick/);
+});

--- a/extension/test/nativecharts.test.js
+++ b/extension/test/nativecharts.test.js
@@ -1931,7 +1931,7 @@ test('Turbo source contract: the content script publishes page-state demand', ()
   );
   assert.match(setTokenBody, /publishPageState\(\);/,
     'every token change must republish feed demand');
-  assert.match(content, /sendPadreMarker\('page-state', \{ wantsTicks: wants \}\)/,
+  assert.match(content, /sendPadreMarker\('page-state', \{ wantsTicks: wants, factsWanted: facts \}\)/,
     'the demand signal must reach the bridge as page-state');
   assert.match(content, /lastWantsTicks = null;/,
     'teardown must reset the publisher so a re-enable re-announces');


### PR DESCRIPTION
## Summary

Fresh pairs were pricing off RPC and Dexscreener because the extension threw away the terminal's own API/WS payloads — which already carry mint, pool and supply — and priced from chart pixels alone. This adds a **host-facts layer under the tick layer**: the page's payloads become the primary source for the three facts a chart tick can't carry (what the on-screen number *is*, the token's supply, and which mint a pair-address URL is showing), with RPC demoted to fallback and validation. Design writeup: `docs/DESIGN-host-facts.md`.

Two rules keep it from inventing numbers, and both refuse rather than guess:

- **R1 identity** — adopt a mint only when the same record ties it to the pair address in our own URL (`facts.addresses` contains `token.srcAddress`), the mint is base58 32–44, and it isn't WSOL/USDC/USDT. Only while `token.pending`.
- **R2 supply** — accept a supply only when the *same object's* `mcap / priceUsd` agrees with it within 1%, testing both the raw value and `raw / 10 ** decimals` so an atomic and a whole-token reading can't be confused. Ambiguous-unit chart closes never count as `priceUsd`.

Facts are node-local snapshots, deliberately not the merged record used for ticks, so a price from one sibling and an mcap from another can never be combined into a supply. Facts are emitted *before* ticks from the same payload, so a pending page adopts identity before it prices its first tick, and they never move the displayed price by themselves.

Provenance rides along with the number: `bootstrapSupplyInfo()` reports the basis (`measured` > `pump-constant` > `host`), host-derived fills persist `supplySource: 'site-facts'` plus the witness into the journal, and the lineage is sticky — a validated tick or a live-feed requote that still leans on the host anchor keeps it; only an independent basis (measured supply, pump constant, resolver adoption, on-chain replacement) clears it.

When measured on-chain supply later arrives:

```js
agree within 2%  → drop the transient host supply, keep measured, no flag
disagree > 2%    → drop it, latch token.hostSupplyRejected, PTErrors.record(),
                   flag open positions → P&L tooltip warns the entry used a
                   disputed supply
```

A buy whose supply is disproved mid-flight is refused at commit. A **sell is never blocked** — stranding someone in a position is the complaint we're fixing, so the exit fills and the discrepancy is surfaced through the warning and the journal row instead.

Also fixed here, found while testing against real terminals (details in the E2E comment below):

- **Historical snapshots reaching the live header.** Padre showed BONK at `$204.53M` against a live ≈`$263M` — exactly `callouts[0].marketCap` from pump.fun's callout endpoint, the only page-level JSON on that page, with BUY enabled for the ~1s until the live feed corrected it. Historical subtrees (`callouts`, `history`, `ath`, `snapshots`, `candles`, …) now taint like position subtrees do: identity flows, prices and caps don't, for ticks and for fact arithmetic alike.
- **R2's silence is now observable.** Axiom and GMGN never ship supply, a USD price and a live mcap in one record, so R2 correctly adopts nothing — but that was indistinguishable from the feature working. A bounded `host-facts-supply-uncorroborated` diagnostic (same dedupe and 8-per-token cap as the refusals) now records it. No behaviour change.

Verified on the user's logged-in Padre, Axiom and GMGN, including a 26s-old Padre launch and a 3min-old GMGN launch: identity from pair URLs, buys, exact 50% sells, entry scale, fill markers and average lines all correct.

Extension suite 2,177 passing; schema drift clean.

Link to Devin session: https://app.devin.ai/sessions/3a28e5f7d10e4aba8f441c52a0233cff
Open in Devin Desktop: https://app.devin.ai/desktop/session/3a28e5f7d10e4aba8f441c52a0233cff?variant=devin
Requested by: @OnlyTerp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/papertrench/pull/92" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->