### PR TITLE
fix(panel): stop a preset tap plus BUY from committing two fills

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -5502,7 +5502,8 @@
     }
     els.btnBuy.addEventListener('click', () => {
       const custom = Number(els.custom.value);
-      const sel = els.buyPresets.querySelector('.pt-preset.sel');
+      const instant = settings.instantBuyEnabled !== false;
+      const sel = !instant && els.buyPresets.querySelector('.pt-preset.sel');
       // Panel units throughout — dollars on a foreign-chain panel, SOL
       // otherwise; requestBuy owns the conversion.
       const amt = custom > 0 ? custom : sel ? Number(sel.dataset.amt) : 0;
@@ -5669,12 +5670,13 @@
     // The free-text amount box is off by default now. It was three lines of
     // panel for a field the preset row already covers: those became eight
     // configurable boxes, so an arbitrary size is a setting away rather than
-    // a permanent tax on every panel. Hidden, never removed — BUY and the
-    // limit-arm both read it and both already fall back to the selected
-    // preset when it is empty, so nothing downstream has to know.
+    // a permanent tax on every panel. Hidden, never removed — instant BUY
+    // reads it when enabled, while limit-arm still falls back to the selected
+    // preset when it is empty.
     const customOn = sectionOn && settings.panelCustomAmount === true;
     if (els.custom) els.custom.style.display = customOn ? '' : 'none';
-    if (els.btnBuy) els.btnBuy.style.display = sectionOn ? '' : 'none';
+    const instant = settings.instantBuyEnabled !== false;
+    if (els.btnBuy) els.btnBuy.style.display = sectionOn && (!instant || customOn) ? '' : 'none';
     if (els.buyPresets) els.buyPresets.style.display = presetsOn ? '' : 'none';
 
     // Chips carry PANEL units: SOL on Solana, dollars on foreign chains
@@ -5683,7 +5685,6 @@
     const list = usdMode
       ? (settings.presetsBuyUsd || USD_PRESETS_DEFAULT)
       : (settings.presetsBuy || [0.1, 0.5, 1, 2]);
-    const instant = settings.instantBuyEnabled !== false;
     if (sectionOn && els.buyLabel) els.buyLabel.textContent = buyLabelText();
     renderCosts();
     if (!presetsOn) return;

--- a/extension/test/quickbuy.test.js
+++ b/extension/test/quickbuy.test.js
@@ -26,6 +26,10 @@ test('preset taps route through the shared buy path when instant is on', () => {
     'a preset tap must fire the order when one-click quick buy is enabled');
   assert.match(content, /if \(!\(amt > 0\)\) return toast\(panelUsd\(\) \? 'Pick a dollar amount first' : 'Pick a SOL amount first'\);\s*\n\s*requestBuy\(amt\);/,
     'the BUY button must use the same shared path (currency-aware refusal)');
+  assert.match(content, /els\.btnBuy\.style\.display = sectionOn && \(!instant \|\| customOn\) \? '' : 'none';/,
+    'instant mode hides BUY unless custom sizing is enabled');
+  assert.match(content, /const sel = !instant && els\.buyPresets\.querySelector\('\.pt-preset\.sel'\);/,
+    'instant BUY must ignore a chip selection and read custom sizing only');
   assert.match(content, /let buyInFlight = false;/,
     'rapid taps must be guarded against stacking fills');
   assert.match(content, /buyInFlight = true;\s*\n\s*buyInFlightAt = Date\.now\(\);\s*\n\s*doBuy\(solAmount, quotedUsd\)\.finally\(\(\) => \{ buyInFlight = false; \}\);/,

--- a/extension/test/statepersist.test.js
+++ b/extension/test/statepersist.test.js
@@ -67,6 +67,15 @@ function runOverlay(priceSeries, opts) {
           this._fields[m[1]] = child;
           this.children.push(child);
         }
+        const presets = /<button class="pt-preset(?: sel)?" data-amt="([^"]+)"/g;
+        while ((m = presets.exec(v))) {
+          const child = makeNode('button');
+          child.dataset.amt = m[1];
+          child.classList.add('pt-preset');
+          if (m[0].includes(' sel')) child.classList.add('sel');
+          child._parent = this;
+          this.children.push(child);
+        }
       },
       get innerHTML() { return this._h || ''; },
       appendChild(c) { this.children.push(c); this.childNodes = this.children; c._parent = this; return c; },
@@ -82,9 +91,18 @@ function runOverlay(priceSeries, opts) {
       querySelector(sel) {
         const m = /data-f="([a-z]+)"/.exec(sel);
         if (m && this._fields && this._fields[m[1]]) return this._fields[m[1]];
+        if (sel === '.pt-preset.sel') {
+          return this.children.find((child) => child.classList.contains('pt-preset')
+            && child.classList.contains('sel')) || null;
+        }
         return makeNode('span');
       },
-      querySelectorAll() { return []; },
+      querySelectorAll(sel) {
+        if (sel === '.pt-preset') {
+          return this.children.filter((child) => child.classList.contains('pt-preset'));
+        }
+        return [];
+      },
       getBoundingClientRect() { return { top: 0 }; },
       attachShadow() { return shadowRoot; },
       focus() {}, closest() { return null; },
@@ -291,6 +309,12 @@ function runOverlay(priceSeries, opts) {
     externalWriteSilently: (obj) => Object.assign(storage, obj),
     setValue: (id, v) => { if (shadowNodes[id]) shadowNodes[id].value = String(v); },
     clickById: (id) => { if (shadowNodes[id]) shadowNodes[id].click(); },
+    clickPreset: (index) => {
+      const presets = shadowNodes['pt-buy-presets'] && shadowNodes['pt-buy-presets'].children;
+      if (presets && presets[index]) presets[index].click();
+    },
+    presetAmount: (index) => Number(shadowNodes['pt-buy-presets'].children[index].dataset.amt),
+    toastTexts: () => (shadowNodes['pt-toast-root'].children || []).map((child) => child.textContent),
     nextPrice: () => { priceIdx++; },
   };
 }
@@ -388,7 +412,7 @@ test('the whole buy section disappears when panelBuyEnabled is off', async () =>
   }
 });
 
-test('the preset row hides alone while the BUY button stays', async () => {
+test('the preset row hides alone while instant BUY stays hidden without custom sizing', async () => {
   const ov = runOverlay([0.001], {
     initialSettings: { panelPresetsEnabled: false, settingsRevision: E.SETTINGS_REVISION },
   });
@@ -397,31 +421,31 @@ test('the preset row hides alone while the BUY button stays', async () => {
 
   assert.equal(ov.shadowNodes['pt-buy-presets'].style.display, 'none',
     'the one-tap presets must be hidden');
-  assert.notEqual(ov.shadowNodes['pt-buy'].style.display, 'none',
-    'the BUY button must remain available');
+  assert.equal(ov.shadowNodes['pt-buy'].style.display, 'none',
+    'instant mode keeps BUY hidden until custom sizing is enabled');
   // The free-text amount box is OFF by default as of the panel declutter —
   // the preset row it duplicates is now eight configurable boxes. It is
-  // hidden, never removed, so BUY and limit-arm still read it.
+  // hidden, never removed, so limit-arm still reads it.
   assert.equal(ov.shadowNodes['pt-custom'].style.display, 'none',
     'the custom amount box is opt-in now');
 });
 
-test('with both toggles on, every buy control is visible', async () => {
+test('with both toggles on, instant mode shows chips and hides BUY by default', async () => {
   const ov = runOverlay([0.001]);
 
   await ov.advance(1200);
 
-  for (const id of ['pt-buy-label', 'pt-buy-presets', 'pt-buy']) {
+  for (const id of ['pt-buy-label', 'pt-buy-presets']) {
     assert.notEqual(ov.shadowNodes[id].style.display, 'none',
       `${id} must be visible with default settings`);
   }
+  assert.equal(ov.shadowNodes['pt-buy'].style.display, 'none',
+    'instant mode uses preset chips as the order buttons by default');
 });
 
 test('the custom amount box returns when the setting is switched on', async () => {
   // Off by default, but nothing is removed — the request was for panel space,
-  // not for the capability. BUY reads this element either way and falls back
-  // to the selected preset when it is empty, so hiding it can never strand a
-  // trader without a way to size an order.
+  // not for the capability. Instant BUY appears once the custom box is on.
   const ov = runOverlay([0.001], {
     initialSettings: { panelCustomAmount: true, settingsRevision: E.SETTINGS_REVISION },
   });
@@ -440,6 +464,90 @@ test('the buy-section switch still outranks the custom-amount setting', async ()
   await ov.advance(1200);
   assert.equal(ov.shadowNodes['pt-custom'].style.display, 'none',
     'a view-only trade tab shows no buy controls at all');
+});
+
+/* ==================== instant panel buy controls ==================== */
+
+test('instant preset tap fills once and an empty BUY does not fill again', async () => {
+  const ov = runOverlay([0.001]);
+  await ov.advance(1200);
+
+  assert.equal(ov.shadowNodes['pt-buy'].style.display, 'none',
+    'instant presets are the visible order buttons when custom sizing is off');
+  const amount = ov.presetAmount(0);
+  const before = ov.storage().pt_state.journal.length;
+  ov.clickPreset(0);
+  await ov.advance(800);
+  const afterPreset = ov.storage().pt_state;
+  assert.equal(afterPreset.journal.length - before, 1,
+    'a preset tap must commit exactly one fill');
+  assert.equal(afterPreset.journal.at(-1).solGross, amount,
+    'the fill size comes from the tapped preset');
+
+  ov.clickById('pt-buy');
+  await ov.advance(200);
+  const afterBuy = ov.storage().pt_state;
+  assert.equal(afterBuy.journal.length, afterPreset.journal.length,
+    'an empty custom box must not submit a second fill');
+  assert.ok(ov.toastTexts().some((text) => text === 'Pick a SOL amount first'),
+    'the empty BUY must explain that an amount is required');
+});
+
+test('instant BUY uses a typed custom amount once when enabled', async () => {
+  const ov = runOverlay([0.001], {
+    initialSettings: { panelCustomAmount: true, settingsRevision: E.SETTINGS_REVISION },
+  });
+  await ov.advance(1200);
+
+  assert.notEqual(ov.shadowNodes['pt-buy'].style.display, 'none',
+    'custom sizing keeps BUY available in instant mode');
+  const before = ov.storage().pt_state.journal.length;
+  const amount = 0.37;
+  ov.setValue('pt-custom', amount);
+  ov.clickById('pt-buy');
+  await ov.advance(800);
+  const journal = ov.storage().pt_state.journal;
+  assert.equal(journal.length - before, 1);
+  assert.equal(journal.at(-1).solGross, amount,
+    'instant BUY must use the typed custom amount, not a selected chip');
+});
+
+test('two-step BUY still uses the selected preset once', async () => {
+  const ov = runOverlay([0.001], {
+    initialSettings: { instantBuyEnabled: false, settingsRevision: E.SETTINGS_REVISION },
+  });
+  await ov.advance(1200);
+
+  assert.notEqual(ov.shadowNodes['pt-buy'].style.display, 'none',
+    'two-step mode needs the BUY trigger');
+  const amount = ov.presetAmount(0);
+  const before = ov.storage().pt_state.journal.length;
+  ov.clickPreset(0);
+  await ov.advance(200);
+  assert.equal(ov.storage().pt_state.journal.length, before,
+    'two-step preset selection must not fill immediately');
+  ov.clickById('pt-buy');
+  await ov.advance(800);
+  const journal = ov.storage().pt_state.journal;
+  assert.equal(journal.length - before, 1);
+  assert.equal(journal.at(-1).solGross, amount,
+    'two-step BUY must read the selected preset');
+});
+
+test('instant limit ARM still reads the selected preset', async () => {
+  const ov = runOverlay([0.001]);
+  await ov.advance(1200);
+
+  const amount = ov.presetAmount(0);
+  ov.clickPreset(0);
+  await ov.advance(800);
+  ov.setValue('pt-limit-price', '0.0005');
+  ov.clickById('pt-limit-arm');
+  await ov.advance(200);
+  const pending = ov.storage().pt_state.pendingBuys[BONK];
+  assert.ok(pending && pending.length === 1, 'the limit order must be armed');
+  assert.equal(pending[0].solAmount, amount,
+    'instant limit ARM still reads the selected chip');
 });
 /* ---------------- reported: panel forgets its place on refresh ----------------
  *


### PR DESCRIPTION
## Summary

With default settings the panel could fill twice for one intended order: tap a size chip, press BUY, get two fills of the same size — silently, with no refusal toast.

Instant mode (`settings.instantBuyEnabled !== false`, the default) makes a chip tap *be* the order, but the click handler also marks the chip `.sel`, and the BUY button sizes itself from `.sel`:

```
preset click  →  chip.classList.add('sel')   +  requestBuy(chip.amt)   // fill #1
BUY click     →  amt = custom || sel.amt     →  requestBuy(amt)        // fill #2, same size
```

The leftover selection is what makes the second fill quiet: it supplies an amount, so the "Pick a SOL amount first" guard never trips. And BUY was hidden only in `focus && !micro` density, so at standard density both the instant chips and a big BUY button sat on screen inviting the two-step mental model.

This makes instant mode mean one thing consistently — *the chips are the order buttons*:

```diff
-if (els.btnBuy) els.btnBuy.style.display = sectionOn ? '' : 'none';
+if (els.btnBuy) els.btnBuy.style.display = sectionOn && (!instant || customOn) ? '' : 'none';

-const sel = els.buyPresets.querySelector('.pt-preset.sel');
+const sel = !instant && els.buyPresets.querySelector('.pt-preset.sel');
```

So in instant mode BUY only exists for the free-text amount box (opt-in via `panelCustomAmount`) and only ever fills what is typed there; an empty box refuses with the existing currency-aware toast instead of re-filling the tapped chip. Two-step mode (`instantBuyEnabled: false`) is untouched: chip selects, BUY fills once.

The `.sel` marking itself stays, because `armLimitBuy` reads it — arming a limit buy from a chip selection still works in both modes, and a test pins that.

`quickbuy.test.js` gains source assertions for both edits; `statepersist.test.js` drives the shipped panel through the real fill path (its harness now renders preset chips) and asserts on journal length, so a double fill is counted, not inferred: preset tap commits exactly one fill and a following empty BUY commits none, typed custom amount fills once, BUY visibility follows the setting, two-step mode unchanged, instant ARM still reads the chip. Reverting the visibility edit reds three of them; reverting the amount-selection edit reds the double-fill test.

Extension suite 2,152 passed / 0 failed; server 279 passed / 0 failed / 10 skipped.

Found while runtime-testing #96; unrelated to that diff. The refusal path was verified in the harness, not yet on a live terminal.

Link to Devin session: https://app.devin.ai/sessions/b676704d774f4aa099ba7f31381b036f
Open in Devin Desktop: https://app.devin.ai/desktop/session/b676704d774f4aa099ba7f31381b036f?variant=devin
Requested by: @OnlyTerp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/papertrench/pull/97" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->