### PR TITLE
fix(quickbuy): heal a stand-in-keyed bag by chain proof

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -2972,6 +2972,18 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         break;
       }
 
+      case 'pt_onchain_identify': {
+        const pool = isSolanaAddress(message.pool) ? message.pool : null;
+        const mint = isSolanaAddress(message.mint) ? message.mint : null;
+        if (!FEED || (!pool && !mint)) { sendResponse(null); break; }
+        try {
+          const settings = await getSettings();
+          FEED.configure({ rpcUrl: settings.rpcUrl || null });
+          sendResponse(await FEED.identify({ pool, mint }));
+        } catch (e) { sendResponse(null); }
+        break;
+      }
+
       // The authoritative price at click time. Null means no fresh on-chain
       // observation exists, and the caller must not invent one.
       case 'pt_onchain_quote':

--- a/extension/content.js
+++ b/extension/content.js
@@ -1161,6 +1161,7 @@
       // same coin under its old stand-in. Deterministic identity proof, one
       // rekey, no network added.
       healStandInPositions(data);
+      healStandInPositionsByChain(data);
       // Rug verdicts read Solana holder state — a foreign chain has no
       // verdict, and the guard stays silent rather than pretending.
       if (!data.chain || data.chain === 'solana') refreshRugVerdict(data.mint);
@@ -1266,6 +1267,39 @@
     for (const standIn of stranded) rekeyLiveState(standIn, tokenRecord.mint);
   }
 
+  const attemptedStandInProbes = new Set();
+
+  async function probeStandInPosition(standIn, mint) {
+    try {
+      const found = await R.onchainPrewatch({ pool: standIn, mint: standIn });
+      if (!found || !found.mint) return;
+      if (found.mint === mint) {
+        rekeyLiveState(standIn, mint);
+        return;
+      }
+      await withState(async () => {
+        const current = state.positions && state.positions[standIn];
+        if (!current || !current.standInKey) return;
+        const mutate = () => {
+          const position = state.positions && state.positions[standIn];
+          if (position) delete position.standInKey;
+        };
+        mutate();
+        await persistStateNow(mutate);
+      }).catch(() => {});
+    } catch (_) {}
+  }
+
+  function healStandInPositionsByChain(tokenRecord) {
+    if (!tokenRecord || !tokenRecord.mint || !state.positions) return;
+    for (const [key, position] of Object.entries(state.positions)) {
+      if (key === tokenRecord.mint || !position || !(Number(position.qty) > 0)
+        || !position.standInKey || attemptedStandInProbes.has(key)) continue;
+      attemptedStandInProbes.add(key);
+      void probeStandInPosition(key, tokenRecord.mint);
+    }
+  }
+
   function rekeyLiveState(oldMint, newMint) {
     if (!oldMint || !newMint || oldMint === newMint) return;
     const cached = livePositionPrices[oldMint];
@@ -1274,9 +1308,13 @@
       if (!livePositionPrices[newMint]) livePositionPrices[newMint] = cached;
     }
     if (!E.rekeyMint(state, oldMint, newMint)) return;
+    if (state.positions[newMint]) delete state.positions[newMint].standInKey;
     posEls = null; // the cached card nodes belong to the stand-in's render
     withState(async () => {
-      const mutate = () => E.rekeyMint(state, oldMint, newMint);
+      const mutate = () => {
+        if (!E.rekeyMint(state, oldMint, newMint)) return;
+        if (state.positions[newMint]) delete state.positions[newMint].standInKey;
+      };
       mutate();
       await persistStateNow(mutate);
     }).catch(() => {}).then(() => {
@@ -1521,6 +1559,7 @@
       if (Array.isArray(fresh.poolAddresses)) {
         token.poolAddresses = fresh.poolAddresses;
         healStandInPositions(token);
+        healStandInPositionsByChain(token);
       }
 
       // The resolver quote becomes the new anchor immediately. Live ticks
@@ -6837,6 +6876,7 @@
         }
       } catch (_) { /* identity stays the row's own key */ }
     }
+    const standInKey = !data.mint || data.mint === address;
     // Guardrails apply to chip buys exactly like panel buys.
     const guard = E.guardCheck(state, settings, { solAmount: amount });
     if (!guard.ok) { toast(guard.message); return null; }
@@ -6853,6 +6893,7 @@
           priceNative: data.priceNative, priceUsd: data.priceUsd, mcap: data.mcap,
           ...(feeContextForOrder() || {}),
         });
+        if (standInKey) filled.position.standInKey = true;
         filled.opened = opened;
       };
       mutate();

--- a/extension/content.js
+++ b/extension/content.js
@@ -29,6 +29,7 @@
     solUsd: () => sendMessage({ type: 'pt_sol_usd' }).then((r) => (typeof r === 'number' && r > 0 ? r : 0)).catch(() => 0),
     onchainWatch: (mint, pool) => sendMessage({ type: 'pt_onchain_watch', mint, pool }).then(okOrNull),
     onchainPrewatch: (ids) => sendMessage({ type: 'pt_onchain_prewatch', pool: ids.pool || null, mint: ids.mint || null }).then(okOrNull),
+    onchainIdentify: (ids) => sendMessage({ type: 'pt_onchain_identify', pool: ids.pool || null, mint: ids.mint || null }).then(okOrNull),
     rugCheck: (mint) => sendMessage({ type: 'pt_rug_check', mint }).then(okOrNull),
     onchainUnwatch: (mint) => sendMessage({ type: 'pt_onchain_unwatch', mint }).catch(() => null),
     onchainQuote: (mint) => sendMessage({ type: 'pt_onchain_quote', mint }).then(okOrNull),
@@ -1269,24 +1270,24 @@
 
   const attemptedStandInProbes = new Set();
 
-  async function probeStandInPosition(standIn, mint) {
+  async function probeStandInPosition(standIn) {
     try {
-      const found = await R.onchainPrewatch({ pool: standIn, mint: standIn });
+      const found = await R.onchainIdentify({ pool: standIn, mint: standIn });
       if (!found || !found.mint) return;
-      if (found.mint === mint) {
-        rekeyLiveState(standIn, mint);
+      if (found.mint === standIn) {
+        await withState(async () => {
+          const current = state.positions && state.positions[standIn];
+          if (!current || !current.standInKey) return;
+          const mutate = () => {
+            const position = state.positions && state.positions[standIn];
+            if (position) delete position.standInKey;
+          };
+          mutate();
+          await persistStateNow(mutate);
+        }).catch(() => {});
         return;
       }
-      await withState(async () => {
-        const current = state.positions && state.positions[standIn];
-        if (!current || !current.standInKey) return;
-        const mutate = () => {
-          const position = state.positions && state.positions[standIn];
-          if (position) delete position.standInKey;
-        };
-        mutate();
-        await persistStateNow(mutate);
-      }).catch(() => {});
+      rekeyLiveState(standIn, found.mint);
     } catch (_) {}
   }
 
@@ -1296,7 +1297,7 @@
       if (key === tokenRecord.mint || !position || !(Number(position.qty) > 0)
         || !position.standInKey || attemptedStandInProbes.has(key)) continue;
       attemptedStandInProbes.add(key);
-      void probeStandInPosition(key, tokenRecord.mint);
+      void probeStandInPosition(key);
     }
   }
 

--- a/extension/content.js
+++ b/extension/content.js
@@ -1559,8 +1559,8 @@
       if (Array.isArray(fresh.poolAddresses)) {
         token.poolAddresses = fresh.poolAddresses;
         healStandInPositions(token);
-        healStandInPositionsByChain(token);
       }
+      healStandInPositionsByChain(token);
 
       // The resolver quote becomes the new anchor immediately. Live ticks
       // validate against this, so the anchor never lags behind real moves.

--- a/extension/onchain-feed.js
+++ b/extension/onchain-feed.js
@@ -1033,7 +1033,9 @@
         return found ? { mint: found, pool: address } : null;
       }
       const facts = mintFactsFromAccount(account, address);
-      return facts ? { ...facts, mint: address } : null;
+      if (facts) return { ...facts, mint: address };
+      const found = await discoverPoolMint(bytes);
+      return found ? { mint: found, pool: address } : null;
     } catch (error) {
       try { console.debug('PaperTrench: identify failed:', error && error.message); } catch (_) {}
       noteFeedError(error, { fn: 'identify', pool: address || null });

--- a/extension/onchain-feed.js
+++ b/extension/onchain-feed.js
@@ -1004,6 +1004,43 @@
     }
   }
 
+  /**
+   * Resolve an address to its mint without opening a live subscription.
+   * Healing needs identity proof only; using prewatch here would leave a
+   * background watch behind for a coin no tab is charting.
+   */
+  async function identify({ pool, mint }) {
+    let address = null;
+    try {
+      address = pool || mint;
+      if (!address) return null;
+      const [account] = await getAccounts([address]);
+      if (!account) return null;
+
+      const kind = O.poolKindForOwner(account.owner);
+      if (kind === 'pump-curve') {
+        const found = await curveMint(address);
+        return found && found.mint ? { mint: found.mint, pool: address } : null;
+      }
+      const bytes = O.bytesFromBase64(account.data[0]);
+      if (kind === 'whirlpool' || kind === 'clmm') {
+        const poolInfo = O.decodeWhirlpool(bytes);
+        const found = whirlpoolTokenMint(poolInfo);
+        return found ? { mint: found, pool: address } : null;
+      }
+      if (kind) {
+        const found = await discoverPoolMint(bytes);
+        return found ? { mint: found, pool: address } : null;
+      }
+      const facts = mintFactsFromAccount(account, address);
+      return facts ? { ...facts, mint: address } : null;
+    } catch (error) {
+      try { console.debug('PaperTrench: identify failed:', error && error.message); } catch (_) {}
+      noteFeedError(error, { fn: 'identify', pool: address || null });
+      return null;
+    }
+  }
+
   /** The known pool/curve reserve token accounts for a watched mint — the
    * holders that are LIQUIDITY, not people (used by the rug guard). */
   function reserveAccounts(mint) {
@@ -1078,7 +1115,7 @@
 
   const api = {
     configure, watch, unwatch, currentQuote, isLive, onQuote, activeEndpoint,
-    prewatch, reserveAccounts,
+    prewatch, identify, reserveAccounts,
     _getAccountsForTest: getAccounts,
     _getAccountsWithSlotForTest: getAccountsWithSlot,
     QUOTE_STALE_MS, COMMITMENT,

--- a/extension/test/onchainfeed.test.js
+++ b/extension/test/onchainfeed.test.js
@@ -225,6 +225,7 @@ const vm2 = require('node:vm');
 
 function feedWithRpc(handler) {
   const sentFrames = [];
+  const rpcMethods = [];
   const sandbox = {
     console, Date, JSON, Math, Number, String, Array, Object, Boolean,
     Promise, Map, Set, URL, TextEncoder, Uint8Array, BigInt, isFinite,
@@ -242,12 +243,16 @@ function feedWithRpc(handler) {
   const ctx = vm2.createContext(sandbox);
   vm2.runInContext(fs.readFileSync(path.join(ROOT, 'onchain.js'), 'utf8'), ctx, { filename: 'onchain.js' });
   sandbox.PTRpcPool = {
-    call: handler,
+    call: (...args) => {
+      rpcMethods.push(args[0]);
+      return handler(...args);
+    },
     websocketUrls: () => [],
     setUserEndpoint() {}, reportSuccess() {}, reportFailure() {},
   };
   vm2.runInContext(fs.readFileSync(path.join(ROOT, 'onchain-feed.js'), 'utf8'), ctx, { filename: 'onchain-feed.js' });
   sandbox.PTOnchainFeed._sentFrames = sentFrames;
+  sandbox.PTOnchainFeed._rpcMethods = rpcMethods;
   return sandbox.PTOnchainFeed;
 }
 
@@ -489,6 +494,14 @@ test('a bare non-pump mint account answers with measured supply facts', async ()
     'supplyUi is the raw u64 supply over its decimals — whole tokens');
   assert.equal(feed.currentQuote(PLAIN_MINT), null,
     'no live feed exists for a poolless mint; nothing must pretend one does');
+
+  const gpaBefore = feed._rpcMethods.filter((method) => method === 'getProgramAccounts').length;
+  const identified = await feed.identify({ mint: PLAIN_MINT });
+  assert.equal(identified.mint, PLAIN_MINT);
+  assert.equal(identified.decimals, 6);
+  assert.equal(feed._watched.size, 0);
+  assert.equal(feed._sentFrames.filter((frame) => frame.method === 'accountSubscribe').length, 0);
+  assert.equal(feed._rpcMethods.filter((method) => method === 'getProgramAccounts').length, gpaBefore);
 });
 
 test('a 165-byte token ACCOUNT is refused as mint facts — garbage supply prices garbage fills', async () => {
@@ -576,6 +589,14 @@ test('an UNKNOWN-layout pool yields identity and supply — never a price, never
   assert.equal(found.priceNative, null, 'no decoder, no price — a vault ratio would be invented');
   assert.ok(Math.abs(found.supplyUi - 1e9) < 1e-6, 'measured supply rides along for the mcap bootstrap');
   assert.equal(feed.currentQuote(TOK_MINT), null, 'nothing is ever watched on an unverified layout');
+
+  const gpaBefore = feed._rpcMethods.filter((method) => method === 'getProgramAccounts').length;
+  const identified = await feed.identify({ pool: MYSTERY_POOL });
+  assert.equal(identified.mint, TOK_MINT,
+    'identity-only probing must scan an unknown pool for its WSOL-anchored token');
+  assert.equal(feed._watched.size, 0);
+  assert.equal(feed._sentFrames.filter((frame) => frame.method === 'accountSubscribe').length, 0);
+  assert.equal(feed._rpcMethods.filter((method) => method === 'getProgramAccounts').length, gpaBefore);
 });
 
 test('a pool between two non-SOL tokens is refused — nothing says which side the page charts', async () => {

--- a/extension/test/onchainfeed.test.js
+++ b/extension/test/onchainfeed.test.js
@@ -224,6 +224,7 @@ test('F-33: single-account pools keep the strict newer-slot guard', () => {
 const vm2 = require('node:vm');
 
 function feedWithRpc(handler) {
+  const sentFrames = [];
   const sandbox = {
     console, Date, JSON, Math, Number, String, Array, Object, Boolean,
     Promise, Map, Set, URL, TextEncoder, Uint8Array, BigInt, isFinite,
@@ -231,7 +232,10 @@ function feedWithRpc(handler) {
     btoa: (s) => Buffer.from(s, 'binary').toString('base64'),
     crypto: require('node:crypto').webcrypto,
     setTimeout, clearTimeout, setInterval: () => 1, clearInterval: () => {},
-    WebSocket: function () { this.readyState = 3; },
+    WebSocket: function () {
+      this.readyState = 3;
+      this.send = (frame) => sentFrames.push(JSON.parse(frame));
+    },
   };
   sandbox.self = sandbox;
   sandbox.globalThis = sandbox;
@@ -243,6 +247,7 @@ function feedWithRpc(handler) {
     setUserEndpoint() {}, reportSuccess() {}, reportFailure() {},
   };
   vm2.runInContext(fs.readFileSync(path.join(ROOT, 'onchain-feed.js'), 'utf8'), ctx, { filename: 'onchain-feed.js' });
+  sandbox.PTOnchainFeed._sentFrames = sentFrames;
   return sandbox.PTOnchainFeed;
 }
 
@@ -326,6 +331,44 @@ test('F-34: a completed (migrated) curve refuses prewatch — the resolver path 
     throw new Error('unexpected rpc ' + method);
   });
   assert.equal(await feed.prewatch({ pool: CURVE_ADDR }), null);
+});
+
+test('identity resolves complete curves without watching or scanning', async () => {
+  const curveB64 = curveAccountB64({
+    virtualToken: 1_000_000_000_000_000, virtualSol: 115_000_000_000, complete: true,
+  });
+  const rpcLog = [];
+  const feed = feedWithRpc(async (method, params) => {
+    rpcLog.push(method);
+    if (method === 'getMultipleAccounts') {
+      return {
+        context: { slot: 1 },
+        value: [{ owner: PUMP_PROGRAM_ID, data: [curveB64] }],
+      };
+    }
+    if (method === 'getTokenAccountsByOwner') {
+      return {
+        value: [{
+          pubkey: RESERVE_ADDR,
+          account: { data: { parsed: { info: {
+            mint: FRESH_MINT,
+            tokenAmount: { amount: '793000000000000' },
+          } } } },
+        }],
+      };
+    }
+    throw new Error('unexpected rpc ' + method);
+  });
+
+  assert.equal(await feed.prewatch({ pool: CURVE_ADDR }), null,
+    'the completed curve remains unpriceable through prewatch');
+  const found = await feed.identify({ pool: CURVE_ADDR });
+  assert.deepEqual(JSON.parse(JSON.stringify(found)), {
+    mint: FRESH_MINT, pool: CURVE_ADDR,
+  });
+  assert.equal(feed._watched.size, 0, 'identity proof must not create a watched entry');
+  assert.equal(feed._sentFrames.filter((frame) => frame.method === 'accountSubscribe').length, 0);
+  assert.equal(rpcLog.filter((method) => method === 'getProgramAccounts').length, 0);
 });
 
 test('F-34: a non-pump pool refuses prewatch rather than guessing', async () => {

--- a/extension/test/standinchainheal.test.js
+++ b/extension/test/standinchainheal.test.js
@@ -472,3 +472,42 @@ test('a row fill whose identity probe succeeds is not marked as stand-in', async
   assert.equal(positions[REAL_MINT].standInKey, undefined);
   assert.equal(positions[STAND_IN], undefined);
 });
+
+test('a requote with no poolAddresses still heals a flagged stand-in', async () => {
+  const rowAmount = 0.25;
+  const priceNative = 0.0004 / 200;
+  const expectedRow = fillExpected(rowAmount, priceNative);
+  const world = { chainAnswers: false };
+  const view = runHarness({
+    rowAmount,
+    // Only the chart mint is indexed, and its record carries a lone `pair`:
+    // the F-61 poolAddresses backstop never arms on this coin.
+    stage: (address) => address === REAL_MINT
+      ? { payload: pairPayload(REAL_MINT, REAL_MINT) } : 'blind',
+    prewatch: (pool, mint) => world.chainAnswers && pool === STAND_IN && mint === STAND_IN
+      ? { mint: REAL_MINT, pool: STAND_IN, priceNative } : null,
+  });
+
+  // The chart is adopted BEFORE the flagged bag exists, so setToken's pass
+  // has nothing to probe and only the requote heartbeat can heal it.
+  view.navigate(`https://axiom.trade/meme/${REAL_MINT}`);
+  await view.advance(3000);
+  assert.equal(view.chainProbes.length, 0);
+
+  view.rowTick(STAND_IN, 0.0004);
+  await view.settle();
+  view.tapChip(STAND_IN);
+  await view.settle();
+  const fillProbes = view.chainProbes.filter((key) => key === STAND_IN).length;
+  assert.equal(view.storage().pt_state.positions[STAND_IN].standInKey, true);
+
+  world.chainAnswers = true;
+  await view.advance(6000);
+  const positions = view.storage().pt_state.positions;
+  assert.equal(view.chainProbes.filter((key) => key === STAND_IN).length - fillProbes, 1,
+    'the requote heal probes the flagged key exactly once');
+  assert.equal(positions[STAND_IN], undefined);
+  assert.ok(positions[REAL_MINT]);
+  assert.equal(positions[REAL_MINT].qty, expectedRow.qty);
+  assert.equal(positions[REAL_MINT].standInKey, undefined);
+});

--- a/extension/test/standinchainheal.test.js
+++ b/extension/test/standinchainheal.test.js
@@ -1,0 +1,474 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+
+global.window = global.window || {};
+require('../engine.js');
+const E = global.window.PaperEngine;
+
+const REAL_MINT = 'R' + '1'.repeat(42);
+const STAND_IN = 'C' + '2'.repeat(42);
+const OTHER_MINT = 'D' + '4'.repeat(42);
+const WSOL = 'So11111111111111111111111111111111111111112';
+
+function pairPayload(mint, pair) {
+  return {
+    pair: {
+      chainId: 'solana',
+      dexId: 'pumpswap',
+      pairAddress: pair,
+      baseToken: { address: mint, symbol: 'TEST', name: 'Test' },
+      quoteToken: { address: WSOL, symbol: 'SOL' },
+      priceNative: '0.000002',
+      priceUsd: '0.0004',
+      liquidity: { usd: 60000 },
+      marketCap: 42000,
+    },
+  };
+}
+
+function runHarness(options = {}) {
+  const timers = [];
+  let now = 5_000_000;
+  const nodesById = {};
+  const winListeners = {};
+  const chainProbes = [];
+
+  function makeNode(tag) {
+    const node = {
+      tag, style: { setProperty() {}, removeProperty() {} }, dataset: {}, value: '',
+      children: [], childNodes: [], _fields: {},
+      classList: {
+        _s: new Set(),
+        add(...classes) { classes.forEach((value) => this._s.add(value)); },
+        remove(...classes) { classes.forEach((value) => this._s.delete(value)); },
+        toggle(name, on) { if (on === undefined) this._s.has(name) ? this._s.delete(name) : this._s.add(name); else on ? this._s.add(name) : this._s.delete(name); },
+        contains(name) { return this._s.has(name); },
+      },
+      set textContent(value) { this._text = value; },
+      get textContent() { return this._text || ''; },
+      set innerHTML(value) {
+        this._html = value;
+        const fields = /data-f="([a-z]+)"/g;
+        let match;
+        while ((match = fields.exec(value))) {
+          const child = makeNode('span');
+          child.dataset.f = match[1];
+          this._fields[match[1]] = child;
+        }
+      },
+      get innerHTML() { return this._html || ''; },
+      appendChild(child) {
+        if (child._parent && child._parent !== this) child._parent.removeChild(child);
+        child._parent = this;
+        this.children.push(child);
+        this.childNodes = this.children;
+        return child;
+      },
+      removeChild(child) {
+        const index = this.children.indexOf(child);
+        if (index >= 0) this.children.splice(index, 1);
+      },
+      remove() { if (this._parent) this._parent.removeChild(this); },
+      setAttribute() {}, getAttribute() { return null; },
+      addEventListener(type, fn) {
+        if (!this._listeners) this._listeners = {};
+        (this._listeners[type] ||= []).push(fn);
+      },
+      click() { for (const fn of (this._listeners && this._listeners.click) || []) fn(); },
+      querySelectorAll() { return []; },
+      querySelector(selector) {
+        const match = /data-f="([a-z]+)"/.exec(selector);
+        return match && this._fields[match[1]] ? this._fields[match[1]] : makeNode('span');
+      },
+      getBoundingClientRect() { return { top: 0 }; },
+      attachShadow() { return shadowRoot; },
+      focus() {}, closest() { return null; },
+      get offsetWidth() { return 1; },
+    };
+    return node;
+  }
+
+  const shadowRoot = {
+    set innerHTML(value) { this._html = value; },
+    get innerHTML() { return this._html || ''; },
+    getElementById(id) { return nodesById[id] ||= makeNode('div'); },
+    querySelector() { return makeNode('div'); },
+    querySelectorAll() { return []; },
+    appendChild() {},
+  };
+
+  const startUrl = 'https://axiom.trade/pulse';
+  const parsedStart = new URL(startUrl);
+  const location = {
+    href: startUrl, hostname: parsedStart.hostname, pathname: parsedStart.pathname,
+    search: parsedStart.search, origin: parsedStart.origin,
+  };
+  const doc = {
+    readyState: 'complete', hidden: false, title: 'pulse',
+    body: Object.assign(makeNode('body'), { innerText: '' }),
+    documentElement: makeNode('html'), head: makeNode('head'),
+    createElement: (tag) => makeNode(tag),
+    getElementById: () => null, querySelector: () => null, querySelectorAll: () => [],
+    addEventListener: () => {}, createTreeWalker: () => ({ nextNode: () => null }),
+  };
+  const win = {
+    addEventListener(type, fn) { (winListeners[type] ||= []).push(fn); },
+    removeEventListener() {},
+    postMessage() {},
+    location,
+    getComputedStyle: () => ({ right: '18px', top: '84px' }),
+    confirm: () => false,
+  };
+  win.window = win;
+
+  const settings = E.defaultSettings();
+  settings.feeBps = 0;
+  settings.gasSolPerTx = 0;
+  settings.tipSolPerTx = 0;
+  settings.presetsBuy = [options.rowAmount || 0.25];
+  const state = E.defaultState(settings);
+  if (options.seed) options.seed(state, settings);
+  const storage = { pt_settings: settings, pt_state: state };
+
+  const sandbox = {
+    window: win, self: win, document: doc, location, console,
+    URLSearchParams, URL,
+    AbortController: function () { this.signal = {}; this.abort = () => {}; },
+    MutationObserver: function () { this.observe = () => {}; this.disconnect = () => {}; },
+    TextDecoder: function () { this.decode = () => ''; },
+    ResizeObserver: function () { this.observe = () => {}; this.disconnect = () => {}; },
+    Set, Map, WeakSet, WeakMap, Promise, JSON, Math, Number, String, Array, Object,
+    Boolean, RegExp, Error, isNaN, parseInt, parseFloat, Infinity, NaN,
+    Date: Object.assign(function () {}, { now: () => now, parse: Date.parse }),
+    setTimeout: (fn, ms) => { timers.push({ fn, at: now + (ms || 0) }); return timers.length; },
+    clearTimeout: () => {},
+    clearInterval: (id) => { if (timers[id - 1]) timers[id - 1].dead = true; },
+    setInterval: (fn, ms) => { timers.push({ fn, at: now + ms, every: ms }); return timers.length; },
+    fetch: (url) => {
+      const text = String(url);
+      if (text.includes('lite-api.jup.ag')) {
+        const query = decodeURIComponent(text.split('query=')[1] || '');
+        return Promise.resolve({
+          ok: true, status: 200,
+          json: async () => query.includes(WSOL) ? [{ id: WSOL, usdPrice: 200 }] : [],
+        });
+      }
+      const match = /\/latest\/dex\/(?:pairs\/solana|tokens)\/([A-Za-z0-9]+)/.exec(text);
+      if (match) {
+        const result = options.stage ? options.stage(match[1]) : 'blind';
+        if (!result || result === 'blind') {
+          return Promise.resolve({ ok: true, status: 200, json: async () => ({ pairs: null }) });
+        }
+        return Promise.resolve({
+          ok: true, status: 200,
+          json: async () => result.payload || pairPayload(result.mint, result.pair),
+        });
+      }
+      return Promise.resolve({ ok: true, status: 200, json: async () => ({ pairs: null }) });
+    },
+    chrome: {
+      runtime: {
+        id: 'papertrench-test',
+        getURL: (file) => 'x/' + file,
+        sendMessage: (message) => {
+          if (message && message.type === 'pt_attest_append') {
+            return Promise.resolve({ ok: true, seq: 0, head: 'pt-test-head' });
+          }
+          if (message && message.type === 'pt_state_commit') return Promise.resolve({});
+          const resolver = win.PaperTrenchResolver;
+          if (!resolver) return Promise.resolve({});
+          if (message.type === 'pt_resolve') return resolver.resolve(message.address);
+          if (message.type === 'pt_refresh') return resolver.refresh(message.token);
+          if (message.type === 'pt_sol_usd') return resolver.solUsd();
+          if (message.type === 'pt_batch_prices') return resolver.batchPrices(message.mints);
+          if (message.type === 'pt_onchain_prewatch') {
+            if (message.pool && message.pool === message.mint) chainProbes.push(message.pool);
+            const answer = options.prewatch
+              && options.prewatch(message.pool, message.mint);
+            return Promise.resolve(answer || null);
+          }
+          return Promise.resolve({});
+        },
+        onMessage: { addListener: () => {} },
+        openOptionsPage: () => {},
+      },
+      storage: {
+        local: {
+          get: (keys, callback) => {
+            const out = {};
+            for (const key of (Array.isArray(keys) ? keys : [keys])) {
+              if (key in storage) out[key] = storage[key];
+            }
+            if (callback) callback(out);
+            return Promise.resolve(out);
+          },
+          set: (value, callback) => {
+            Object.assign(storage, value);
+            if (callback) callback();
+            return Promise.resolve();
+          },
+        },
+        onChanged: { addListener: () => {} },
+      },
+      tabs: { query: () => Promise.resolve([{ id: 1 }]), sendMessage: () => Promise.resolve() },
+    },
+    NodeFilter: { SHOW_TEXT: 4 },
+  };
+
+  const ctx = vm.createContext(sandbox);
+  const manifest = JSON.parse(fs.readFileSync(path.join(ROOT, 'manifest.json'), 'utf8'));
+  const entry = manifest.content_scripts.find((script) => (script.js || []).includes('content.js'));
+  for (const file of entry.js) {
+    vm.runInContext(fs.readFileSync(path.join(ROOT, file), 'utf8'), ctx, { filename: file });
+  }
+
+  async function settle() {
+    for (let i = 0; i < 400; i++) await Promise.resolve();
+  }
+  async function advance(ms, step = 100) {
+    for (let elapsed = 0; elapsed < ms; elapsed += step) {
+      now += step;
+      for (const timer of timers) {
+        if (timer.dead || timer.at > now) continue;
+        if (timer.every) timer.at = now + timer.every;
+        else timer.dead = true;
+        try { timer.fn(); } catch (_) {}
+      }
+      await settle();
+    }
+  }
+  function rowTick(address, usd) {
+    for (const fn of winListeners.message || []) {
+      fn({
+        source: win,
+        origin: location.origin,
+        data: {
+          source: 'papertrench-bridge', type: 'tick',
+          payload: {
+            mint: address, symbol: 'TEST', name: 'Test',
+            candidates: [{ unit: 'usd', value: usd }],
+          },
+        },
+      });
+    }
+  }
+  function tapChip(address) {
+    for (const fn of winListeners.pointerdown || []) fn({ isTrusted: true });
+    for (const fn of winListeners.message || []) {
+      fn({
+        source: win,
+        origin: location.origin,
+        data: {
+          source: 'papertrench-bridge', type: 'row-buy',
+          payload: { address },
+        },
+      });
+    }
+  }
+  return {
+    advance, settle, rowTick, tapChip, chainProbes,
+    navigate(url) {
+      const parsed = new URL(url);
+      location.href = url;
+      location.hostname = parsed.hostname;
+      location.pathname = parsed.pathname;
+      location.search = parsed.search;
+    },
+    storage: () => storage,
+  };
+}
+
+function fillExpected(solAmount, priceNative) {
+  const settings = E.defaultSettings();
+  settings.feeBps = 0;
+  settings.gasSolPerTx = 0;
+  settings.tipSolPerTx = 0;
+  const state = E.defaultState(settings);
+  E.buy(state, settings, {
+    ts: 1, mint: 'expected', site: 'test',
+    priceNative, solAmount,
+  });
+  return state.positions.expected;
+}
+
+test('a missed row identity probe heals both stacks by chain proof', async () => {
+  const rowAmount = 0.25;
+  const priorAmount = 0.1;
+  const priceNative = 0.0004 / 200;
+  const expectedPrior = fillExpected(priorAmount, priceNative);
+  const expectedRow = fillExpected(rowAmount, priceNative);
+  const world = { chart: false };
+  const view = runHarness({
+    rowAmount,
+    seed(state, settings) {
+      const seeded = E.buy(state, settings, {
+        ts: 1, mint: REAL_MINT, site: 'panel',
+        priceNative, solAmount: priorAmount,
+      });
+      seeded.position.lastPriceNative = expectedPrior.lastPriceNative;
+    },
+    stage(address) {
+      if (!world.chart) return 'blind';
+      if (address === REAL_MINT) return { payload: pairPayload(REAL_MINT, REAL_MINT) };
+      return 'blind';
+    },
+    prewatch(pool, mint) {
+      if (world.chart && pool === STAND_IN && mint === STAND_IN) {
+        return { mint: REAL_MINT, pool: STAND_IN, priceNative };
+      }
+      return null;
+    },
+  });
+
+  await view.advance(3000);
+  view.rowTick(STAND_IN, 0.0004);
+  await view.settle();
+  view.tapChip(STAND_IN);
+  await view.settle();
+
+  let positions = view.storage().pt_state.positions;
+  const fillProbes = view.chainProbes.length;
+  assert.ok(positions[STAND_IN], 'a missed proof leaves the row fill under its key');
+  assert.equal(positions[STAND_IN].standInKey, true);
+
+  world.chart = true;
+  view.navigate(`https://axiom.trade/meme/${REAL_MINT}`);
+  await view.advance(3000);
+  positions = view.storage().pt_state.positions;
+  const merged = positions[REAL_MINT];
+  assert.equal(view.chainProbes.length, fillProbes + 1,
+    'the chart must use chain proof when the resolver lists no poolAddresses');
+  assert.ok(merged, 'chain proof moves the stand-in onto the chart mint');
+  assert.equal(positions[STAND_IN], undefined);
+  assert.equal(merged.qty, expectedPrior.qty + expectedRow.qty);
+  assert.equal(merged.costSol, expectedPrior.costSol + expectedRow.costSol);
+  assert.equal(merged.investedSol, expectedPrior.investedSol + expectedRow.investedSol);
+  assert.equal(merged.netInvestedSol, expectedPrior.netInvestedSol + expectedRow.netInvestedSol);
+  assert.equal(merged.standInKey, undefined);
+});
+
+test('a chain proof for a different mint clears the flag without merging', async () => {
+  const world = { chart: false };
+  const view = runHarness({
+    stage: (address) => world.chart && (address === REAL_MINT || address === OTHER_MINT)
+      ? { payload: pairPayload(address, address) } : 'blind',
+    prewatch: (pool, mint) => world.chart && pool === STAND_IN && mint === STAND_IN
+      ? { mint: OTHER_MINT, pool: STAND_IN }
+      : null,
+  });
+  await view.advance(3000);
+  view.rowTick(STAND_IN, 0.0004);
+  await view.settle();
+  view.tapChip(STAND_IN);
+  await view.settle();
+
+  world.chart = true;
+  view.navigate(`https://axiom.trade/meme/${REAL_MINT}`);
+  await view.advance(3000);
+  const before = view.chainProbes.length;
+  const position = view.storage().pt_state.positions[STAND_IN];
+  assert.ok(position);
+  assert.equal(position.standInKey, undefined);
+
+  view.navigate(`https://axiom.trade/meme/${OTHER_MINT}`);
+  await view.advance(3000);
+  assert.equal(view.chainProbes.length, before,
+    'a proven-different key is not probed again in this page session');
+  assert.ok(view.storage().pt_state.positions[STAND_IN]);
+  assert.equal(view.storage().pt_state.positions[STAND_IN].standInKey, undefined);
+  assert.equal(view.storage().pt_state.positions[REAL_MINT], undefined);
+  assert.equal(view.storage().pt_state.positions[OTHER_MINT], undefined);
+});
+
+test('a chain rekey clears the flag when no real-mint stack exists', async () => {
+  const world = { chart: false };
+  const view = runHarness({
+    stage: (address) => world.chart && address === REAL_MINT
+      ? { payload: pairPayload(REAL_MINT, REAL_MINT) } : 'blind',
+    prewatch: (pool, mint) => world.chart && pool === STAND_IN && mint === STAND_IN
+      ? { mint: REAL_MINT, pool: STAND_IN } : null,
+  });
+  await view.advance(3000);
+  view.rowTick(STAND_IN, 0.0004);
+  await view.settle();
+  view.tapChip(STAND_IN);
+  await view.settle();
+
+  world.chart = true;
+  view.navigate(`https://axiom.trade/meme/${REAL_MINT}`);
+  await view.advance(3000);
+  const position = view.storage().pt_state.positions[REAL_MINT];
+  assert.ok(position);
+  assert.equal(position.standInKey, undefined);
+});
+
+test('each stand-in key gets at most one chain probe per page session', async () => {
+  const world = { chart: false };
+  const view = runHarness({
+    stage: (address) => world.chart && (address === REAL_MINT || address === OTHER_MINT)
+      ? { payload: pairPayload(address, address) } : 'blind',
+    prewatch: () => null,
+  });
+  await view.advance(3000);
+  view.rowTick(STAND_IN, 0.0004);
+  await view.settle();
+  view.tapChip(STAND_IN);
+  await view.settle();
+
+  world.chart = true;
+  view.navigate(`https://axiom.trade/meme/${REAL_MINT}`);
+  await view.advance(3000);
+  const probes = view.chainProbes.filter((key) => key === STAND_IN).length;
+  assert.ok(probes > 0, 'the flagged key must be probed on the chart page');
+  assert.equal(view.storage().pt_state.positions[STAND_IN].standInKey, true,
+    'a failed proof leaves the key eligible on a later page');
+  view.navigate(`https://axiom.trade/meme/${OTHER_MINT}`);
+  await view.advance(3000);
+  view.navigate(`https://axiom.trade/meme/${REAL_MINT}`);
+  await view.advance(3000);
+  assert.equal(view.chainProbes.filter((key) => key === STAND_IN).length, probes);
+});
+
+test('clean positions and clean pages add no chain-heal probes', async () => {
+  const cleanPosition = runHarness({
+    seed(state, settings) {
+      E.buy(state, settings, {
+        ts: 1, mint: REAL_MINT, site: 'panel',
+        priceNative: 0.000002, solAmount: 0.1,
+      });
+    },
+    stage: (address) => address === REAL_MINT
+      ? { payload: pairPayload(REAL_MINT, REAL_MINT) } : 'blind',
+    prewatch: () => null,
+  });
+  cleanPosition.navigate(`https://axiom.trade/meme/${REAL_MINT}`);
+  await cleanPosition.advance(3000);
+  assert.equal(cleanPosition.chainProbes.length, 0);
+
+  const cleanPage = runHarness({ stage: () => 'blind', prewatch: () => null });
+  await cleanPage.advance(3000);
+  assert.equal(cleanPage.chainProbes.length, 0);
+});
+
+test('a row fill whose identity probe succeeds is not marked as stand-in', async () => {
+  const view = runHarness({
+    stage: () => 'blind',
+    prewatch: (pool, mint) => pool === STAND_IN && mint === STAND_IN
+      ? { mint: REAL_MINT, pool: STAND_IN, priceNative: 0.000002 }
+      : null,
+  });
+  await view.advance(3000);
+  view.rowTick(STAND_IN, 0.0004);
+  await view.settle();
+  view.tapChip(STAND_IN);
+  await view.settle();
+  const positions = view.storage().pt_state.positions;
+  assert.ok(positions[REAL_MINT]);
+  assert.equal(positions[REAL_MINT].standInKey, undefined);
+  assert.equal(positions[STAND_IN], undefined);
+});

--- a/extension/test/standinchainheal.test.js
+++ b/extension/test/standinchainheal.test.js
@@ -37,6 +37,7 @@ function runHarness(options = {}) {
   const nodesById = {};
   const winListeners = {};
   const chainProbes = [];
+  const chainIdentifies = [];
 
   function makeNode(tag) {
     const node = {
@@ -192,6 +193,16 @@ function runHarness(options = {}) {
               && options.prewatch(message.pool, message.mint);
             return Promise.resolve(answer || null);
           }
+          if (message.type === 'pt_onchain_identify') {
+            if (message.pool && message.pool === message.mint) {
+              chainProbes.push(message.pool);
+              chainIdentifies.push(message.pool);
+            }
+            const answer = options.identify
+              ? options.identify(message.pool, message.mint)
+              : options.prewatch && options.prewatch(message.pool, message.mint);
+            return Promise.resolve(answer || null);
+          }
           return Promise.resolve({});
         },
         onMessage: { addListener: () => {} },
@@ -271,7 +282,7 @@ function runHarness(options = {}) {
     }
   }
   return {
-    advance, settle, rowTick, tapChip, chainProbes,
+    advance, settle, rowTick, tapChip, chainProbes, chainIdentifies,
     navigate(url) {
       const parsed = new URL(url);
       location.href = url;
@@ -352,9 +363,22 @@ test('a missed row identity probe heals both stacks by chain proof', async () =>
   assert.equal(merged.standInKey, undefined);
 });
 
-test('a chain proof for a different mint clears the flag without merging', async () => {
+test('a chain proof rekeys to its mint, then merges on that chart', async () => {
+  const rowAmount = 0.25;
+  const priorAmount = 0.1;
+  const priceNative = 0.0004 / 200;
+  const expectedPrior = fillExpected(priorAmount, priceNative);
+  const expectedRow = fillExpected(rowAmount, priceNative);
   const world = { chart: false };
   const view = runHarness({
+    rowAmount,
+    seed(state, settings) {
+      const seeded = E.buy(state, settings, {
+        ts: 1, mint: OTHER_MINT, site: 'panel',
+        priceNative, solAmount: priorAmount,
+      });
+      seeded.position.lastPriceNative = expectedPrior.lastPriceNative;
+    },
     stage: (address) => world.chart && (address === REAL_MINT || address === OTHER_MINT)
       ? { payload: pairPayload(address, address) } : 'blind',
     prewatch: (pool, mint) => world.chart && pool === STAND_IN && mint === STAND_IN
@@ -370,19 +394,46 @@ test('a chain proof for a different mint clears the flag without merging', async
   world.chart = true;
   view.navigate(`https://axiom.trade/meme/${REAL_MINT}`);
   await view.advance(3000);
-  const before = view.chainProbes.length;
-  const position = view.storage().pt_state.positions[STAND_IN];
-  assert.ok(position);
-  assert.equal(position.standInKey, undefined);
+  let positions = view.storage().pt_state.positions;
+  assert.equal(positions[STAND_IN], undefined);
+  assert.ok(positions[OTHER_MINT]);
+  assert.equal(positions[OTHER_MINT].standInKey, undefined);
 
   view.navigate(`https://axiom.trade/meme/${OTHER_MINT}`);
   await view.advance(3000);
-  assert.equal(view.chainProbes.length, before,
-    'a proven-different key is not probed again in this page session');
-  assert.ok(view.storage().pt_state.positions[STAND_IN]);
-  assert.equal(view.storage().pt_state.positions[STAND_IN].standInKey, undefined);
+  positions = view.storage().pt_state.positions;
+  assert.equal(view.chainProbes.filter((key) => key === STAND_IN).length, 2,
+    'the stand-in gets one row prewatch and one chain identity probe');
+  assert.equal(Object.keys(positions).length, 1);
+  assert.equal(positions[OTHER_MINT].qty, expectedPrior.qty + expectedRow.qty);
+  assert.equal(positions[OTHER_MINT].costSol, expectedPrior.costSol + expectedRow.costSol);
+  assert.equal(positions[OTHER_MINT].investedSol, expectedPrior.investedSol + expectedRow.investedSol);
+  assert.equal(positions[OTHER_MINT].netInvestedSol, expectedPrior.netInvestedSol + expectedRow.netInvestedSol);
   assert.equal(view.storage().pt_state.positions[REAL_MINT], undefined);
-  assert.equal(view.storage().pt_state.positions[OTHER_MINT], undefined);
+});
+
+test('a chain proof that names the stand-in only clears its flag', async () => {
+  const world = { chart: false };
+  const view = runHarness({
+    stage: (address) => world.chart && address === REAL_MINT
+      ? { payload: pairPayload(REAL_MINT, REAL_MINT) } : 'blind',
+    identify: (pool, mint) => world.chart && pool === STAND_IN && mint === STAND_IN
+      ? { mint: STAND_IN, pool: STAND_IN } : null,
+    prewatch: () => null,
+  });
+  await view.advance(3000);
+  view.rowTick(STAND_IN, 0.0004);
+  await view.settle();
+  view.tapChip(STAND_IN);
+  await view.settle();
+
+  world.chart = true;
+  view.navigate(`https://axiom.trade/meme/${REAL_MINT}`);
+  await view.advance(3000);
+  const positions = view.storage().pt_state.positions;
+  assert.ok(positions[STAND_IN]);
+  assert.equal(positions[STAND_IN].standInKey, undefined);
+  assert.equal(positions[REAL_MINT], undefined);
 });
 
 test('a chain rekey clears the flag when no real-mint stack exists', async () => {


### PR DESCRIPTION
## Summary

A screener-row quick-buy can commit a fill under the row's **click address** instead of the mint: `fillRowBuy` gives an unproven candidate one bounded identity probe, and when that misses, the bag is keyed by the stand-in. F-61 already backstops this, but only through the resolver record's `poolAddresses` — a list Dexscreener only has once the coin is indexed. On a seconds-old coin there is no such record, so the chart page adopts the real mint from chain/host facts, later panel buys open a *second* bag under it, and the wallet holds one coin twice: the tab's totals sum only the panel fills while the row fill still draws on the chart (01jb, 8/25 — 0.25 via chip, then 0.1s from the panel, totals showed the 0.1s).

This closes that gap with a chain proof instead of a wider guess. Positions whose key was never proven are flagged at commit time, and only those keys are ever probed:

```js
// fillRowBuy, after the existing identity probe
const standInKey = !data.mint || data.mint === address;
...
if (standInKey) filled.position.standInKey = true;   // inside mutate, so a lost CAS re-applies it
```

```js
// healStandInPositionsByChain(tokenRecord) — after healStandInPositions, off setToken and requote
for (open position keyed K, K !== tokenRecord.mint, K flagged, K not yet attempted) {
  found = await R.onchainIdentify({ pool: K, mint: K });
  found.mint === K   -> delete standInKey        // the key IS the mint: correct all along
  found.mint (other) -> rekeyLiveState(K, found.mint)
  no answer          -> leave it; still eligible on a later page
}
```

The chain answer is about the key, **not** about whichever chart triggered the probe, so a mismatch rekeys onto `found.mint` rather than being discarded — opening that coin later then shows one merged bag. The flag clears only when the key is proven correct or after a rekey, and `rekeyLiveState` now clears it on the existing `poolAddresses` heal too. Nothing weaker than a chain answer naming a mint ever merges two bags.

Healing needs identity, not price, so it deliberately does **not** go through `prewatch`: `prewatchPool` ends in `watch()`, which would leave a subscription in the background's shared `watched` map for a coin no tab is charting (unwatching it is not an option — another tab may be streaming it), and it returns `null` for a *completed* pump curve, which is exactly the graduated-curve stand-in F-61 is about. New identity-only feed entry point, wired as its own `pt_onchain_identify` message so every existing `prewatch` caller keeps its behavior:

```js
identify({ pool, mint })   // one account read, no watch/socket/subscribe, no findGraduatedPool scan
  pump-curve        -> curveMint          (complete curves included: identity survives migration)
  whirlpool | clmm  -> decodeWhirlpool + whirlpoolTokenMint
  other known kind  -> discoverPoolMint
  unknown owner     -> mint facts, else discoverPoolMint's WSOL-anchored vault scan
  otherwise         -> null
```

That last line mirrors `prewatch`'s unverified-launchpad precedence on purpose: a pool whose owner program has no verified decoder still yields identity even though its price stays refused, and an undecoded launchpad is exactly where a row buy lands on a pair address in the first place.

Two properties held on purpose: one probe per key per page session (`attemptedStandInProbes`), and a page whose positions are all cleanly keyed issues **zero** extra reads — the RPC pool is what the rest of this sweep is trying to stop starving.

`extension/test/standinchainheal.test.js` drives the shipped `content.js` in the `strandedbag.test.js` harness (merge totals derived from the fill inputs rather than pasted; chart-A-probes-mint-B-then-open-B; key-is-the-mint; failed probe keeps the flag; requote with no `poolAddresses`; once-per-key; zero probes on clean state; a proven fill staying unflagged), and `onchainfeed.test.js` pins the feed contract on its existing fixtures: `identify` resolves a completed curve where `prewatch` returns `null`, resolves an unknown-layout pool through the vault scan, and leaves zero watched entries, zero `accountSubscribe` frames and zero `getProgramAccounts` calls behind. Every production edit was reverted in turn to confirm which test goes red. Extension suite 2,157 passed / 0 failed; server 279 passed / 0 failed / 10 skipped.

Live browser verification of the row-chip origin is still pending: Axiom Pulse is the only adapter whose rows key by a pair address (GMGN and Padre rows are mint-keyed), and it is auth-walled on the test box.


Link to Devin session: https://app.devin.ai/sessions/b676704d774f4aa099ba7f31381b036f
Open in Devin Desktop: https://app.devin.ai/desktop/session/b676704d774f4aa099ba7f31381b036f?variant=devin
Requested by: @OnlyTerp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/papertrench/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->