### PR TITLE
fix(gmgn): the axis anchor survives a token being identified (D-65, D-66)

### DIFF
--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -2059,6 +2059,61 @@ portifly, Discord 🐛-bug-reports 2026-08-28: *"I'm having an issue on GMGN. Th
 
 **fixed v3.18.0** (C-16 parity: when avg{Side}Mcap is absent but avg{Side}Native and currentPriceNative are present, the level is gmgnLastCandleClose × (avgNative/currentNative); the spec carries avg{Side}Native; the sweep re-arms while ANY level source wants a line. Locked by `test/d64_gmgnlines.test.js` — 4 tests; negative control: stashed fix = 0/4, restored = 4/4.)
 
+**D-65 · S2 · The GMGN axis anchor survived a token switch but not a token being IDENTIFIED — so a fresh launch lost its average lines for the whole session**
+`extension/price-bridge.js` (setCurrentSymbolNeedles, gmgnAxisAnchor, gmgnCapScale, gmgnMarkerLevel, gmgnLineLevel)
+
+portifly, Discord 🐛-bug-reports, after v3.18.0 shipped D-64: *"unfortunately I'm
+still having this problem, even with the new version"* … *"when I click on a token
+and buy or sell, no line appears; however, when I open a second tab for the same
+token, it does appear."* That second sentence is the whole defect, and it points at
+ordering rather than at the level arithmetic D-64 had just corrected.
+
+Both GMGN level lanes need `gmgnLastCandleClose` — the mcap lane scales through it
+(C-08 `gmgnCapScale`) and D-64's native lane multiplies by it — so D-64's fix could
+not help while the anchor was 0. `setCurrentSymbolNeedles` cleared it whenever the
+paper-axis needle set "changed", but that signal fires for two different events and
+only one of them is a new token: a real switch (A → B, nothing in common, genuinely
+stale) and identity SHARPENING (`[PAIR]` → `[PAIR, MINT, SYMBOL]` as the resolver
+learns what it is looking at — the same token). A fresh launch is the second case,
+repeatedly; it is the coin whose identity resolves last and in pieces, the same
+property behind F-51's rekey. GMGN fetches its mcap candles once per chart mount, so
+once the anchor was wiped nothing restored it. In a NEW tab the identity is complete
+before the candles land, nothing wipes it, and the lines draw — hence the second tab.
+
+Clearing on a genuine switch was racy in the other direction too: the new token's
+candles routinely arrive BEFORE its paper-axis, so the clear destroyed a close that
+had just been captured for the token being moved to.
+
+**fixed** (the close is tagged with the token its own request named —
+`/api/v1/token_mcap_candles/<chain>/<address>` — and staleness is judged at USE time
+through `gmgnAxisAnchor()`, which every lane now reads; ownership is decided on
+address needles only, since a short symbol can appear inside an unrelated base58
+address. Ordering stops mattering because the data carries its subject. Locked by
+`test/d65_gmgnanchor.test.js` (5 source-contract tests) plus two behavioural tests in
+`test/nativecharts.test.js`; negative control: restoring the clear = 1 behavioural
+failure + 1 contract failure, removed = all pass.)
+
+**D-66 · S2 · A buy clicked on a still-resolving coin threw out of an async handler and ate the click**
+`extension/content.js` requestBuy
+
+Field debug report (v3.18.0, Axiom, 2026-08-31), content scope:
+`TypeError: Cannot read properties of null (reading 'mint')` at `requestBuy`.
+
+The arming path exists precisely for a coin that is still resolving, and it opens by
+guarding `if (!token) return toast(...)`. It then **awaits** `acquireClickQuote` — the
+acquisition beat — and a standdown or SPA navigation during that await sets `token`
+back to null (content.js's teardown does exactly this). The branch immediately after
+the await re-checks `token` for that reason; the fall-through that arms the buy did
+not, and dereferenced `token.mint`.
+
+Because `requestBuy` is async, the throw surfaced as an unhandled rejection nobody
+sees: no fill, no armed buy, and no message explaining either — the click simply
+vanished. On the fresh launches this path serves, that is indistinguishable from
+"my buy didn't go through".
+
+**fixed** (the arming fall-through re-checks `token` after the await and refuses with
+the same message the entry guard uses).
+
 ---
 
 ## V — Visual polish

--- a/extension/content.js
+++ b/extension/content.js
@@ -3216,6 +3216,16 @@
           return;
         }
       }
+      // The acquisition beat above AWAITED, and the world can change across
+      // it: an SPA navigation or a standdown sets `token` back to null, and
+      // the branch immediately above re-checks `token` for exactly that
+      // reason. Arming did not, so a click that raced a navigation threw
+      // "Cannot read properties of null (reading 'mint')" out of an async
+      // handler — an unhandled rejection nobody sees, which ate the click
+      // whole: no fill, no armed buy, and no message explaining either.
+      // Reported from the field with that stack (requestBuy), on exactly the
+      // fresh launches this arming path exists to serve.
+      if (!token) return toast('No token detected on this page');
       armedBuy = { amount: solAmount, usd: quotedUsd, at: Date.now(), mint: token.mint, fromClick: true };
       // D-39: a click-armed buy NEVER narrates its state (no arming toast
       // of any kind) and never waits for a second source — flushArmedBuy

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -103,8 +103,29 @@
     // A new token means the old bar close is no longer a valid axis hint —
     // and the export dedupe must forget the old token's close, or the first
     // poll on the new token can be swallowed as "unchanged" (DEFECT F-19).
-    // The GMGN candle close is the same class of per-token evidence (C-08).
-    if (changed) { lastBarClose = 0; lastBarTimeSec = 0; lastExportedClose = 0; gmgnLastCandleClose = 0; barCloseLedger.clear(); }
+    //
+    // D-65: the GMGN candle close is NOT cleared here any more. It used to
+    // be, on the same "the needles changed" signal — but that signal fires
+    // for two different events, and only one of them is a new token:
+    //
+    //   a real switch      A -> B, nothing in common. Stale, must go.
+    //   identity sharpening  [PAIR] -> [PAIR, MINT, SYMBOL], as the resolver
+    //                      learns what it is looking at. Same token.
+    //
+    // The second is the normal life of a FRESH LAUNCH, whose identity
+    // resolves late and in pieces, and each sharpening wiped the axis anchor
+    // that both GMGN line lanes need. GMGN fetches its mcap candles once per
+    // chart mount, so nothing ever put the anchor back and the average lines
+    // could not be computed for the rest of the session.
+    //
+    // Clearing on a genuine switch is racy too: the new token's candles
+    // routinely land BEFORE its paper-axis does, so the clear destroyed a
+    // close that had just been captured for the token we were moving to.
+    //
+    // Both go away by tagging the close with the token it was observed for
+    // (gmgnLastCandleCloseKey) and checking that at USE time instead —
+    // staleness is then a fact about the data, not a guess about ordering.
+    if (changed) { lastBarClose = 0; lastBarTimeSec = 0; lastExportedClose = 0; barCloseLedger.clear(); }
   }
   // GMGN runs a private TradingView widget inside a same-origin blob iframe.
   // Its live React chart manager exposes `getActiveChart().createOrderLine()`.
@@ -117,6 +138,38 @@
   // what GMGN's Y axis actually shows, so lines and fill shapes are scaled
   // through it rather than trusting resolver-implied supply. Reset per token.
   let gmgnLastCandleClose = 0;
+  // D-65: which token that close was observed for, read from the candle
+  // request's own URL (/api/v1/token_mcap_candles/<chain>/<address>). The
+  // anchor is per-token evidence, so it carries its subject rather than
+  // relying on a clear that has to fire at exactly the right moment.
+  let gmgnLastCandleCloseKey = null;
+
+  /**
+   * The GMGN axis anchor, or 0 when we have none FOR THIS TOKEN.
+   *
+   * Every GMGN level lane needs this: the mcap lane scales through it
+   * (gmgnCapScale) and the native-ratio lanes multiply by it (C-16, D-64).
+   * A close belonging to the previous token would put every line and every
+   * fill mark at a level from a different coin, so it is refused here rather
+   * than cleared on a signal that cannot see the difference.
+   *
+   * An unparseable URL leaves the key null; that close is still used, which
+   * is exactly the pre-D-65 behaviour for a shape we do not recognise.
+   */
+  function gmgnAxisAnchor() {
+    if (!(gmgnLastCandleClose > 0)) return 0;
+    if (!gmgnLastCandleCloseKey) return gmgnLastCandleClose;
+    // Addresses only. The needle list also carries the SYMBOL, and a short
+    // symbol can appear inside an unrelated base58 address — matching on
+    // that would accept another coin's anchor.
+    const addrs = [currentSymbolInfo.pairAddress, currentSymbolInfo.mint]
+      .filter((v) => typeof v === 'string' && v.length >= 2)
+      .map((v) => v.toUpperCase());
+    // No identity resolved yet: nothing to contradict the close, and this is
+    // the ordinary state while a fresh launch is still being identified.
+    if (!addrs.length) return gmgnLastCandleClose;
+    return addrs.indexOf(gmgnLastCandleCloseKey) >= 0 ? gmgnLastCandleClose : 0;
+  }
 
   /* ---------------- content-script liveness (DEFECTS O-04/C-17) ----------
    * The MAIN world cannot observe extension death, so the bridge watches for
@@ -458,6 +511,11 @@
         // C-08: this close IS the value on GMGN's Y axis — the scale anchor
         // for every GMGN line and fill shape (see gmgnCapScale).
         gmgnLastCandleClose = mcap;
+        // D-65: tag it with the token the request names, so the anchor can be
+        // judged stale at use time instead of cleared on a signal that cannot
+        // tell a token switch from an identity merely becoming complete.
+        const forToken = /\/token_mcap_candles\/[^/?#]+\/([^/?#]+)/.exec(url);
+        gmgnLastCandleCloseKey = forToken ? forToken[1].toUpperCase() : null;
         emit('tick', {
           candidates: [],
           mcap,
@@ -2603,7 +2661,8 @@
    */
   function gmgnCapScale() {
     const current = gmgnLineSpec && numberValue(gmgnLineSpec.currentMcap);
-    if (gmgnLastCandleClose > 0 && current > 0) return gmgnLastCandleClose / current;
+    const anchor = gmgnAxisAnchor();
+    if (anchor > 0 && current > 0) return anchor / current;
     return 1;
   }
 
@@ -2620,8 +2679,9 @@
     if (mcap > 0) return mcap * gmgnCapScale();
     const native = numberValue(payload && payload.priceNative);
     const currentNative = gmgnLineSpec && numberValue(gmgnLineSpec.currentPriceNative);
-    if (native > 0 && currentNative > 0 && gmgnLastCandleClose > 0) {
-      return gmgnLastCandleClose * (native / currentNative);
+    const anchor = gmgnAxisAnchor();
+    if (native > 0 && currentNative > 0 && anchor > 0) {
+      return anchor * (native / currentNative);
     }
     return null;
   }
@@ -2744,8 +2804,9 @@
     // report of exactly that gap.
     const native = numberValue(gmgnLineSpec && gmgnLineSpec['avg' + side + 'Native']);
     const currentNative = numberValue(gmgnLineSpec && gmgnLineSpec.currentPriceNative);
-    if (native > 0 && currentNative > 0 && gmgnLastCandleClose > 0) {
-      return gmgnLastCandleClose * (native / currentNative);
+    const anchor = gmgnAxisAnchor();
+    if (native > 0 && currentNative > 0 && anchor > 0) {
+      return anchor * (native / currentNative);
     }
     return null;
   }

--- a/extension/test/d65_gmgnanchor.test.js
+++ b/extension/test/d65_gmgnanchor.test.js
@@ -1,0 +1,120 @@
+/* D-65: the GMGN axis anchor survived a token SWITCH but not a token being
+ * IDENTIFIED — which is the entire life of a fresh launch.
+ *
+ * Live evidence (Discord 🐛-bug-reports, portifly, after v3.18.0 shipped
+ * D-64): "unfortunately I'm still having this problem, even with the new
+ * version" … "when I click on a token and buy or sell, no line appears;
+ * however, when I open a second tab for the same token, it does appear."
+ *
+ * That second sentence is the bug. Both GMGN level lanes need
+ * gmgnLastCandleClose — the mcap lane scales through it (C-08 gmgnCapScale)
+ * and D-64's native lane multiplies by it — and setCurrentSymbolNeedles
+ * cleared it whenever the paper-axis needle set "changed". That signal fires
+ * for two different events and only one of them is a new token:
+ *
+ *   a real switch        A -> B, nothing in common. Genuinely stale.
+ *   identity sharpening  [PAIR] -> [PAIR, MINT, SYMBOL], as the resolver
+ *                        learns what it is looking at. The SAME token.
+ *
+ * A fresh launch is the second case, repeatedly — it is the coin whose
+ * identity resolves last and in pieces (the same property behind F-51's
+ * rekey). GMGN fetches its mcap candles once per chart mount, so once the
+ * anchor was wiped nothing put it back, and no average line could be
+ * computed for the rest of that session. Open the same coin in a NEW tab and
+ * the identity is complete before the candles land, so nothing wipes it —
+ * which is exactly why the second tab worked, and why the symptom pointed at
+ * ordering rather than at the level arithmetic D-64 had just fixed.
+ *
+ * Clearing on a genuine switch was racy in the other direction too: the new
+ * token's candles routinely arrive BEFORE its paper-axis, so the clear
+ * destroyed a close that had just been captured for the token being moved to.
+ *
+ * Fix under test: the close is tagged with the token its own request named
+ * (/api/v1/token_mcap_candles/<chain>/<address>) and staleness is judged at
+ * USE time. Ordering stops mattering because the data carries its subject.
+ */
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const ROOT = path.join(__dirname, '..');
+const src = fs.readFileSync(path.join(ROOT, 'price-bridge.js'), 'utf8');
+
+/** The body of a named function declaration, to its closing brace column. */
+function bodyOf(name) {
+  const at = src.indexOf('function ' + name + '(');
+  assert.ok(at >= 0, 'function must exist: ' + name);
+  const end = src.indexOf('\n  }', at);
+  assert.ok(end > at, 'function must close: ' + name);
+  return src.slice(at, end);
+}
+
+test('D-65/1: the needle path no longer clears the anchor', () => {
+  const body = bodyOf('setCurrentSymbolNeedles');
+  assert.doesNotMatch(body, /gmgnLastCandleClose\s*=\s*0/,
+    'clearing here is what wiped the anchor every time a fresh launch\'s '
+    + 'identity sharpened — and GMGN never re-fetches its candles to restore it');
+  // The rest of the per-token reset is still correct and must stay: those
+  // are export-dedupe state (F-19), not axis evidence.
+  assert.match(body, /lastBarClose = 0/, 'F-19 bar dedupe reset must survive');
+  assert.match(body, /barCloseLedger\.clear\(\)/, 'the bar ledger reset must survive');
+});
+
+test('D-65/2: the close is tagged with the token its request named', () => {
+  assert.match(src, /let gmgnLastCandleCloseKey = null;/,
+    'the anchor needs a subject to be judged against');
+  assert.match(src, /\/\\\/token_mcap_candles\\\/\[\^\/\?#\]\+\\\/\(\[\^\/\?#\]\+\)\//,
+    'the key must be parsed from the candle request URL');
+  // Captured in the same branch that captures the close, so the two can
+  // never disagree about which token they describe.
+  const at = src.indexOf('gmgnLastCandleClose = mcap;');
+  assert.ok(at > 0, 'the capture site must exist');
+  assert.match(src.slice(at, at + 400), /gmgnLastCandleCloseKey =/,
+    'key and close must be captured together');
+});
+
+test('D-65/3: every level lane reads the guarded accessor, not the raw close', () => {
+  assert.match(src, /function gmgnAxisAnchor\(\)/, 'the accessor must exist');
+  for (const fn of ['gmgnCapScale', 'gmgnMarkerLevel', 'gmgnLineLevel']) {
+    const body = bodyOf(fn);
+    assert.match(body, /gmgnAxisAnchor\(\)/, fn + ' must read the accessor');
+    assert.doesNotMatch(body, /gmgnLastCandleClose(?!Key)/,
+      fn + ' must not read the raw close — that is how another coin\'s anchor '
+      + 'would price this coin\'s line');
+  }
+});
+
+test('D-65/4: the accessor refuses an anchor belonging to a different token', () => {
+  const body = bodyOf('gmgnAxisAnchor');
+  // No identity yet is the ordinary state while a fresh launch is still
+  // being resolved; the close must be usable then, or the fix would
+  // reintroduce the very gap it exists to close.
+  assert.match(body, /if \(!addrs\.length\) return gmgnLastCandleClose;/,
+    'an unidentified token must still be able to use its own anchor');
+  // Symbols are not identity: a short ticker can appear inside an unrelated
+  // base58 address, and matching on it would accept a foreign anchor.
+  assert.match(body, /currentSymbolInfo\.pairAddress, currentSymbolInfo\.mint/,
+    'only address needles may decide ownership');
+  assert.doesNotMatch(body, /currentSymbolNeedles/,
+    'the needle list carries the symbol too — it must not be used here');
+  assert.match(body, /indexOf\(gmgnLastCandleCloseKey\) >= 0 \? gmgnLastCandleClose : 0/,
+    'a non-matching key must yield no anchor at all');
+});
+
+test('D-65/5: the URL parser reads the address out of real GMGN candle requests', () => {
+  // Exercised against the exact URLs the production interceptor sees, and
+  // the ones the existing nativecharts fixtures inject.
+  const re = /\/token_mcap_candles\/[^/?#]+\/([^/?#]+)/;
+  assert.equal(re.exec('https://www.gmgn.ai/api/v1/token_mcap_candles/sol/Mint1')[1], 'Mint1');
+  assert.equal(
+    re.exec('https://gmgn.ai/api/v1/token_mcap_candles/sol/Mint1?resolution=1m&limit=500')[1],
+    'Mint1', 'the query string must not be swallowed into the address');
+  assert.equal(re.exec('https://gmgn.ai/api/v1/token_mcap_candles/base/AbC123#frag')[1], 'AbC123');
+  // A shape we do not recognise leaves the key null, and the accessor then
+  // trusts the close — deliberately the pre-D-65 behaviour rather than a
+  // regression into drawing nothing.
+  assert.equal(re.exec('https://gmgn.ai/api/v1/token_mcap_candles/'), null);
+});

--- a/extension/test/nativecharts.test.js
+++ b/extension/test/nativecharts.test.js
@@ -1420,6 +1420,64 @@ test('C-16: a capless fill is queued and drawn once the cap becomes derivable', 
     'level = close x (fillNative / currentNative): the fill expressed on GMGN’s own axis');
 });
 
+test('D-65: a fresh launch keeps its axis anchor while its identity sharpens', async () => {
+  const env = runBridge({ gmgnMounted: true });
+
+  // The ordinary fresh-launch sequence: the chart mounts and GMGN fetches its
+  // mcap candles ONCE, before the resolver has finished identifying the coin.
+  injectActivityFrame(env, JSON.stringify({ code: 0, data: { list: [{ close: 300_000_000 }] } }),
+    'https://www.gmgn.ai/api/v1/token_mcap_candles/sol/Mint1');
+
+  // Identity then arrives in pieces, as it does for a coin nobody has indexed
+  // yet — first the pair, then the mint and symbol. Each of these used to
+  // clear the anchor, and GMGN never re-fetches candles to restore it.
+  env.send('paper-axis', { pairAddress: 'Mint1', mint: null, symbol: null });
+  env.send('paper-axis', { pairAddress: 'Mint1', mint: 'Mint1', symbol: 'FRESH' });
+
+  // A line priced only in SOL — D-64's premise: no mcap/priceUsd yet, so the
+  // native lane is the only one that can compute a level, and it needs the
+  // anchor the sharpening identity used to destroy.
+  env.send('gmgn-lines', {
+    enabled: true,
+    avgBuyMcap: null,
+    avgBuyNative: 5e-8,
+    currentPriceNative: 1e-7,
+  });
+  env.runTimeouts();
+  await microtasks();
+
+  const line = env.orderLines.find((l) => l.values.setPrice !== undefined);
+  assert.ok(line, 'the average line must draw — this is portifly\'s report');
+  assert.equal(line.values.setPrice, 150_000_000,
+    'level = anchor x (avgNative / currentNative), with the anchor intact');
+});
+
+test('D-65: an anchor from the previous token never prices the next one', async () => {
+  const env = runBridge({ gmgnMounted: true });
+
+  // Mint1's candles and identity.
+  injectActivityFrame(env, JSON.stringify({ code: 0, data: { list: [{ close: 300_000_000 }] } }),
+    'https://www.gmgn.ai/api/v1/token_mcap_candles/sol/Mint1');
+  env.send('paper-axis', { pairAddress: 'Mint1', mint: 'Mint1', symbol: 'ONE' });
+
+  // Switch to a genuinely different coin. Its candles have NOT arrived yet,
+  // so the only anchor in memory belongs to Mint1 — and must not be used.
+  env.send('paper-axis', { pairAddress: 'Mint2', mint: 'Mint2', symbol: 'TWO' });
+  env.send('gmgn-lines', {
+    enabled: true,
+    avgBuyMcap: null,
+    avgBuyNative: 5e-8,
+    currentPriceNative: 1e-7,
+  });
+  env.runTimeouts();
+  await microtasks();
+
+  const drawn = env.orderLines.filter((l) => l.values.setPrice !== undefined);
+  assert.equal(drawn.length, 0,
+    'no line may be drawn from another coin\'s anchor — a wrong level is worse '
+    + 'than no level, and the sweep will draw it once Mint2\'s candles land');
+});
+
 test('C-13: failed GMGN shape draws are re-queued with bounded retries, never lost', async () => {
   const env = runBridge({ gmgnMounted: true });
   env.failGmgnShapes(2); // a mid-boot chart refuses the first two draws


### PR DESCRIPTION
portifly, after v3.18.0 shipped D-64: *"unfortunately I'm still having this problem, even with the new version."* Then the sentence that solved it:

> *"when I click on a token and buy or sell, no line appears; however, when I open a second tab for the same token, it does appear."*

That points at **ordering**, not at the level arithmetic D-64 had just corrected.

## D-65 — why D-64 could not land

Both GMGN level lanes need `gmgnLastCandleClose`: the mcap lane scales through it (C-08 `gmgnCapScale`) and D-64's native lane multiplies by it. While that anchor is `0`, **neither lane can compute anything** — so D-64's fix was correct and still invisible.

`setCurrentSymbolNeedles` cleared the anchor whenever the paper-axis needle set "changed". That signal fires for two different events, and only one of them is a new token:

| Event | Needles | Anchor |
|---|---|---|
| A real switch | `A` → `B`, nothing in common | genuinely stale, must go |
| **Identity sharpening** | `[PAIR]` → `[PAIR, MINT, SYMBOL]` | **same token** — wiped anyway |

A fresh launch is the second case, repeatedly: it is the coin whose identity resolves last and in pieces (the same property behind F-51's rekey). **GMGN fetches its mcap candles once per chart mount**, so once the anchor was wiped nothing put it back, and no average line could be computed for the rest of that session.

Open the same coin in a **new tab** and the identity is complete before the candles land, so nothing wipes it and the lines draw. That is the second tab, exactly.

Clearing on a genuine switch was racy in the other direction too: the new token's candles routinely arrive *before* its paper-axis, so the clear destroyed a close that had just been captured for the token being moved to.

### The fix

Tag the close with the token its own request named — `/api/v1/token_mcap_candles/<chain>/<address>` — and judge staleness at **use** time via `gmgnAxisAnchor()`, which all three lanes now read. Ordering stops mattering because the data carries its subject.

Ownership is decided on **address needles only**: the needle list also carries the symbol, and a short ticker can appear inside an unrelated base58 address.

## D-66 — the click that vanished

From the same report's debug log:

```
TypeError: Cannot read properties of null (reading 'mint')
    at requestBuy (content.js:3219)
```

The arming path exists precisely for a still-resolving coin, and opens with `if (!token) return toast(...)`. It then **awaits** the acquisition beat — and a standdown or SPA navigation during that await sets `token` back to `null`. The branch immediately after the await re-checks `token` for exactly that reason; the fall-through that arms the buy did not.

`requestBuy` is async, so the throw surfaced as an **unhandled rejection nobody sees**: no fill, no armed buy, no message. On the fresh launches this path serves, that is indistinguishable from *"my buy didn't go through"* — and it is part of what the second reporter was seeing.

## Verification

Extension **2155/2155**, server **289/289**, all site guards pass.

Locked by `test/d65_gmgnanchor.test.js` (5 source contracts) plus two behavioural tests in `nativecharts.test.js` driving the real bridge.

**Negative control** — restoring the single cleared assignment:

```
✖ D-65: a fresh launch keeps its axis anchor while its identity sharpens
✔ D-65: an anchor from the previous token never prices the next one
   nativecharts 73/74,  d65 4/5
```

Removed again: 74/74 and 5/5. The second test is the one that proves the fix does not simply keep every anchor forever.

## Not fixed here

The same report carries RPC saturation (`publicnode` 403s, `tatum` 429s, `rpc pool cooling down`) behind the 30s+ fills on new pairs. That is keyless-endpoint capacity rather than a defect in this path — filed separately.