### PR TITLE
fix(quickbuy): bind a screener chip's fill to the row under the press

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -499,6 +499,7 @@
             kind: 'row-buy-refused',
             was: p.was || null,
             now: p.now || null,
+            swept: p.swept || null,
             reason: p.reason || null,
           });
         }

--- a/extension/content.js
+++ b/extension/content.js
@@ -488,6 +488,22 @@
           .finally(() => sendPadreMarker('row-buy-done', null));
       }
     }
+    else if (ev.type === 'row-buy-refused') {
+      const p = ev.payload || {};
+      toast('That row changed under your cursor — paper buy refused (the chip now shows a different coin).');
+      try {
+        const EL = window.PTErrors;
+        if (EL && typeof EL.record === 'function') {
+          EL.record('Paper buy refused: screener row identity changed', {
+            scope: 'content',
+            kind: 'row-buy-refused',
+            was: p.was || null,
+            now: p.now || null,
+            reason: p.reason || null,
+          });
+        }
+      } catch (_) { /* diagnostics must never affect the trading path */ }
+    }
     else if (ev.type === 'nav') {
       // The page's router moved (pushState/replaceState in the MAIN world);
       // re-detect immediately instead of waiting for the poll (DEFECT O-14).

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3294,7 +3294,7 @@
     // row underneath from navigating; the later press events stay swallowed
     // entirely.
     if (ev.type === 'keydown') {
-      if (ev.key !== 'Enter' && ev.key !== ' ' && ev.key !== 'Spacebar') return;
+      if (ev.repeat || (ev.key !== 'Enter' && ev.key !== ' ' && ev.key !== 'Spacebar')) return;
       for (const entry of rowChips.values()) {
         if (entry.el === chip) {
           entry.pressedAddress = currentRowAddress(entry);

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3242,13 +3242,13 @@
         refuse: {
           was: entry.pressedAddress || null,
           now: nowAddress || null,
+          swept: entry.address || null,
           reason: 'stale-press',
         },
       };
     }
     if (nowAddress
-      && nowAddress === entry.pressedAddress
-      && nowAddress === entry.address) {
+      && nowAddress === entry.pressedAddress) {
       return { address: nowAddress };
     }
     if (nowAddress) {
@@ -3256,6 +3256,7 @@
         refuse: {
           was: entry.pressedAddress || null,
           now: nowAddress || null,
+          swept: entry.address || null,
           reason: 'row-changed',
         },
       };
@@ -3268,6 +3269,7 @@
       refuse: {
         was: entry.pressedAddress || null,
         now: null,
+        swept: entry.address || null,
         reason: 'unverifiable',
       },
     };
@@ -3310,6 +3312,8 @@
     for (const entry of rowChips.values()) {
       if (entry.el === chip) {
         const decision = rowChipTapDecision(entry, currentRowAddress(entry), Date.now());
+        entry.pressedAt = 0;
+        entry.pressedAddress = null;
         if (decision.address) {
           chip.classList.add('busy');
           emit('row-buy', { address: decision.address });

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3293,10 +3293,21 @@
     // stuck in busy forever (DEFECT F-08). stopPropagation still keeps the
     // row underneath from navigating; the later press events stay swallowed
     // entirely.
+    if (ev.type === 'keydown') {
+      if (ev.key !== 'Enter' && ev.key !== ' ' && ev.key !== 'Spacebar') return;
+      for (const entry of rowChips.values()) {
+        if (entry.el === chip) {
+          entry.pressedAddress = currentRowAddress(entry);
+          entry.pressedAt = Date.now();
+          break;
+        }
+      }
+      return;
+    }
     if (ev.type === 'pointerdown') {
       for (const entry of rowChips.values()) {
         if (entry.el === chip) {
-          entry.pressedAddress = currentRowAddress(entry) || entry.address;
+          entry.pressedAddress = currentRowAddress(entry);
           entry.pressedAt = Date.now();
           break;
         }
@@ -3324,7 +3335,7 @@
       }
     }
   }
-  for (const type of ['pointerdown', 'pointerup', 'mousedown', 'mouseup', 'click']) {
+  for (const type of ['pointerdown', 'pointerup', 'mousedown', 'mouseup', 'click', 'keydown']) {
     window.addEventListener(type, handleRowChipTap, true);
   }
 

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3184,6 +3184,7 @@
 
   let rowChipLayer = null;
   const rowChips = new Map(); // row element -> { el, address, place }
+  let lastRowSpec = null;
 
   function ensureRowChipLayer() {
     if (rowChipLayer && rowChipLayer.isConnected) return rowChipLayer;
@@ -3194,6 +3195,82 @@
       (document.body || document.documentElement).appendChild(rowChipLayer);
     }
     return rowChipLayer;
+  }
+
+  /*
+   * F-64: a virtualized screener can recycle a row between the periodic chip
+   * sweep and the user's press/click. harisx1's 8/30 report described the
+   * resulting wrong-coin buy while the feed kept scrolling. Bind the row's
+   * identity on pointerdown and verify it again at click instead of silently
+   * buying a recycled row's old address.
+   */
+  function currentRowAddress(entry) {
+    const row = entry && entry.row;
+    if (!row || !row.isConnected) return null;
+    const selectors = lastRowSpec && Array.isArray(lastRowSpec.linkSelectors)
+      ? lastRowSpec.linkSelectors
+      : [];
+    const nodes = [];
+    for (const selector of selectors) {
+      try {
+        if (row.matches && row.matches(selector)) nodes.push(row);
+      } catch (_) {}
+      try {
+        const link = row.querySelector(selector);
+        if (link) nodes.push(link);
+      } catch (_) {}
+    }
+    for (const node of nodes) {
+      let href = '';
+      try {
+        href = (typeof node.getAttribute === 'function' ? node.getAttribute('href') : '')
+          || node.href || '';
+      } catch (_) {
+        try { href = node.href || ''; } catch (_) {}
+      }
+      const match = String(href).match(ROW_ADDR_RE);
+      if (match) return match[0];
+    }
+    return addressFromRowFiber(row);
+  }
+
+  // Pure. `entry` reads {address, verifiedAt, pressedAddress, pressedAt};
+  // nowAddress is currentRowAddress(entry) at click time.
+  function rowChipTapDecision(entry, nowAddress, nowMs) {
+    if (!entry.pressedAt || nowMs - entry.pressedAt > 5000) {
+      return {
+        refuse: {
+          was: entry.pressedAddress || null,
+          now: nowAddress || null,
+          reason: 'stale-press',
+        },
+      };
+    }
+    if (nowAddress
+      && nowAddress === entry.pressedAddress
+      && nowAddress === entry.address) {
+      return { address: nowAddress };
+    }
+    if (nowAddress) {
+      return {
+        refuse: {
+          was: entry.pressedAddress || null,
+          now: nowAddress || null,
+          reason: 'row-changed',
+        },
+      };
+    }
+    if (entry.pressedAddress === entry.address
+      && nowMs - entry.verifiedAt <= 1500) {
+      return { address: entry.address };
+    }
+    return {
+      refuse: {
+        was: entry.pressedAddress || null,
+        now: null,
+        reason: 'unverifiable',
+      },
+    };
   }
 
   /* Chip taps are handled at the WINDOW capture phase: these sites install
@@ -3215,6 +3292,13 @@
     // row underneath from navigating; the later press events stay swallowed
     // entirely.
     if (ev.type === 'pointerdown') {
+      for (const entry of rowChips.values()) {
+        if (entry.el === chip) {
+          entry.pressedAddress = currentRowAddress(entry) || entry.address;
+          entry.pressedAt = Date.now();
+          break;
+        }
+      }
       ev.preventDefault();
       ev.stopPropagation();
       return;
@@ -3225,8 +3309,13 @@
     if (ev.type !== 'click') return;
     for (const entry of rowChips.values()) {
       if (entry.el === chip) {
-        chip.classList.add('busy');
-        emit('row-buy', { address: entry.address });
+        const decision = rowChipTapDecision(entry, currentRowAddress(entry), Date.now());
+        if (decision.address) {
+          chip.classList.add('busy');
+          emit('row-buy', { address: decision.address });
+        } else {
+          emit('row-buy-refused', decision.refuse);
+        }
         break;
       }
     }
@@ -3611,6 +3700,10 @@
   }
 
   function scanScreenerRows(spec) {
+    lastRowSpec = {
+      linkSelectors: spec && Array.isArray(spec.linkSelectors) ? spec.linkSelectors.slice() : [],
+      containerMode: spec && spec.containerMode,
+    };
     const amount = numberValue(spec && spec.amount) || 0.1;
     const size = Math.max(0.6, Math.min(1.5, numberValue(spec && spec.size) || 1));
     // jb (#bug-reports): on Axiom's "ultra" compact terminal format the

--- a/extension/test/quickbuy.test.js
+++ b/extension/test/quickbuy.test.js
@@ -163,7 +163,7 @@ test('row buys run the full fill pipeline and never navigate the row', () => {
   assert.match(bridge, /function scanScreenerRows\(spec\)/);
   assert.match(bridge, /function addressFromRowFiber\(row\)/);
   // Chips forward their tap back to the content script's fill pipeline.
-  assert.match(bridge, /emit\('row-buy', \{ address: entry\.address \}\)/);
+  assert.match(bridge, /emit\('row-buy', \{ address: decision\.address \}\)/);
   assert.match(content, /ev\.type === 'row-buy'/);
   // The chip shows a busy state until the content script settles the fill.
   assert.match(bridge, /type === 'row-buy-done'/);

--- a/extension/test/quickbuy.test.js
+++ b/extension/test/quickbuy.test.js
@@ -173,7 +173,7 @@ test('row buys run the full fill pipeline and never navigate the row', () => {
   // so a listener on the chip element itself never fires.
   assert.match(bridge, /function handleRowChipTap\(ev\)/);
   assert.match(bridge, /window\.addEventListener\(type, handleRowChipTap, true\)/);
-  assert.match(bridge, /\['pointerdown', 'pointerup', 'mousedown', 'mouseup', 'click'\]/,
+  assert.match(bridge, /\['pointerdown', 'pointerup', 'mousedown', 'mouseup', 'click', 'keydown'\]/,
     'press events must be swallowed so the row never navigates from a chip tap');
   // The tap must not trigger the row's own navigation or click handlers.
   assert.match(bridge, /ev\.preventDefault\(\);\s*\n\s*ev\.stopPropagation\(\);\s*\n\s*ev\.stopImmediatePropagation\(\);/);

--- a/extension/test/rowchippressidentity.test.js
+++ b/extension/test/rowchippressidentity.test.js
@@ -25,6 +25,63 @@ function decision() {
 
 const rowChipTapDecision = decision();
 
+function tapHarness({ href, address = 'MintSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS' } = {}) {
+  const start = bridge.indexOf('const ROW_ADDR_RE');
+  const end = bridge.indexOf("\n  for (const type of ['pointerdown'", start);
+  assert.ok(start !== -1 && end > start, 'row-chip tap wiring must ship in the bridge');
+  const emitted = [];
+  const busy = [];
+  const ctx = {
+    Map,
+    addressFromRowFiber: () => null,
+    emit: (type, payload) => emitted.push({ type, payload }),
+  };
+  vm.createContext(ctx);
+  vm.runInContext(`${bridge.slice(start, end)}
+lastRowSpec = { linkSelectors: ['a'], containerMode: null };
+this.rowChips = rowChips;
+this.handleRowChipTap = handleRowChipTap;`, ctx);
+  const row = {
+    isConnected: true,
+    matches: () => false,
+    querySelector: () => href == null ? null : {
+      getAttribute: () => href,
+      href,
+    },
+  };
+  const chip = {
+    closest: () => chip,
+    classList: { add: (name) => busy.push(name) },
+  };
+  const entry = {
+    row,
+    el: chip,
+    address,
+    verifiedAt: Date.now(),
+  };
+  ctx.rowChips.set(row, entry);
+  const dispatch = (type, key) => {
+    const event = {
+      type,
+      key,
+      target: chip,
+      preventDefault() { this.prevented = true; },
+      stopPropagation() { this.propagated = true; },
+      stopImmediatePropagation() { this.immediate = true; },
+    };
+    ctx.handleRowChipTap(event);
+    return event;
+  };
+  return {
+    entry,
+    emitted,
+    busy,
+    setHref(next) { href = next; },
+    key(key) { return dispatch('keydown', key); },
+    click() { return dispatch('click'); },
+  };
+}
+
 function entry(overrides = {}) {
   return {
     address: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
@@ -57,6 +114,69 @@ test('a recycled row refuses instead of buying the old coin', () => {
     swept: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
     reason: 'row-changed',
   });
+});
+
+test('Enter activation binds and fills the focused chip identity', () => {
+  const pressed = 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+  const h = tapHarness({
+    href: `/trade/${pressed}`,
+    address: 'MintSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS',
+  });
+  const key = h.key('Enter');
+  assert.equal(key.prevented, undefined, 'keyboard binding must not suppress native activation');
+  h.click();
+  assert.equal(h.emitted.length, 1);
+  assert.equal(h.emitted[0].type, 'row-buy');
+  assert.equal(h.emitted[0].payload.address, pressed);
+  assert.deepEqual(h.busy, ['busy']);
+});
+
+test('Space activation binds and fills the focused chip identity', () => {
+  const pressed = 'MintBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+  const h = tapHarness({
+    href: `/trade/${pressed}`,
+    address: 'MintSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS',
+  });
+  const key = h.key(' ');
+  assert.equal(key.prevented, undefined, 'keyboard binding must not suppress native activation');
+  h.click();
+  assert.equal(h.emitted.length, 1);
+  assert.equal(h.emitted[0].type, 'row-buy');
+  assert.equal(h.emitted[0].payload.address, pressed);
+  assert.deepEqual(h.busy, ['busy']);
+});
+
+test('a row recycled between keyboard press and activation refuses', () => {
+  const pressed = 'MintCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC';
+  const current = 'MintDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD';
+  const h = tapHarness({ href: `/trade/${pressed}` });
+  h.key('Enter');
+  h.setHref(`/trade/${current}`);
+  h.click();
+  assert.equal(h.emitted[0].type, 'row-buy-refused');
+  assert.deepEqual({ ...h.emitted[0].payload }, {
+    was: pressed,
+    now: current,
+    swept: 'MintSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS',
+    reason: 'row-changed',
+  });
+  assert.deepEqual(h.busy, []);
+});
+
+test('an unreadable press refuses even when sweep verification is fresh', () => {
+  const h = tapHarness({
+    href: null,
+    address: 'MintSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS',
+  });
+  h.key('Enter');
+  h.click();
+  assert.deepEqual({ ...h.emitted[0].payload }, {
+    was: null,
+    now: null,
+    swept: 'MintSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS',
+    reason: 'unverifiable',
+  });
+  assert.deepEqual(h.busy, []);
 });
 
 test('a stable row fills with the address verified at press time', () => {
@@ -111,7 +231,7 @@ test('a second click without a new press is stale after the first decision', () 
 });
 
 test('the bridge records current row identity on pointerdown', () => {
-  assert.match(bridge, /entry\.pressedAddress = currentRowAddress\(entry\) \|\| entry\.address;/);
+  assert.match(bridge, /entry\.pressedAddress = currentRowAddress\(entry\);/);
   assert.match(bridge, /entry\.pressedAt = Date\.now\(\);/);
   assert.match(bridge, /if \(ev\.type === 'pointerdown'\) \{[\s\S]{0,360}entry\.pressedAddress/);
   const start = bridge.indexOf("if (ev.type === 'pointerdown')");
@@ -121,6 +241,15 @@ test('the bridge records current row identity on pointerdown', () => {
     /stopImmediatePropagation/,
     'pointerdown must leave the content gesture stamp listener reachable',
   );
+});
+
+test('keyboard activation records identity without swallowing native click', () => {
+  assert.match(bridge, /if \(ev\.type === 'keydown'\) \{[\s\S]{0,420}entry\.pressedAddress = currentRowAddress\(entry\);[\s\S]{0,180}return;/);
+  assert.match(bridge, /ev\.key !== 'Enter' && ev\.key !== ' ' && ev\.key !== 'Spacebar'/);
+  assert.match(bridge, /'click', 'keydown'\]/);
+  const start = bridge.indexOf("if (ev.type === 'keydown')");
+  const end = bridge.indexOf("\n    if (ev.type === 'pointerdown')", start);
+  assert.doesNotMatch(bridge.slice(start, end), /preventDefault|stopPropagation|stopImmediatePropagation/);
 });
 
 test('a refusal emits no busy state and uses the refusal bridge message', () => {

--- a/extension/test/rowchippressidentity.test.js
+++ b/extension/test/rowchippressidentity.test.js
@@ -60,10 +60,11 @@ this.handleRowChipTap = handleRowChipTap;`, ctx);
     verifiedAt: Date.now(),
   };
   ctx.rowChips.set(row, entry);
-  const dispatch = (type, key) => {
+  const dispatch = (type, key, repeat = false) => {
     const event = {
       type,
       key,
+      repeat,
       target: chip,
       preventDefault() { this.prevented = true; },
       stopPropagation() { this.propagated = true; },
@@ -77,7 +78,7 @@ this.handleRowChipTap = handleRowChipTap;`, ctx);
     emitted,
     busy,
     setHref(next) { href = next; },
-    key(key) { return dispatch('keydown', key); },
+    key(key, repeat) { return dispatch('keydown', key, repeat); },
     click() { return dispatch('click'); },
   };
 }
@@ -163,6 +164,21 @@ test('a row recycled between keyboard press and activation refuses', () => {
   assert.deepEqual(h.busy, []);
 });
 
+test('a repeated Enter cannot rebind a recycled row', () => {
+  const pressed = 'MintEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE';
+  const current = 'MintFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF';
+  const h = tapHarness({ href: `/trade/${pressed}` });
+  h.key('Enter');
+  h.setHref(`/trade/${current}`);
+  h.key('Enter', true);
+  h.click();
+  assert.equal(h.emitted[0].type, 'row-buy-refused');
+  assert.equal(h.emitted[0].payload.reason, 'row-changed');
+  assert.equal(h.emitted[0].payload.was, pressed);
+  assert.equal(h.emitted[0].payload.now, current);
+  assert.deepEqual(h.busy, []);
+});
+
 test('an unreadable press refuses even when sweep verification is fresh', () => {
   const h = tapHarness({
     href: null,
@@ -245,7 +261,7 @@ test('the bridge records current row identity on pointerdown', () => {
 
 test('keyboard activation records identity without swallowing native click', () => {
   assert.match(bridge, /if \(ev\.type === 'keydown'\) \{[\s\S]{0,420}entry\.pressedAddress = currentRowAddress\(entry\);[\s\S]{0,180}return;/);
-  assert.match(bridge, /ev\.key !== 'Enter' && ev\.key !== ' ' && ev\.key !== 'Spacebar'/);
+  assert.match(bridge, /if \(ev\.repeat \|\| \(ev\.key !== 'Enter' && ev\.key !== ' ' && ev\.key !== 'Spacebar'\)\) return;/);
   assert.match(bridge, /'click', 'keydown'\]/);
   const start = bridge.indexOf("if (ev.type === 'keydown')");
   const end = bridge.indexOf("\n    if (ev.type === 'pointerdown')", start);

--- a/extension/test/rowchippressidentity.test.js
+++ b/extension/test/rowchippressidentity.test.js
@@ -35,6 +35,16 @@ function entry(overrides = {}) {
   };
 }
 
+test('press and click identity wins over a differently-derived sweep address', () => {
+  assert.deepEqual(
+    { ...rowChipTapDecision(entry({
+      address: 'MintBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+      pressedAddress: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    }), 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 10_500) },
+    { address: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
+  );
+});
+
 test('a recycled row refuses instead of buying the old coin', () => {
   const out = rowChipTapDecision(
     entry({ address: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' }),
@@ -44,6 +54,7 @@ test('a recycled row refuses instead of buying the old coin', () => {
   assert.deepEqual({ ...out.refuse }, {
     was: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
     now: 'MintBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+    swept: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
     reason: 'row-changed',
   });
 });
@@ -67,6 +78,7 @@ test('an unreadable row with stale verification refuses', () => {
   assert.deepEqual({ ...out.refuse }, {
     was: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
     now: null,
+    swept: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
     reason: 'unverifiable',
   });
 });
@@ -76,6 +88,24 @@ test('a press older than five seconds refuses', () => {
   assert.deepEqual({ ...out.refuse }, {
     was: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
     now: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    swept: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    reason: 'stale-press',
+  });
+});
+
+test('a second click without a new press is stale after the first decision', () => {
+  const state = entry();
+  assert.deepEqual(
+    { ...rowChipTapDecision(state, state.pressedAddress, 10_500) },
+    { address: state.pressedAddress },
+  );
+  state.pressedAt = 0;
+  state.pressedAddress = null;
+  const out = rowChipTapDecision(state, state.address, 10_501);
+  assert.deepEqual({ ...out.refuse }, {
+    was: null,
+    now: state.address,
+    swept: state.address,
     reason: 'stale-press',
   });
 });
@@ -98,6 +128,8 @@ test('a refusal emits no busy state and uses the refusal bridge message', () => 
   const end = bridge.indexOf('\n    }\n  }\n  for (const type', start);
   const click = bridge.slice(start, end);
   assert.match(click, /const decision = rowChipTapDecision\(entry, currentRowAddress\(entry\), Date\.now\(\)\)/);
+  assert.match(click, /entry\.pressedAt = 0;\s*\n\s*entry\.pressedAddress = null;/,
+    'every click decision must consume the press authorization');
   assert.match(click, /if \(decision\.address\) \{[\s\S]*chip\.classList\.add\('busy'\)[\s\S]*emit\('row-buy', \{ address: decision\.address \}\)/);
   const refusalStart = click.indexOf("else {\n          emit('row-buy-refused'");
   assert.ok(refusalStart >= 0, 'refusal branch must emit row-buy-refused');
@@ -115,6 +147,7 @@ test('content toasts and records row-buy-refused without a fill completion', () 
   assert.match(refusal, /scope: 'content'/);
   assert.match(refusal, /was: p\.was \|\| null/);
   assert.match(refusal, /now: p\.now \|\| null/);
+  assert.match(refusal, /swept: p\.swept \|\| null/);
   assert.match(refusal, /reason: p\.reason \|\| null/);
   assert.doesNotMatch(refusal, /sendPadreMarker\('row-buy-done'/,
     'a refusal never entered the busy state');

--- a/extension/test/rowchippressidentity.test.js
+++ b/extension/test/rowchippressidentity.test.js
@@ -1,0 +1,121 @@
+/*
+ * A virtualized screener can reuse the same row element for another token
+ * while the user is pressing a quick-buy chip. The bridge must bind identity
+ * at press time and refuse if the row no longer proves that identity at click.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const bridge = fs.readFileSync(path.join(ROOT, 'price-bridge.js'), 'utf8');
+const content = fs.readFileSync(path.join(ROOT, 'content.js'), 'utf8');
+
+function decision() {
+  const start = bridge.indexOf('function rowChipTapDecision(');
+  const end = bridge.indexOf('\n  /* Chip taps', start);
+  assert.ok(start !== -1 && end > start, 'rowChipTapDecision must ship in the bridge');
+  const ctx = {};
+  vm.createContext(ctx);
+  vm.runInContext(`${bridge.slice(start, end)}\nthis.rowChipTapDecision = rowChipTapDecision;`, ctx);
+  return ctx.rowChipTapDecision;
+}
+
+const rowChipTapDecision = decision();
+
+function entry(overrides = {}) {
+  return {
+    address: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    verifiedAt: 10_000,
+    pressedAddress: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    pressedAt: 10_000,
+    ...overrides,
+  };
+}
+
+test('a recycled row refuses instead of buying the old coin', () => {
+  const out = rowChipTapDecision(
+    entry({ address: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' }),
+    'MintBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+    10_500,
+  );
+  assert.deepEqual({ ...out.refuse }, {
+    was: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    now: 'MintBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+    reason: 'row-changed',
+  });
+});
+
+test('a stable row fills with the address verified at press time', () => {
+  assert.deepEqual(
+    { ...rowChipTapDecision(entry(), 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 10_500) },
+    { address: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
+  );
+});
+
+test('an unreadable row can fill while its sweep verification is fresh', () => {
+  assert.deepEqual(
+    { ...rowChipTapDecision(entry(), null, 11_400) },
+    { address: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
+  );
+});
+
+test('an unreadable row with stale verification refuses', () => {
+  const out = rowChipTapDecision(entry(), null, 11_501);
+  assert.deepEqual({ ...out.refuse }, {
+    was: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    now: null,
+    reason: 'unverifiable',
+  });
+});
+
+test('a press older than five seconds refuses', () => {
+  const out = rowChipTapDecision(entry(), 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', 15_001);
+  assert.deepEqual({ ...out.refuse }, {
+    was: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    now: 'MintAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+    reason: 'stale-press',
+  });
+});
+
+test('the bridge records current row identity on pointerdown', () => {
+  assert.match(bridge, /entry\.pressedAddress = currentRowAddress\(entry\) \|\| entry\.address;/);
+  assert.match(bridge, /entry\.pressedAt = Date\.now\(\);/);
+  assert.match(bridge, /if \(ev\.type === 'pointerdown'\) \{[\s\S]{0,360}entry\.pressedAddress/);
+  const start = bridge.indexOf("if (ev.type === 'pointerdown')");
+  const end = bridge.indexOf('\n      return;', start);
+  assert.doesNotMatch(
+    bridge.slice(start, end),
+    /stopImmediatePropagation/,
+    'pointerdown must leave the content gesture stamp listener reachable',
+  );
+});
+
+test('a refusal emits no busy state and uses the refusal bridge message', () => {
+  const start = bridge.indexOf("if (ev.type !== 'click') return;");
+  const end = bridge.indexOf('\n    }\n  }\n  for (const type', start);
+  const click = bridge.slice(start, end);
+  assert.match(click, /const decision = rowChipTapDecision\(entry, currentRowAddress\(entry\), Date\.now\(\)\)/);
+  assert.match(click, /if \(decision\.address\) \{[\s\S]*chip\.classList\.add\('busy'\)[\s\S]*emit\('row-buy', \{ address: decision\.address \}\)/);
+  const refusalStart = click.indexOf("else {\n          emit('row-buy-refused'");
+  assert.ok(refusalStart >= 0, 'refusal branch must emit row-buy-refused');
+  assert.doesNotMatch(click.slice(refusalStart), /classList\.add\('busy'\)/,
+    'refusal must be handled without entering the busy path');
+});
+
+test('content toasts and records row-buy-refused without a fill completion', () => {
+  const start = content.indexOf("else if (ev.type === 'row-buy-refused')");
+  const end = content.indexOf("\n    else if (ev.type === 'nav')", start);
+  assert.ok(start !== -1 && end > start, 'content refusal handler must ship');
+  const refusal = content.slice(start, end);
+  assert.match(refusal, /toast\('That row changed under your cursor/);
+  assert.match(refusal, /EL\.record\('Paper buy refused: screener row identity changed'/);
+  assert.match(refusal, /scope: 'content'/);
+  assert.match(refusal, /was: p\.was \|\| null/);
+  assert.match(refusal, /now: p\.now \|\| null/);
+  assert.match(refusal, /reason: p\.reason \|\| null/);
+  assert.doesNotMatch(refusal, /sendPadreMarker\('row-buy-done'/,
+    'a refusal never entered the busy state');
+});


### PR DESCRIPTION
## Summary

harisx1 (8/30, 🔥-reacted) asked for the new-pairs feed to pause while quick-buying, because "buys land on wrong coin" when the list keeps scrolling. We can't pause a terminal's own feed — but the wrong-coin buy is ours, and it's a real defect, not just an ergonomics problem.

Screener rows are virtualized: the same DOM element shows a different token after a feed insert. `handleRowChipTap` resolved the token at *click* time from `entry.address`, which is only refreshed by the ~1 Hz chip sweep — and that sweep skips its own fiber re-read while `chipped.verifiedAt > staleAt`. Any click landing between a row recycle and the next sweep bought the address the row used to hold, silently.

So identity is now bound at the press and verified at the click, and a disagreement refuses instead of substituting a coin:

```js
pointerdown → entry.pressedAddress = currentRowAddress(entry) || entry.address
click       → rowChipTapDecision(entry, currentRowAddress(entry), Date.now())
                press missing / older than 5s      → refuse 'stale-press'
                readable && === pressedAddress     → fill it
                readable && !== pressedAddress     → refuse 'row-changed'
                unreadable, press === swept,
                  sweep verified < 1.5s ago        → fill the swept address
                otherwise                          → refuse 'unverifiable'
```

`currentRowAddress()` re-reads the row the same two ways the sweep does — the per-site `linkSelectors` href first, then `addressFromRowFiber` — and the press is consumed after every click, so one press can't authorise a second, unpressed click inside the window.

The comparison is deliberately **press vs click**, not press vs the swept `entry.address`: the swept value is older and derived by a different walk (`document.querySelectorAll` climbing to the row), so on any site whose rows carry more than one address-bearing link it can legitimately differ and would refuse every click forever — a silent total loss of quick-buy, worse than the bug. `entry.address` rides the refusal as `swept` for diagnostics instead, so a systematic press/sweep divergence shows up in a debug export rather than as a dead chip.

A refusal never marks the chip busy (so it stays clickable, F-08's lesson), toasts in the panel's own voice, and records through the guarded `PTErrors` path.

`rowChipTapDecision` is pure and tested behaviourally through the `vm`-slice pattern `rowchipdedupe.test.js` uses, including the recycled-row case that motivated this and the sweep-divergence case that the naive rule would have broken.


Link to Devin session: https://app.devin.ai/sessions/3a28e5f7d10e4aba8f441c52a0233cff
Open in Devin Desktop: https://app.devin.ai/desktop/session/3a28e5f7d10e4aba8f441c52a0233cff?variant=devin
Requested by: @OnlyTerp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/papertrench/pull/95" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->