### PR TITLE
feat(popup): ask for a backup in the update nudge, before the wallet can be lost

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -198,8 +198,28 @@
     line-height: 1.45;
   }
   .update-banner .upd-ico { font-size: 15px; line-height: 1.2; }
-  .update-banner .upd-txt { flex: 1; min-width: 0; }
+  .update-banner .upd-txt {
+    flex: 1; min-width: 0; display: flex; flex-direction: column; align-items: flex-start;
+  }
   .update-banner .upd-txt b { color: var(--amber-2); font-weight: 600; }
+  .update-banner .upd-txt #update-backup {
+    flex: none;
+    margin-top: 6px;
+    padding: 4px 8px;
+    border: 1px solid rgba(255, 192, 129, 0.55);
+    border-radius: 5px;
+    background: transparent;
+    color: var(--amber-2);
+    cursor: pointer;
+    font: inherit;
+  }
+  .update-banner .upd-txt #update-backup:hover { background: rgba(255, 157, 69, 0.12); }
+  .update-banner .upd-txt #update-backup-state {
+    display: block;
+    margin-top: 4px;
+    color: var(--faint);
+    font-size: 11px;
+  }
   .update-banner .upd-txt a {
     color: var(--amber-2);
     text-decoration: none;
@@ -222,7 +242,12 @@
 
   <div class="update-banner" id="update-banner" hidden>
     <span class="upd-ico">⬆</span>
-    <span class="upd-txt" id="update-txt">A newer PaperTrench is out.</span>
+    <span class="upd-txt" id="update-txt">
+      <b id="update-version"></b>
+      <a id="update-link"></a>
+      <button id="update-backup" type="button">Back up wallet first</button>
+      <span id="update-backup-state"></span>
+    </span>
     <button class="upd-dismiss" id="update-dismiss" title="Dismiss">×</button>
   </div>
 

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -215,13 +215,17 @@ const UPDATER = (() => {
     }
     return {
       marker: marker.ok ? marker.value || null : null,
+      markerReadable: marker.ok,
       values,
       readable,
     };
   }
 
-  function backupText(record, snapshot, readable = true) {
+  function backupText(record, snapshot, readable = true, markerReadable = true) {
     const at = record && Number(record.at);
+    if (!markerReadable) {
+      return 'Backup exists, but the wallet could not be read, so coverage cannot be confirmed. Back up again to be safe.';
+    }
     if (!record) {
       return 'No backup yet — updating into a new folder looks like a fresh install.';
     }
@@ -304,18 +308,32 @@ const UPDATER = (() => {
     link.textContent = 'Download the update →';
     link.target = '_blank';
     link.rel = 'noopener noreferrer';
-    backupState.textContent = backupText(lastBackup, liveSnapshot, backupReadable);
+    backupState.textContent = backupText(
+      lastBackup, liveSnapshot, backupReadable, initialBackup.markerReadable,
+    );
     const refreshBackupState = async () => {
       const current = await readBackupSnapshot();
       lastBackup = current.marker;
       liveSnapshot = current.values;
       backupReadable = current.readable;
-      backupState.textContent = backupText(lastBackup, liveSnapshot, backupReadable);
+      backupState.textContent = backupText(
+        lastBackup, liveSnapshot, backupReadable, current.markerReadable,
+      );
+      return current;
     };
     const hasBackup = () => {
       const at = lastBackup && Number(lastBackup.at);
       return Number.isFinite(at) && backupReadable && lastBackup.fingerprint
         && !lastBackup.chainMissing && lastBackup.fingerprint === backupFingerprint(liveSnapshot);
+    };
+    const openUpdate = async () => {
+      try {
+        if (chrome.tabs && typeof chrome.tabs.create === 'function') {
+          await chrome.tabs.create({ url: link.href });
+          return;
+        }
+      } catch (_) {}
+      try { window.open(link.href, '_blank', 'noopener'); } catch (_) {}
     };
     backupButton.addEventListener('click', async () => {
       try { await backupWallet(); } catch (_) {}
@@ -326,15 +344,15 @@ const UPDATER = (() => {
       ev.preventDefault();
       if (downloadCheck) return downloadCheck;
       downloadCheck = (async () => {
-        await refreshBackupState();
+        const current = await refreshBackupState();
         if (hasBackup() || Date.now() < downloadArmedUntil) {
-          window.open(link.href, '_blank', 'noopener');
+          await openUpdate();
           return;
         }
         downloadArmedUntil = Date.now() + 10 * 1000;
-        if (!lastBackup) {
-          backupState.textContent = 'No backup yet — click again to update anyway';
-        }
+        backupState.textContent = `${backupText(
+          lastBackup, liveSnapshot, backupReadable, current.markerReadable,
+        )} — click again to update anyway`;
       })().finally(() => { downloadCheck = null; });
       return downloadCheck;
     });

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -124,26 +124,43 @@ function canonicalBackupValue(value) {
   return JSON.stringify(value);
 }
 
-function stateFingerprint(state) {
-  if (!state || typeof state !== 'object') return null;
-  const copy = { ...state };
-  // seq and updatedAt move on every heartbeat, not on durable wallet edits.
-  delete copy.seq;
-  delete copy.updatedAt;
-  // markPosition writes these on price ticks; they are not backup content.
-  if (copy.positions && typeof copy.positions === 'object') {
-    copy.positions = Object.fromEntries(Object.entries(copy.positions).map(([key, position]) => {
-      if (!position || typeof position !== 'object') return [key, position];
-      const durable = { ...position };
-      delete durable.lastPriceNative;
-      delete durable.lastPriceUsd;
-      delete durable.peakPnlSol;
-      delete durable.troughPnlSol;
-      return [key, durable];
-    }));
+function backupFingerprint(data) {
+  if (!data || typeof data !== 'object') return null;
+  const state = data.pt_state && typeof data.pt_state === 'object'
+    ? { ...data.pt_state } : data.pt_state;
+  if (state && typeof state === 'object') {
+    // seq and updatedAt move on every heartbeat, not on durable wallet edits.
+    delete state.seq;
+    delete state.updatedAt;
+    // markPosition writes these on price ticks; they are not backup content.
+    if (state.positions && typeof state.positions === 'object') {
+      state.positions = Object.fromEntries(Object.entries(state.positions).map(([key, position]) => {
+        if (!position || typeof position !== 'object') return [key, position];
+        const durable = { ...position };
+        delete durable.lastPriceNative;
+        delete durable.lastPriceUsd;
+        delete durable.peakPnlSol;
+        delete durable.troughPnlSol;
+        return [key, durable];
+      }));
+    }
+    // attestChain is embedded into the exported copy for downgrade safety.
+    delete state.attestChain;
   }
-  // attestChain is embedded into the exported copy for downgrade safety.
-  delete copy.attestChain;
+  const frames = Array.isArray(data.pt_frames) ? data.pt_frames.map((frame) => {
+    if (!frame || typeof frame !== 'object') return frame;
+    const metadata = { ...frame };
+    // Frame data is a large JPEG; append-and-evict metadata still detects
+    // every add or eviction without hashing megabytes on each popup open.
+    delete metadata.dataUrl;
+    return metadata;
+  }) : data.pt_frames;
+  const copy = {
+    pt_state: state,
+    pt_settings: data.pt_settings,
+    pt_frames: frames,
+    pt_replays: data.pt_replays,
+  };
   let hash = 0x811c9dc5;
   for (const char of canonicalBackupValue(copy)) {
     hash ^= char.charCodeAt(0);
@@ -179,12 +196,37 @@ const UPDATER = (() => {
     return 0;
   }
 
-  function backupText(record, state) {
+  async function readBackupSnapshot() {
+    const read = async (key) => {
+      try {
+        const result = await chainGet([key]);
+        return { ok: true, value: result[key] };
+      } catch (_) {
+        return { ok: false, value: undefined };
+      }
+    };
+    const marker = await read('pt_last_backup');
+    const values = {};
+    let readable = true;
+    for (const key of BACKUP_KEYS) {
+      const result = await read(key);
+      values[key] = result.value;
+      if (!result.ok) readable = false;
+    }
+    return {
+      marker: marker.ok ? marker.value || null : null,
+      values,
+      readable,
+    };
+  }
+
+  function backupText(record, snapshot, readable = true) {
     const at = record && Number(record.at);
     if (!record) {
       return 'No backup yet — updating into a new folder looks like a fresh install.';
     }
-    if (!state) {
+    const state = snapshot && snapshot.pt_state;
+    if (!readable || !state) {
       return 'Backup exists, but the wallet could not be read, so coverage cannot be confirmed. Back up again to be safe.';
     }
     if (!Number.isFinite(at)) {
@@ -195,8 +237,11 @@ const UPDATER = (() => {
       return `Last backup: ${date} — different wallet since. Back up again.`;
     }
     const trades = Array.isArray(state.journal) ? state.journal.length : 0;
-    if (record.fingerprint && record.fingerprint === stateFingerprint(state)) {
-      return `Last backup: ${date}`;
+    if (record.chainMissing) {
+      return `Last backup: ${date} — exported without the verification chain. Back up again.`;
+    }
+    if (record.fingerprint && record.fingerprint === backupFingerprint(snapshot)) {
+      return `Last backup: ${date} · exported — check the file is in your downloads`;
     }
     if (Number.isFinite(Number(record.trades)) && trades > Number(record.trades)) {
       const delta = trades - Number(record.trades);
@@ -248,12 +293,10 @@ const UPDATER = (() => {
     }
     let seen = {};
     try { seen = (await chainGet(['pt_update_seen']))['pt_update_seen'] || {}; } catch (_) {}
-    let lastBackup = null;
-    let liveState = null;
-    try { lastBackup = (await chainGet(['pt_last_backup'])).pt_last_backup || null; }
-    catch (_) { lastBackup = null; }
-    try { liveState = (await chainGet(['pt_state'])).pt_state || null; }
-    catch (_) { liveState = null; }
+    const initialBackup = await readBackupSnapshot();
+    let lastBackup = initialBackup.marker;
+    let liveSnapshot = initialBackup.values;
+    let backupReadable = initialBackup.readable;
     const nowMs = Date.now();
     if (seen.version === info.latest && (seen.at || 0) > nowMs - 30 * DAY_MS) return;
     version.textContent = 'v' + info.latest + ' is out';
@@ -261,28 +304,39 @@ const UPDATER = (() => {
     link.textContent = 'Download the update →';
     link.target = '_blank';
     link.rel = 'noopener noreferrer';
-    backupState.textContent = backupText(lastBackup, liveState);
+    backupState.textContent = backupText(lastBackup, liveSnapshot, backupReadable);
     const refreshBackupState = async () => {
-      try { lastBackup = (await chainGet(['pt_last_backup'])).pt_last_backup || null; }
-      catch (_) { lastBackup = null; }
-      try { liveState = (await chainGet(['pt_state'])).pt_state || null; }
-      catch (_) { liveState = null; }
-      backupState.textContent = backupText(lastBackup, liveState);
+      const current = await readBackupSnapshot();
+      lastBackup = current.marker;
+      liveSnapshot = current.values;
+      backupReadable = current.readable;
+      backupState.textContent = backupText(lastBackup, liveSnapshot, backupReadable);
     };
     const hasBackup = () => {
       const at = lastBackup && Number(lastBackup.at);
-      return Number.isFinite(at) && liveState && lastBackup.fingerprint
-        && lastBackup.fingerprint === stateFingerprint(liveState);
+      return Number.isFinite(at) && backupReadable && lastBackup.fingerprint
+        && !lastBackup.chainMissing && lastBackup.fingerprint === backupFingerprint(liveSnapshot);
     };
     backupButton.addEventListener('click', async () => {
       try { await backupWallet(); } catch (_) {}
       await refreshBackupState();
     });
+    let downloadCheck = null;
     link.addEventListener('click', (ev) => {
-      if (hasBackup() || Date.now() < downloadArmedUntil) return;
       ev.preventDefault();
-      downloadArmedUntil = Date.now() + 10 * 1000;
-      backupState.textContent = 'No backup yet — click again to update anyway';
+      if (downloadCheck) return downloadCheck;
+      downloadCheck = (async () => {
+        await refreshBackupState();
+        if (hasBackup() || Date.now() < downloadArmedUntil) {
+          window.open(link.href, '_blank', 'noopener');
+          return;
+        }
+        downloadArmedUntil = Date.now() + 10 * 1000;
+        if (!lastBackup) {
+          backupState.textContent = 'No backup yet — click again to update anyway';
+        }
+      })().finally(() => { downloadCheck = null; });
+      return downloadCheck;
     });
     banner.hidden = false;
     const onDismiss = () => {
@@ -807,7 +861,7 @@ const BACKUP_KEYS = ['pt_state', 'pt_settings', 'pt_frames', 'pt_replays'];
 
 async function backupWallet() {
   const stored = await chrome.storage.local.get(BACKUP_KEYS);
-  const fingerprint = stateFingerprint(stored.pt_state);
+  const fingerprint = backupFingerprint(stored);
   // F-14: the attestation chain lives in segmented storage, not in pt_state.
   // The backup bundles it as ONE array (pt_attest_chain) so a restore can
   // re-segment it on any future segment size — and so the verifiable record
@@ -857,6 +911,7 @@ async function backupWallet() {
         startedAt: state && state.startedAt != null ? state.startedAt : null,
         trades: state && Array.isArray(state.journal) ? state.journal.length : 0,
         fingerprint,
+        chainMissing,
       },
     });
   } catch (_) {}

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -162,8 +162,9 @@ function backupFingerprint(data) {
     pt_replays: data.pt_replays,
   };
   let hash = 0x811c9dc5;
-  for (const char of canonicalBackupValue(copy)) {
-    hash ^= char.charCodeAt(0);
+  const canonical = canonicalBackupValue(copy);
+  for (let i = 0; i < canonical.length; i++) {
+    hash ^= canonical.charCodeAt(i);
     hash = Math.imul(hash, 0x01000193);
   }
   return (hash >>> 0).toString(16).padStart(8, '0');
@@ -213,25 +214,46 @@ const UPDATER = (() => {
       values[key] = result.value;
       if (!result.ok) readable = false;
     }
+    let chainMeta = null;
+    let chainMetaReadable = true;
+    if (AT) {
+      try {
+        chainMeta = await AT.readChainMeta(chainGet);
+      } catch (_) {
+        chainMetaReadable = false;
+      }
+    }
     return {
       marker: marker.ok ? marker.value || null : null,
       markerReadable: marker.ok,
       values,
       readable,
+      chainMeta,
+      chainMetaReadable,
     };
   }
 
-  function backupText(record, snapshot, readable = true, markerReadable = true) {
+  function backupText(
+    record, snapshot, readable = true, markerReadable = true,
+    chainMetaReadable = true, chainMeta = null,
+  ) {
     const at = record && Number(record.at);
     if (!markerReadable) {
-      return 'Backup exists, but the wallet could not be read, so coverage cannot be confirmed. Back up again to be safe.';
+      return 'Backup status could not be read, so coverage cannot be confirmed. Back up again to be safe.';
     }
     if (!record) {
       return 'No backup yet — updating into a new folder looks like a fresh install.';
     }
     const state = snapshot && snapshot.pt_state;
-    if (!readable || !state) {
+    if (!markerReadable || !readable || !state || (!record.chainMissing && !chainMetaReadable)) {
       return 'Backup exists, but the wallet could not be read, so coverage cannot be confirmed. Back up again to be safe.';
+    }
+    if (record.chainMissing) {
+      if (!Number.isFinite(at)) {
+        return 'Backup exists, but its date could not be read. Back up again to be safe.';
+      }
+      const date = new Date(at).toISOString().slice(0, 10);
+      return `Last backup: ${date} — exported without the verification chain. Back up again.`;
     }
     if (!Number.isFinite(at)) {
       return 'Backup exists, but its date could not be read. Back up again to be safe.';
@@ -241,8 +263,15 @@ const UPDATER = (() => {
       return `Last backup: ${date} — different wallet since. Back up again.`;
     }
     const trades = Array.isArray(state.journal) ? state.journal.length : 0;
-    if (record.chainMissing) {
-      return `Last backup: ${date} — exported without the verification chain. Back up again.`;
+    // The wallet write and the chain append are separate commits, so an
+    // export landing between them bundles a fill whose link is missing. The
+    // chain's own meta says so; records written before this field existed
+    // carry no length and fall through to the fingerprint as before.
+    if (chainMeta && Number.isInteger(Number(record.chainLength))
+      && typeof record.chainHead === 'string'
+      && (Number(record.chainLength) !== chainMeta.length
+        || record.chainHead !== chainMeta.head)) {
+      return `Last backup: ${date} — new verified fills since. Back up again.`;
     }
     if (record.fingerprint && record.fingerprint === backupFingerprint(snapshot)) {
       return `Last backup: ${date} · exported — check the file is in your downloads`;
@@ -301,6 +330,8 @@ const UPDATER = (() => {
     let lastBackup = initialBackup.marker;
     let liveSnapshot = initialBackup.values;
     let backupReadable = initialBackup.readable;
+    let liveChainMeta = initialBackup.chainMeta;
+    let chainMetaReadable = initialBackup.chainMetaReadable;
     const nowMs = Date.now();
     if (seen.version === info.latest && (seen.at || 0) > nowMs - 30 * DAY_MS) return;
     version.textContent = 'v' + info.latest + ' is out';
@@ -310,21 +341,31 @@ const UPDATER = (() => {
     link.rel = 'noopener noreferrer';
     backupState.textContent = backupText(
       lastBackup, liveSnapshot, backupReadable, initialBackup.markerReadable,
+      chainMetaReadable, liveChainMeta,
     );
     const refreshBackupState = async () => {
       const current = await readBackupSnapshot();
       lastBackup = current.marker;
       liveSnapshot = current.values;
       backupReadable = current.readable;
+      liveChainMeta = current.chainMeta;
+      chainMetaReadable = current.chainMetaReadable;
       backupState.textContent = backupText(
         lastBackup, liveSnapshot, backupReadable, current.markerReadable,
+        chainMetaReadable, liveChainMeta,
       );
       return current;
     };
     const hasBackup = () => {
       const at = lastBackup && Number(lastBackup.at);
+      const chainCurrent = !liveChainMeta
+        || !Number.isInteger(Number(lastBackup && lastBackup.chainLength))
+        || typeof (lastBackup && lastBackup.chainHead) !== 'string'
+        || (Number(lastBackup.chainLength) === liveChainMeta.length
+          && lastBackup.chainHead === liveChainMeta.head);
       return Number.isFinite(at) && backupReadable && lastBackup.fingerprint
-        && !lastBackup.chainMissing && lastBackup.fingerprint === backupFingerprint(liveSnapshot);
+        && !lastBackup.chainMissing && chainMetaReadable && chainCurrent
+        && lastBackup.fingerprint === backupFingerprint(liveSnapshot);
     };
     const openUpdate = async () => {
       try {
@@ -352,6 +393,7 @@ const UPDATER = (() => {
         downloadArmedUntil = Date.now() + 10 * 1000;
         backupState.textContent = `${backupText(
           lastBackup, liveSnapshot, backupReadable, current.markerReadable,
+          current.chainMetaReadable, current.chainMeta,
         )} — click again to update anyway`;
       })().finally(() => { downloadCheck = null; });
       return downloadCheck;
@@ -885,10 +927,14 @@ async function backupWallet() {
   // re-segment it on any future segment size — and so the verifiable record
   // survives a reinstall exactly like the wallet does. A pre-migration
   // install still carries the chain inside pt_state; bundle that instead.
-  let chainMissing = false;
+  let chainMissing = !AT;
+  let chainLength = null;
+  let chainHead = null;
   if (AT) {
     try {
-      const { chain } = await AT.readChainStore(chainGet);
+      const { meta, chain } = await AT.readChainStore(chainGet);
+      chainLength = meta.length;
+      chainHead = meta.head;
       if (chain.length) stored.pt_attest_chain = chain;
       else if (stored.pt_state && Array.isArray(stored.pt_state.attestChain) && stored.pt_state.attestChain.length) {
         stored.pt_attest_chain = stored.pt_state.attestChain;
@@ -930,6 +976,8 @@ async function backupWallet() {
         trades: state && Array.isArray(state.journal) ? state.journal.length : 0,
         fingerprint,
         chainMissing,
+        chainLength,
+        chainHead,
       },
     });
   } catch (_) {}

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -129,6 +129,7 @@ async function shareDebugLogs() {
 const UPDATER = (() => {
   const REL_URL = 'https://api.github.com/repos/OnlyTerp/papertrench/releases/latest';
   const DAY_MS = 24 * 60 * 60 * 1000;
+  let downloadArmedUntil = 0;
 
   function vCmp(a, b) {
     const pa = String(a).split('.').map(Number);
@@ -138,6 +139,13 @@ const UPDATER = (() => {
       if (d) return d;
     }
     return 0;
+  }
+
+  function backupText(record) {
+    const at = record && Number(record.at);
+    return record && Number.isFinite(at)
+      ? `Last backup: ${new Date(at).toISOString().slice(0, 10)}`
+      : 'No backup yet — updating into a new folder looks like a fresh install.';
   }
 
   async function check(force) {
@@ -168,7 +176,11 @@ const UPDATER = (() => {
     const banner = document.getElementById('update-banner');
     const txt = document.getElementById('update-txt');
     const dismiss = document.getElementById('update-dismiss');
-    if (!banner || !txt || !dismiss) return;
+    const version = document.getElementById('update-version');
+    const link = document.getElementById('update-link');
+    const backupButton = document.getElementById('update-backup');
+    const backupState = document.getElementById('update-backup-state');
+    if (!banner || !txt || !dismiss || !version || !link || !backupButton || !backupState) return;
     let info = null;
     try { info = await check(); } catch (_) { return; }
     if (!info || !info.latest || vCmp(info.latest, chrome.runtime.getManifest().version) <= 0) {
@@ -176,19 +188,37 @@ const UPDATER = (() => {
     }
     let seen = {};
     try { seen = (await chainGet(['pt_update_seen']))['pt_update_seen'] || {}; } catch (_) {}
+    let lastBackup = null;
+    try { lastBackup = (await chainGet(['pt_last_backup']))['pt_last_backup'] || null; } catch (_) { return; }
     const nowMs = Date.now();
     if (seen.version === info.latest && (seen.at || 0) > nowMs - 30 * DAY_MS) return;
-    txt.innerHTML = '';
-    const b = document.createElement('b');
-    b.textContent = 'v' + info.latest + ' is out';
-    txt.appendChild(b);
-    txt.appendChild(document.createElement('br'));
-    const a = document.createElement('a');
-    a.href = info.url;
-    a.textContent = 'Download the update →';
-    a.target = '_blank';
-    a.rel = 'noopener noreferrer';
-    txt.appendChild(a);
+    version.textContent = 'v' + info.latest + ' is out';
+    link.href = info.url;
+    link.textContent = 'Download the update →';
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    backupState.textContent = backupText(lastBackup);
+    const refreshBackupState = async () => {
+      try {
+        const stored = await chainGet(['pt_last_backup']);
+        lastBackup = stored.pt_last_backup || null;
+        backupState.textContent = backupText(lastBackup);
+      } catch (_) {}
+    };
+    const hasBackup = () => {
+      const at = lastBackup && Number(lastBackup.at);
+      return Number.isFinite(at);
+    };
+    backupButton.addEventListener('click', async () => {
+      try { await backupWallet(); } catch (_) {}
+      await refreshBackupState();
+    });
+    link.addEventListener('click', (ev) => {
+      if (hasBackup() || Date.now() < downloadArmedUntil) return;
+      ev.preventDefault();
+      downloadArmedUntil = Date.now() + 10 * 1000;
+      backupState.textContent = 'No backup yet — click again to update anyway';
+    });
     banner.hidden = false;
     const onDismiss = () => {
       try { chrome.storage.local.set({ pt_update_seen: { version: info.latest, at: Date.now() } }); } catch (_) {}
@@ -752,6 +782,11 @@ async function backupWallet() {
   a.click();
   a.remove();
   setTimeout(() => URL.revokeObjectURL(url), 2000);
+  try {
+    await chrome.storage.local.set({
+      pt_last_backup: { at: Date.now(), version: chrome.runtime.getManifest().version },
+    });
+  } catch (_) {}
   // DEFECT D-41: screen recordings live in IndexedDB (tens of MB) and are
   // deliberately NOT exported. The status line must say so — silently
   // implying "everything is in the file" is an overpromise the user only

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -114,6 +114,44 @@ async function shareDebugLogs() {
   }
 }
 
+function canonicalBackupValue(value) {
+  if (Array.isArray(value)) return `[${value.map(canonicalBackupValue).join(',')}]`;
+  if (value && typeof value === 'object') {
+    return `{${Object.keys(value).sort().map((key) => (
+      `${JSON.stringify(key)}:${canonicalBackupValue(value[key])}`
+    )).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function stateFingerprint(state) {
+  if (!state || typeof state !== 'object') return null;
+  const copy = { ...state };
+  // seq and updatedAt move on every heartbeat, not on durable wallet edits.
+  delete copy.seq;
+  delete copy.updatedAt;
+  // markPosition writes these on price ticks; they are not backup content.
+  if (copy.positions && typeof copy.positions === 'object') {
+    copy.positions = Object.fromEntries(Object.entries(copy.positions).map(([key, position]) => {
+      if (!position || typeof position !== 'object') return [key, position];
+      const durable = { ...position };
+      delete durable.lastPriceNative;
+      delete durable.lastPriceUsd;
+      delete durable.peakPnlSol;
+      delete durable.troughPnlSol;
+      return [key, durable];
+    }));
+  }
+  // attestChain is embedded into the exported copy for downgrade safety.
+  delete copy.attestChain;
+  let hash = 0x811c9dc5;
+  for (const char of canonicalBackupValue(copy)) {
+    hash ^= char.charCodeAt(0);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
 /* ---- update nudge ---------------------------------------------------
  * PaperTrench ships as a zip from GitHub — no Chrome Web Store, so Chrome
  * never auto-updates it. Field reports from 8/16–19 described bugs fixed
@@ -143,19 +181,31 @@ const UPDATER = (() => {
 
   function backupText(record, state) {
     const at = record && Number(record.at);
-    if (!record || !Number.isFinite(at) || !state) {
+    if (!record) {
       return 'No backup yet — updating into a new folder looks like a fresh install.';
+    }
+    if (!state) {
+      return 'Backup exists, but the wallet could not be read, so coverage cannot be confirmed. Back up again to be safe.';
+    }
+    if (!Number.isFinite(at)) {
+      return 'Backup exists, but its date could not be read. Back up again to be safe.';
     }
     const date = new Date(at).toISOString().slice(0, 10);
     if (record.startedAt !== state.startedAt) {
       return `Last backup: ${date} — different wallet since. Back up again.`;
     }
     const trades = Array.isArray(state.journal) ? state.journal.length : 0;
-    if (record.trades !== trades) {
-      const delta = Math.max(0, trades - Number(record.trades));
+    if (record.fingerprint && record.fingerprint === stateFingerprint(state)) {
+      return `Last backup: ${date}`;
+    }
+    if (Number.isFinite(Number(record.trades)) && trades > Number(record.trades)) {
+      const delta = trades - Number(record.trades);
       return `Last backup: ${date} — ${delta} ${delta === 1 ? 'trade' : 'trades'} since. Back up again.`;
     }
-    return `Last backup: ${date}`;
+    if (!Number.isFinite(Number(record.trades)) || trades < Number(record.trades)) {
+      return `Last backup: ${date} — wallet history changed. Back up again.`;
+    }
+    return `Last backup: ${date} — wallet changed since. Back up again.`;
   }
 
   async function check(force) {
@@ -200,14 +250,10 @@ const UPDATER = (() => {
     try { seen = (await chainGet(['pt_update_seen']))['pt_update_seen'] || {}; } catch (_) {}
     let lastBackup = null;
     let liveState = null;
-    try {
-      const current = await chainGet(['pt_last_backup', 'pt_state']);
-      lastBackup = current.pt_last_backup || null;
-      liveState = current.pt_state || null;
-    } catch (_) {
-      lastBackup = null;
-      liveState = null;
-    }
+    try { lastBackup = (await chainGet(['pt_last_backup'])).pt_last_backup || null; }
+    catch (_) { lastBackup = null; }
+    try { liveState = (await chainGet(['pt_state'])).pt_state || null; }
+    catch (_) { liveState = null; }
     const nowMs = Date.now();
     if (seen.version === info.latest && (seen.at || 0) > nowMs - 30 * DAY_MS) return;
     version.textContent = 'v' + info.latest + ' is out';
@@ -217,20 +263,16 @@ const UPDATER = (() => {
     link.rel = 'noopener noreferrer';
     backupState.textContent = backupText(lastBackup, liveState);
     const refreshBackupState = async () => {
-      try {
-        const stored = await chainGet(['pt_last_backup', 'pt_state']);
-        lastBackup = stored.pt_last_backup || null;
-        liveState = stored.pt_state || null;
-        backupState.textContent = backupText(lastBackup, liveState);
-      } catch (_) {}
+      try { lastBackup = (await chainGet(['pt_last_backup'])).pt_last_backup || null; }
+      catch (_) { lastBackup = null; }
+      try { liveState = (await chainGet(['pt_state'])).pt_state || null; }
+      catch (_) { liveState = null; }
+      backupState.textContent = backupText(lastBackup, liveState);
     };
     const hasBackup = () => {
       const at = lastBackup && Number(lastBackup.at);
-      const currentTrades = liveState && Array.isArray(liveState.journal)
-        ? liveState.journal.length : null;
-      return Number.isFinite(at) && liveState
-        && lastBackup.startedAt === liveState.startedAt
-        && lastBackup.trades === currentTrades;
+      return Number.isFinite(at) && liveState && lastBackup.fingerprint
+        && lastBackup.fingerprint === stateFingerprint(liveState);
     };
     backupButton.addEventListener('click', async () => {
       try { await backupWallet(); } catch (_) {}
@@ -765,6 +807,7 @@ const BACKUP_KEYS = ['pt_state', 'pt_settings', 'pt_frames', 'pt_replays'];
 
 async function backupWallet() {
   const stored = await chrome.storage.local.get(BACKUP_KEYS);
+  const fingerprint = stateFingerprint(stored.pt_state);
   // F-14: the attestation chain lives in segmented storage, not in pt_state.
   // The backup bundles it as ONE array (pt_attest_chain) so a restore can
   // re-segment it on any future segment size — and so the verifiable record
@@ -813,6 +856,7 @@ async function backupWallet() {
         version: chrome.runtime.getManifest().version,
         startedAt: state && state.startedAt != null ? state.startedAt : null,
         trades: state && Array.isArray(state.journal) ? state.journal.length : 0,
+        fingerprint,
       },
     });
   } catch (_) {}

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -931,29 +931,41 @@ async function backupWallet() {
   let chainLength = null;
   let chainHead = null;
   if (AT) {
-    try {
-      const { meta, chain } = await AT.readChainStore(chainGet);
-      if (chain.length !== meta.length
-        || (chain.length && chain[chain.length - 1].hash !== meta.head)) {
-        throw new Error('Attestation chain is incomplete');
-      }
-      chainLength = meta.length;
-      chainHead = meta.head;
-      if (chain.length) stored.pt_attest_chain = chain;
-      else if (stored.pt_state && Array.isArray(stored.pt_state.attestChain) && stored.pt_state.attestChain.length) {
-        stored.pt_attest_chain = stored.pt_state.attestChain;
-      }
-      // Downgrade safety: ALSO embed the chain inside the backup's pt_state
-      // copy, exactly where a pre-segmentation extension expects it. An old
-      // restore then keeps the record intact instead of silently dropping it
-      // (and flagging a verification mismatch after the next fill); the new
-      // restore strips this copy and re-segments pt_attest_chain. The file
-      // carries the chain twice, but a backup that can lose the verifiable
-      // record on the way back in is not a backup.
-      if (stored.pt_attest_chain && stored.pt_state) {
-        stored.pt_state = { ...stored.pt_state, attestChain: stored.pt_attest_chain };
-      }
-    } catch (_) { chainMissing = true; }
+    // readChainStore reads the meta and the segments in two gets, while an
+    // append writes tail and meta in a single set. A fill landing between the
+    // two reads therefore shows an old meta beside a chain that already holds
+    // the new link — complete, but not self-consistent. Judge completeness
+    // only on a snapshot the meta held still across, and retry otherwise.
+    chainMissing = true;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        const { meta, chain } = await AT.readChainStore(chainGet);
+        const after = await AT.readChainMeta(chainGet);
+        if (after.length !== meta.length || after.head !== meta.head) continue;
+        if (chain.length !== meta.length
+          || (chain.length && chain[chain.length - 1].hash !== meta.head)) {
+          throw new Error('Attestation chain is incomplete');
+        }
+        chainLength = meta.length;
+        chainHead = meta.head;
+        if (chain.length) stored.pt_attest_chain = chain;
+        else if (stored.pt_state && Array.isArray(stored.pt_state.attestChain) && stored.pt_state.attestChain.length) {
+          stored.pt_attest_chain = stored.pt_state.attestChain;
+        }
+        // Downgrade safety: ALSO embed the chain inside the backup's pt_state
+        // copy, exactly where a pre-segmentation extension expects it. An old
+        // restore then keeps the record intact instead of silently dropping it
+        // (and flagging a verification mismatch after the next fill); the new
+        // restore strips this copy and re-segments pt_attest_chain. The file
+        // carries the chain twice, but a backup that can lose the verifiable
+        // record on the way back in is not a backup.
+        if (stored.pt_attest_chain && stored.pt_state) {
+          stored.pt_state = { ...stored.pt_state, attestChain: stored.pt_attest_chain };
+        }
+        chainMissing = false;
+        break;
+      } catch (_) { chainMissing = true; break; }
+    }
   }
   const backup = {
     app: 'papertrench-backup',

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -207,12 +207,12 @@ const UPDATER = (() => {
       }
     };
     const marker = await read('pt_last_backup');
-    const values = {};
+    let values = {};
     let readable = true;
-    for (const key of BACKUP_KEYS) {
-      const result = await read(key);
-      values[key] = result.value;
-      if (!result.ok) readable = false;
+    try {
+      values = await chainGet(BACKUP_KEYS);
+    } catch (_) {
+      readable = false;
     }
     let chainMeta = null;
     let chainMetaReadable = true;
@@ -933,6 +933,10 @@ async function backupWallet() {
   if (AT) {
     try {
       const { meta, chain } = await AT.readChainStore(chainGet);
+      if (chain.length !== meta.length
+        || (chain.length && chain[chain.length - 1].hash !== meta.head)) {
+        throw new Error('Attestation chain is incomplete');
+      }
       chainLength = meta.length;
       chainHead = meta.head;
       if (chain.length) stored.pt_attest_chain = chain;

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -141,11 +141,21 @@ const UPDATER = (() => {
     return 0;
   }
 
-  function backupText(record) {
+  function backupText(record, state) {
     const at = record && Number(record.at);
-    return record && Number.isFinite(at)
-      ? `Last backup: ${new Date(at).toISOString().slice(0, 10)}`
-      : 'No backup yet — updating into a new folder looks like a fresh install.';
+    if (!record || !Number.isFinite(at) || !state) {
+      return 'No backup yet — updating into a new folder looks like a fresh install.';
+    }
+    const date = new Date(at).toISOString().slice(0, 10);
+    if (record.startedAt !== state.startedAt) {
+      return `Last backup: ${date} — different wallet since. Back up again.`;
+    }
+    const trades = Array.isArray(state.journal) ? state.journal.length : 0;
+    if (record.trades !== trades) {
+      const delta = Math.max(0, trades - Number(record.trades));
+      return `Last backup: ${date} — ${delta} ${delta === 1 ? 'trade' : 'trades'} since. Back up again.`;
+    }
+    return `Last backup: ${date}`;
   }
 
   async function check(force) {
@@ -189,7 +199,15 @@ const UPDATER = (() => {
     let seen = {};
     try { seen = (await chainGet(['pt_update_seen']))['pt_update_seen'] || {}; } catch (_) {}
     let lastBackup = null;
-    try { lastBackup = (await chainGet(['pt_last_backup']))['pt_last_backup'] || null; } catch (_) { lastBackup = null; }
+    let liveState = null;
+    try {
+      const current = await chainGet(['pt_last_backup', 'pt_state']);
+      lastBackup = current.pt_last_backup || null;
+      liveState = current.pt_state || null;
+    } catch (_) {
+      lastBackup = null;
+      liveState = null;
+    }
     const nowMs = Date.now();
     if (seen.version === info.latest && (seen.at || 0) > nowMs - 30 * DAY_MS) return;
     version.textContent = 'v' + info.latest + ' is out';
@@ -197,17 +215,22 @@ const UPDATER = (() => {
     link.textContent = 'Download the update →';
     link.target = '_blank';
     link.rel = 'noopener noreferrer';
-    backupState.textContent = backupText(lastBackup);
+    backupState.textContent = backupText(lastBackup, liveState);
     const refreshBackupState = async () => {
       try {
-        const stored = await chainGet(['pt_last_backup']);
+        const stored = await chainGet(['pt_last_backup', 'pt_state']);
         lastBackup = stored.pt_last_backup || null;
-        backupState.textContent = backupText(lastBackup);
+        liveState = stored.pt_state || null;
+        backupState.textContent = backupText(lastBackup, liveState);
       } catch (_) {}
     };
     const hasBackup = () => {
       const at = lastBackup && Number(lastBackup.at);
-      return Number.isFinite(at);
+      const currentTrades = liveState && Array.isArray(liveState.journal)
+        ? liveState.journal.length : null;
+      return Number.isFinite(at) && liveState
+        && lastBackup.startedAt === liveState.startedAt
+        && lastBackup.trades === currentTrades;
     };
     backupButton.addEventListener('click', async () => {
       try { await backupWallet(); } catch (_) {}
@@ -783,8 +806,14 @@ async function backupWallet() {
   a.remove();
   setTimeout(() => URL.revokeObjectURL(url), 2000);
   try {
+    const state = stored.pt_state || null;
     await chrome.storage.local.set({
-      pt_last_backup: { at: Date.now(), version: chrome.runtime.getManifest().version },
+      pt_last_backup: {
+        at: Date.now(),
+        version: chrome.runtime.getManifest().version,
+        startedAt: state && state.startedAt != null ? state.startedAt : null,
+        trades: state && Array.isArray(state.journal) ? state.journal.length : 0,
+      },
     });
   } catch (_) {}
   // DEFECT D-41: screen recordings live in IndexedDB (tens of MB) and are

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -189,7 +189,7 @@ const UPDATER = (() => {
     let seen = {};
     try { seen = (await chainGet(['pt_update_seen']))['pt_update_seen'] || {}; } catch (_) {}
     let lastBackup = null;
-    try { lastBackup = (await chainGet(['pt_last_backup']))['pt_last_backup'] || null; } catch (_) { return; }
+    try { lastBackup = (await chainGet(['pt_last_backup']))['pt_last_backup'] || null; } catch (_) { lastBackup = null; }
     const nowMs = Date.now();
     if (seen.version === info.latest && (seen.at || 0) > nowMs - 30 * DAY_MS) return;
     version.textContent = 'v' + info.latest + ' is out';

--- a/extension/test/updatebanner.test.js
+++ b/extension/test/updatebanner.test.js
@@ -21,13 +21,15 @@ const vm = require('node:vm');
 
 const ROOT = path.join(__dirname, '..');
 
-function loadPopupPage({ release, checkedAt, seenVersion, manifestVersion }) {
+function loadPopupPage({ release, checkedAt, seenVersion, lastBackup, manifestVersion, storageGetThrows = false }) {
   const html = fs.readFileSync(path.join(ROOT, 'popup.html'), 'utf8');
   const stored = new Map();
   if (checkedAt !== undefined) stored.set('pt_update_check', { checkedAt });
   if (seenVersion !== undefined) stored.set('pt_update_seen', { version: seenVersion, at: Date.now() });
+  if (lastBackup !== undefined) stored.set('pt_last_backup', lastBackup);
 
   const storageGet = async (keys) => {
+    if (storageGetThrows) throw new Error('storage unavailable');
     const out = {};
     for (const k of keys) if (stored.has(k)) out[k] = stored.get(k);
     return out;
@@ -51,21 +53,33 @@ function loadPopupPage({ release, checkedAt, seenVersion, manifestVersion }) {
       rel: '',
       title: '',
       style: {},
+      classList: { toggle() {} },
       addEventListener: (t, fn) => { listeners.set(id + ':' + t, fn); },
       appendChild(child) { this.children.push(child); },
+      click() {},
+      remove() {},
       setAttribute() {},
     };
     return el;
   }
   const els = {};
   for (const id of ['dash','desk','toggle','reset','backup','restore','restoreFile','overlay-window',
-                    'warmx','warmdest','xray','power','qs-apply','sharelogs','badge','equity','delta','cash',
-                    'pnl','open','rounds','flow','recent','status','update-banner','update-txt','update-dismiss']) {
+                    'warmx','warmdest','xray','power','qs-apply','qs-balance','qs-presets','qs-sellpcts','qs-fees',
+                    'sharelogs','badge','equity','delta','cash',
+                    'pnl','open','rounds','flow','recent','status','update-banner','update-txt','update-dismiss',
+                    'update-version','update-link','update-backup','update-backup-state']) {
     els[id] = makeEl(id);
   }
+  els['update-txt'].appendChild(els['update-version']);
+  els['update-txt'].appendChild(els['update-link']);
+  els['update-txt'].appendChild(els['update-backup']);
+  els['update-txt'].appendChild(els['update-backup-state']);
+  els['update-backup'].textContent = 'Back up wallet first';
+  const body = { appendChild() {}, };
   const documentStub = {
     getElementById: (id) => els[id] || null,
     createElement: (tag) => makeEl('el-' + tag + '-' + Math.random()),
+    body,
     // popup.js also wires the pane tabs at load. This suite is about the
     // update banner and has no tabs to find, but the stub has to answer the
     // call or the script throws before the banner is ever rendered.
@@ -100,6 +114,8 @@ function loadPopupPage({ release, checkedAt, seenVersion, manifestVersion }) {
         sendMessage: () => {},
       },
     },
+    Blob: class Blob {},
+    URL: { createObjectURL: () => 'blob:backup', revokeObjectURL: () => {} },
     _els: els,
     _stored: stored,
     _listeners: listeners,
@@ -108,7 +124,7 @@ function loadPopupPage({ release, checkedAt, seenVersion, manifestVersion }) {
   const ctx = vm.createContext(sandbox);
   const src = fs.readFileSync(path.join(ROOT, 'popup.js'), 'utf8');
   vm.runInContext(src, ctx, { filename: 'popup.js' });
-  return { ctx, sandbox };
+  return { ctx, sandbox, click: (id, ev = {}) => sandbox._listeners.get(id + ':click')?.(ev) };
 }
 
 // render() is async — after load, kick the microtask queue and settle it.
@@ -132,6 +148,78 @@ test('popup update nudge: newer release -> banner visible with zip link', async 
   assert.equal(anchor.rel, 'noopener noreferrer');
   // The check stamp is persisted so a second popup open the same day hits cache.
   assert.ok(sandbox._stored.has('pt_update_check'));
+});
+
+test('popup update nudge: no backup shows the backup control and warning', async () => {
+  const { sandbox } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    manifestVersion: '3.6.1',
+  });
+  await settle();
+  assert.equal(sandbox._els['update-backup'].textContent, 'Back up wallet first');
+  assert.equal(sandbox._els['update-backup-state'].textContent,
+    'No backup yet — updating into a new folder looks like a fresh install.');
+});
+
+test('popup update nudge: backup control exports and records its timestamp', async () => {
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    manifestVersion: '3.6.1',
+  });
+  await settle();
+  await click('update-backup');
+  await settle();
+  const record = sandbox._stored.get('pt_last_backup');
+  assert.ok(record && Number.isFinite(record.at));
+  assert.equal(record.version, '3.6.1');
+  assert.equal(sandbox._els['update-backup-state'].textContent,
+    `Last backup: ${new Date(record.at).toISOString().slice(0, 10)}`);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  assert.equal(event.prevented, false);
+});
+
+test('popup update nudge: an existing backup shows its date and never arms the link', async () => {
+  const at = Date.now() - 2 * 24 * 60 * 60 * 1000;
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    lastBackup: { at, version: '3.6.0' },
+    manifestVersion: '3.6.1',
+  });
+  await settle();
+  assert.equal(sandbox._els['update-backup-state'].textContent,
+    `Last backup: ${new Date(at).toISOString().slice(0, 10)}`);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  assert.equal(event.prevented, false);
+});
+
+test('popup update nudge: no backup arms the first download click only', async () => {
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    manifestVersion: '3.6.1',
+  });
+  await settle();
+  const first = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', first);
+  assert.equal(first.prevented, true);
+  assert.equal(sandbox._els['update-backup-state'].textContent,
+    'No backup yet — click again to update anyway');
+  const second = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', second);
+  assert.equal(second.prevented, false);
+});
+
+test('popup update nudge: dismiss still records the seen version and hides the banner', async () => {
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    manifestVersion: '3.6.1',
+  });
+  await settle();
+  await click('update-dismiss');
+  await settle();
+  assert.equal(sandbox._els['update-banner'].hidden, true);
+  assert.equal(sandbox._stored.get('pt_update_seen').version, '9.9.9');
 });
 
 test('popup update nudge: already-current -> banner stays hidden', async () => {
@@ -173,17 +261,23 @@ test('popup update nudge: fetch failure leaves the popup exactly as it was', asy
   function makeEl(id) {
     return {
       id, children: [], hidden: true, innerHTML: '', textContent: '', href: '',
-      target: '', rel: '', title: '', style: {},
+      target: '', rel: '', title: '', style: {}, classList: { toggle() {} },
       addEventListener: (t, fn) => { listeners.set(id + ':' + t, fn); },
       appendChild(child) { this.children.push(child); },
       setAttribute() {},
     };
   }
   for (const id of ['dash','desk','toggle','reset','backup','restore','restoreFile','overlay-window',
-                    'warmx','warmdest','xray','power','qs-apply','sharelogs','badge','equity','delta','cash',
-                    'pnl','open','rounds','flow','recent','status','update-banner','update-txt','update-dismiss']) {
+                    'warmx','warmdest','xray','power','qs-apply','qs-balance','qs-presets','qs-sellpcts','qs-fees',
+                    'sharelogs','badge','equity','delta','cash',
+                    'pnl','open','rounds','flow','recent','status','update-banner','update-txt','update-dismiss',
+                    'update-version','update-link','update-backup','update-backup-state']) {
     els[id] = makeEl(id);
   }
+  els['update-txt'].appendChild(els['update-version']);
+  els['update-txt'].appendChild(els['update-link']);
+  els['update-txt'].appendChild(els['update-backup']);
+  els['update-txt'].appendChild(els['update-backup-state']);
   const sandbox = {
     document: { getElementById: (id) => els[id] || null, createElement: (t) => makeEl('x-' + t), querySelectorAll: () => [] },
     console, setTimeout, Date, Number, String, JSON, Math,
@@ -202,6 +296,16 @@ test('popup update nudge: fetch failure leaves the popup exactly as it was', asy
   await settle();
   assert.equal(els['update-banner'].hidden, true, 'a failed fetch must never surface the banner');
   assert.ok(els['update-banner'].innerHTML === '' || true);
+});
+
+test('popup update nudge: storage read failure leaves the banner hidden', async () => {
+  const { sandbox } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    manifestVersion: '3.6.1',
+    storageGetThrows: true,
+  });
+  await settle();
+  assert.equal(sandbox._els['update-banner'].hidden, true);
 });
 
 /* ------------------------------------------------------------------------
@@ -276,11 +380,18 @@ test('every control still exists — panes hide, they never remove', () => {
   const ids = ['equity', 'cash', 'pnl', 'open', 'rounds', 'flow', 'recent',
     'power', 'dash', 'toggle', 'backup', 'restore', 'restoreFile', 'overlay-window',
     'warmx', 'warmdest', 'turbo-receipts', 'xray', 'qs-balance', 'qs-presets',
-    'qs-sellpcts', 'qs-fees', 'qs-apply', 'sharelogs', 'reset', 'status'];
+    'qs-sellpcts', 'qs-fees', 'qs-apply', 'sharelogs', 'reset', 'status',
+    'update-backup', 'update-backup-state'];
   for (const id of ids) {
     const count = popupHtmlTabs.split(`id="${id}"`).length - 1;
     assert.equal(count, 1, `${id} must appear exactly once`);
   }
+});
+
+test('update backup controls keep their banner styling', () => {
+  const css = styleOf('popup.html');
+  assert.match(css, /#update-backup\s*\{[^}]*cursor:\s*pointer/);
+  assert.match(css, /#update-backup-state\s*\{[^}]*display:\s*block/);
 });
 
 test('the wallet is pinned above the tabs, not inside one', () => {

--- a/extension/test/updatebanner.test.js
+++ b/extension/test/updatebanner.test.js
@@ -983,6 +983,78 @@ test('popup update nudge: an incomplete attestation chain is never covered', asy
   assert.equal(sandbox._tabs.length, 0);
 });
 
+test('popup update nudge: an append racing the chain read still exports the chain', async () => {
+  const state = { startedAt: 1234, journal: [{}] };
+  const chain = [{ hash: 'h1' }, { hash: 'h2' }];
+  let storeReads = 0;
+  const attest = {
+    // First read catches the pre-append meta beside the appended link.
+    readChainStore: async () => {
+      storeReads += 1;
+      return storeReads === 1
+        ? { meta: { segCount: 1, length: 1, head: 'h1' }, chain }
+        : { meta: { segCount: 1, length: 2, head: 'h2' }, chain };
+    },
+    readChainMeta: async () => ({ segCount: 1, length: 2, head: 'h2' }),
+  };
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    manifestVersion: '3.6.1',
+    state,
+    attest,
+  });
+  await settle();
+  await click('update-backup');
+  await settle();
+  const record = sandbox._stored.get('pt_last_backup');
+  assert.equal(storeReads, 2);
+  assert.equal(record.chainMissing, false);
+  assert.equal(record.chainLength, 2);
+  assert.equal(record.chainHead, 'h2');
+  assert.equal(sandbox._els['update-backup-state'].textContent,
+    `Last backup: ${new Date(record.at).toISOString().slice(0, 10)} \u00b7 exported \u2014 check the file is in your downloads`);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  await settle();
+  assert.equal(sandbox._tabs.length, 1);
+});
+
+test('popup update nudge: a chain that never settles is exported without it', async () => {
+  const state = { startedAt: 1234, journal: [{}] };
+  const chain = [{ hash: 'h1' }];
+  let storeReads = 0;
+  let length = 1;
+  const attest = {
+    readChainStore: async () => {
+      storeReads += 1;
+      return { meta: { segCount: 1, length: 1, head: 'h1' }, chain };
+    },
+    readChainMeta: async () => {
+      length += 1;
+      return { segCount: 1, length, head: `h${length}` };
+    },
+  };
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    manifestVersion: '3.6.1',
+    state,
+    attest,
+  });
+  await settle();
+  await click('update-backup');
+  await settle();
+  const record = sandbox._stored.get('pt_last_backup');
+  assert.equal(storeReads, 3);
+  assert.equal(record.chainMissing, true);
+  assert.match(sandbox._els['update-backup-state'].textContent,
+    /exported without the verification chain/);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  await settle();
+  assert.equal(event.prevented, true);
+  assert.equal(sandbox._tabs.length, 0);
+});
+
 test('popup update nudge: backup content is read in one storage snapshot', async () => {
   const { sandbox } = loadPopupPage({
     release: { tag_name: 'v9.9.9' },

--- a/extension/test/updatebanner.test.js
+++ b/extension/test/updatebanner.test.js
@@ -298,14 +298,19 @@ test('popup update nudge: fetch failure leaves the popup exactly as it was', asy
   assert.ok(els['update-banner'].innerHTML === '' || true);
 });
 
-test('popup update nudge: storage read failure leaves the banner hidden', async () => {
-  const { sandbox } = loadPopupPage({
+test('popup update nudge: storage read failure still shows the warning and arms the link', async () => {
+  const { sandbox, click } = loadPopupPage({
     release: { tag_name: 'v9.9.9' },
     manifestVersion: '3.6.1',
     storageGetThrows: true,
   });
   await settle();
-  assert.equal(sandbox._els['update-banner'].hidden, true);
+  assert.equal(sandbox._els['update-banner'].hidden, false);
+  assert.equal(sandbox._els['update-backup-state'].textContent,
+    'No backup yet — updating into a new folder looks like a fresh install.');
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  assert.equal(event.prevented, true);
 });
 
 /* ------------------------------------------------------------------------

--- a/extension/test/updatebanner.test.js
+++ b/extension/test/updatebanner.test.js
@@ -29,6 +29,7 @@ function loadPopupPage({
 }) {
   const html = fs.readFileSync(path.join(ROOT, 'popup.html'), 'utf8');
   const stored = new Map();
+  const getCalls = [];
   if (checkedAt !== undefined) stored.set('pt_update_check', { checkedAt });
   if (seenVersion !== undefined) stored.set('pt_update_seen', { version: seenVersion, at: Date.now() });
   if (lastBackup !== undefined) {
@@ -45,6 +46,7 @@ function loadPopupPage({
   if (chainMeta !== undefined) stored.set('pt_attest_meta', chainMeta);
 
   const storageGet = async (keys) => {
+    getCalls.push([...keys]);
     if (storageGetThrows) throw new Error('storage unavailable');
     if (storageStateGetThrows && keys.includes('pt_state')) throw new Error('state unavailable');
     if (storageLastBackupGetThrows && keys.includes('pt_last_backup')) throw new Error('backup unavailable');
@@ -141,6 +143,7 @@ function loadPopupPage({
     open: (...args) => { opens.push(args); },
     _els: els,
     _stored: stored,
+    _getCalls: getCalls,
     _listeners: listeners,
     _opens: opens,
     _tabs: tabs,
@@ -950,4 +953,48 @@ test('popup update nudge: a failing chain meta read is unconfirmable', async () 
   await settle();
   assert.equal(event.prevented, true);
   assert.equal(sandbox._tabs.length, 0);
+});
+
+test('popup update nudge: an incomplete attestation chain is never covered', async () => {
+  const state = { startedAt: 1234, journal: [] };
+  const attest = {
+    readChainMeta: async () => ({ segCount: 1, length: 2, head: 'head-2' }),
+    readChainStore: async () => ({
+      meta: { segCount: 1, length: 2, head: 'head-2' },
+      chain: [{ hash: 'head-1' }],
+    }),
+  };
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    manifestVersion: '3.6.1',
+    state,
+    attest,
+  });
+  await settle();
+  await click('update-backup');
+  await settle();
+  assert.equal(sandbox._stored.get('pt_last_backup').chainMissing, true);
+  assert.match(sandbox._els['update-backup-state'].textContent,
+    /exported without the verification chain/);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  await settle();
+  assert.equal(event.prevented, true);
+  assert.equal(sandbox._tabs.length, 0);
+});
+
+test('popup update nudge: backup content is read in one storage snapshot', async () => {
+  const { sandbox } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    manifestVersion: '3.6.1',
+  });
+  await settle();
+  const contentReads = sandbox._getCalls.filter((keys) => (
+    keys.length === 4
+    && keys.includes('pt_state')
+    && keys.includes('pt_settings')
+    && keys.includes('pt_frames')
+    && keys.includes('pt_replays')
+  ));
+  assert.equal(contentReads.length, 1);
 });

--- a/extension/test/updatebanner.test.js
+++ b/extension/test/updatebanner.test.js
@@ -24,7 +24,7 @@ const ROOT = path.join(__dirname, '..');
 function loadPopupPage({
   release, checkedAt, seenVersion, lastBackup, state, settings, frames, replays,
   backupFingerprintState, backupFingerprintData, manifestVersion, attest,
-  storageGetThrows = false, storageStateGetThrows = false,
+  storageGetThrows = false, storageStateGetThrows = false, storageLastBackupGetThrows = false,
 }) {
   const html = fs.readFileSync(path.join(ROOT, 'popup.html'), 'utf8');
   const stored = new Map();
@@ -39,6 +39,7 @@ function loadPopupPage({
   const storageGet = async (keys) => {
     if (storageGetThrows) throw new Error('storage unavailable');
     if (storageStateGetThrows && keys.includes('pt_state')) throw new Error('state unavailable');
+    if (storageLastBackupGetThrows && keys.includes('pt_last_backup')) throw new Error('backup unavailable');
     const out = {};
     for (const k of keys) if (stored.has(k)) out[k] = stored.get(k);
     return out;
@@ -96,6 +97,7 @@ function loadPopupPage({
   };
 
   const opens = [];
+  const tabs = [];
   const sandbox = {
     document: documentStub,
     console,
@@ -118,6 +120,7 @@ function loadPopupPage({
     },
     chrome: {
       storage: { local: { get: storageGet, set: storageSet } },
+      tabs: { create: async (props) => { tabs.push(props); return {}; } },
       runtime: {
         getManifest: () => ({ version: manifestVersion }),
         openOptionsPage: () => {},
@@ -131,6 +134,7 @@ function loadPopupPage({
     _stored: stored,
     _listeners: listeners,
     _opens: opens,
+    _tabs: tabs,
   };
   if (attest) sandbox.PTAttest = attest;
   sandbox.window = sandbox;
@@ -213,7 +217,8 @@ test('popup update nudge: backup control exports and records its fingerprint', a
   await click('update-link', event);
   await settle();
   assert.equal(event.prevented, true);
-  assert.equal(sandbox._opens.length, 1);
+  assert.equal(sandbox._tabs.length, 1);
+  assert.equal(sandbox._tabs[0].url, 'https://zip.example/x.zip');
 });
 
 test('popup update nudge: an existing backup shows its date and never arms the link', async () => {
@@ -234,7 +239,7 @@ test('popup update nudge: an existing backup shows its date and never arms the l
   await settle();
   assert.equal(event.prevented, true);
   assert.equal(duplicate.prevented, true);
-  assert.equal(sandbox._opens.length, 1);
+  assert.equal(sandbox._tabs.length, 1);
 });
 
 test('popup update nudge: no backup arms the first download click only', async () => {
@@ -247,12 +252,12 @@ test('popup update nudge: no backup arms the first download click only', async (
   await click('update-link', first);
   assert.equal(first.prevented, true);
   assert.equal(sandbox._els['update-backup-state'].textContent,
-    'No backup yet — click again to update anyway');
+    'No backup yet — updating into a new folder looks like a fresh install. — click again to update anyway');
   const second = { prevented: false, preventDefault() { this.prevented = true; } };
   await click('update-link', second);
   await settle();
   assert.equal(second.prevented, true);
-  assert.equal(sandbox._opens.length, 1);
+  assert.equal(sandbox._tabs.length, 1);
 });
 
 test('popup update nudge: a fill after export makes the backup stale and arms the link', async () => {
@@ -269,11 +274,13 @@ test('popup update nudge: a fill after export makes the backup stale and arms th
   const event = { prevented: false, preventDefault() { this.prevented = true; } };
   await click('update-link', event);
   assert.equal(event.prevented, true);
+  assert.equal(sandbox._els['update-backup-state'].textContent,
+    `Last backup: ${new Date(at).toISOString().slice(0, 10)} — 1 trade since. Back up again. — click again to update anyway`);
   const confirmation = { prevented: false, preventDefault() { this.prevented = true; } };
   await click('update-link', confirmation);
   await settle();
   assert.equal(confirmation.prevented, true);
-  assert.equal(sandbox._opens.length, 1);
+  assert.equal(sandbox._tabs.length, 1);
 });
 
 test('popup update nudge: a reset-style wallet generation change is uncovered', async () => {
@@ -323,7 +330,7 @@ test('popup update nudge: a matching wallet generation and trade count bypasses 
   await click('update-link', event);
   await settle();
   assert.equal(event.prevented, true);
-  assert.equal(sandbox._opens.length, 1);
+  assert.equal(sandbox._tabs.length, 1);
 });
 
 test('popup update nudge: a thesis added after export is uncovered', async () => {
@@ -438,7 +445,7 @@ test('popup update nudge: frame image bytes alone stay covered', async () => {
   await click('update-link', event);
   await settle();
   assert.equal(event.prevented, true);
-  assert.equal(sandbox._opens.length, 1);
+  assert.equal(sandbox._tabs.length, 1);
 });
 
 test('popup update nudge: chain-missing export is never covered', async () => {
@@ -528,7 +535,7 @@ test('popup update nudge: heartbeat-only state changes stay covered', async () =
   await click('update-link', event);
   await settle();
   assert.equal(event.prevented, true);
-  assert.equal(sandbox._opens.length, 1);
+  assert.equal(sandbox._tabs.length, 1);
 });
 
 test('popup update nudge: a decreased trade count says wallet history changed', async () => {
@@ -660,10 +667,30 @@ test('popup update nudge: storage read failure still shows the warning and arms 
   await settle();
   assert.equal(sandbox._els['update-banner'].hidden, false);
   assert.equal(sandbox._els['update-backup-state'].textContent,
-    'No backup yet — updating into a new folder looks like a fresh install.');
+    'Backup exists, but the wallet could not be read, so coverage cannot be confirmed. Back up again to be safe.');
   const event = { prevented: false, preventDefault() { this.prevented = true; } };
   await click('update-link', event);
   assert.equal(event.prevented, true);
+});
+
+test('popup update nudge: pt_last_backup read failure is unconfirmable', async () => {
+  const at = Date.now() - 2 * 24 * 60 * 60 * 1000;
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    manifestVersion: '3.6.1',
+    lastBackup: { at, startedAt: 1234, trades: 0, fingerprint: 'stored' },
+    state: { startedAt: 1234, journal: [] },
+    storageLastBackupGetThrows: true,
+  });
+  await settle();
+  assert.equal(sandbox._els['update-banner'].hidden, false);
+  assert.equal(sandbox._els['update-backup-state'].textContent,
+    'Backup exists, but the wallet could not be read, so coverage cannot be confirmed. Back up again to be safe.');
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  assert.equal(event.prevented, true);
+  assert.match(sandbox._els['update-backup-state'].textContent,
+    /coverage cannot be confirmed.*click again to update anyway/);
 });
 
 test('popup update nudge: pt_state read failure still shows the warning and arms the link', async () => {

--- a/extension/test/updatebanner.test.js
+++ b/extension/test/updatebanner.test.js
@@ -22,24 +22,33 @@ const vm = require('node:vm');
 const ROOT = path.join(__dirname, '..');
 
 function loadPopupPage({
-  release, checkedAt, seenVersion, lastBackup, state, settings, frames, replays,
+  release, checkedAt, seenVersion, lastBackup, state, settings, frames, replays, chainMeta,
   backupFingerprintState, backupFingerprintData, manifestVersion, attest,
   storageGetThrows = false, storageStateGetThrows = false, storageLastBackupGetThrows = false,
+  storageMetaGetThrows = false,
 }) {
   const html = fs.readFileSync(path.join(ROOT, 'popup.html'), 'utf8');
   const stored = new Map();
   if (checkedAt !== undefined) stored.set('pt_update_check', { checkedAt });
   if (seenVersion !== undefined) stored.set('pt_update_seen', { version: seenVersion, at: Date.now() });
-  if (lastBackup !== undefined) stored.set('pt_last_backup', lastBackup);
+  if (lastBackup !== undefined) {
+    stored.set('pt_last_backup', {
+      chainLength: 0,
+      chainHead: 'papertrench-genesis-v1',
+      ...lastBackup,
+    });
+  }
   if (state !== undefined) stored.set('pt_state', state);
   if (settings !== undefined) stored.set('pt_settings', settings);
   if (frames !== undefined) stored.set('pt_frames', frames);
   if (replays !== undefined) stored.set('pt_replays', replays);
+  if (chainMeta !== undefined) stored.set('pt_attest_meta', chainMeta);
 
   const storageGet = async (keys) => {
     if (storageGetThrows) throw new Error('storage unavailable');
     if (storageStateGetThrows && keys.includes('pt_state')) throw new Error('state unavailable');
     if (storageLastBackupGetThrows && keys.includes('pt_last_backup')) throw new Error('backup unavailable');
+    if (storageMetaGetThrows && keys.includes('pt_attest_meta')) throw new Error('meta unavailable');
     const out = {};
     for (const k of keys) if (stored.has(k)) out[k] = stored.get(k);
     return out;
@@ -136,14 +145,32 @@ function loadPopupPage({
     _opens: opens,
     _tabs: tabs,
   };
-  if (attest) sandbox.PTAttest = attest;
+  const defaultAttest = {
+    readChainMeta: async () => {
+      if (storageMetaGetThrows) throw new Error('meta unavailable');
+      return stored.get('pt_attest_meta') || {
+      segCount: 0, length: 0, head: 'papertrench-genesis-v1',
+      };
+    },
+    readChainStore: async () => {
+      if (storageMetaGetThrows) throw new Error('meta unavailable');
+      return {
+        meta: stored.get('pt_attest_meta') || {
+        segCount: 0, length: 0, head: 'papertrench-genesis-v1',
+        },
+        chain: [],
+      };
+    },
+  };
+  const effectiveAttest = attest === undefined ? defaultAttest : attest;
+  if (effectiveAttest) sandbox.PTAttest = effectiveAttest;
   sandbox.window = sandbox;
   const ctx = vm.createContext(sandbox);
   const src = fs.readFileSync(path.join(ROOT, 'popup.js'), 'utf8');
   vm.runInContext(src, ctx, { filename: 'popup.js' });
   if (lastBackup && lastBackup.fingerprint === '__from_state__') {
     stored.set('pt_last_backup', {
-      ...lastBackup,
+      ...stored.get('pt_last_backup'),
       fingerprint: typeof ctx.backupFingerprint === 'function'
         ? ctx.backupFingerprint(backupFingerprintData || {
           pt_state: backupFingerprintState || state,
@@ -667,7 +694,7 @@ test('popup update nudge: storage read failure still shows the warning and arms 
   await settle();
   assert.equal(sandbox._els['update-banner'].hidden, false);
   assert.equal(sandbox._els['update-backup-state'].textContent,
-    'Backup exists, but the wallet could not be read, so coverage cannot be confirmed. Back up again to be safe.');
+    'Backup status could not be read, so coverage cannot be confirmed. Back up again to be safe.');
   const event = { prevented: false, preventDefault() { this.prevented = true; } };
   await click('update-link', event);
   assert.equal(event.prevented, true);
@@ -685,7 +712,7 @@ test('popup update nudge: pt_last_backup read failure is unconfirmable', async (
   await settle();
   assert.equal(sandbox._els['update-banner'].hidden, false);
   assert.equal(sandbox._els['update-backup-state'].textContent,
-    'Backup exists, but the wallet could not be read, so coverage cannot be confirmed. Back up again to be safe.');
+    'Backup status could not be read, so coverage cannot be confirmed. Back up again to be safe.');
   const event = { prevented: false, preventDefault() { this.prevented = true; } };
   await click('update-link', event);
   assert.equal(event.prevented, true);
@@ -826,4 +853,101 @@ test('switching panes uses the hidden attribute the CSS guard backs', () => {
   assert.match(popupJsTabs, /pane\.hidden = !on/, 'panes toggle via the attribute');
   assert.match(popupHtmlTabs, /\[hidden\] \{ display: none !important; \}/,
     'and the guard that makes it take effect must still be here');
+});
+
+test('popup backup fingerprint: emoji-only thesis edits change the fingerprint', async () => {
+  const { ctx } = loadPopupPage({ release: { tag_name: 'v9.9.9' }, manifestVersion: '3.6.1' });
+  await settle();
+  const withOne = { pt_state: { startedAt: 1, positions: { M: { thesis: 'runner \u{1F680}' } } } };
+  // Same high surrogate, different low one: the hash must read both units.
+  const withOther = { pt_state: { startedAt: 1, positions: { M: { thesis: 'runner \u{1F681}' } } } };
+  assert.notEqual(ctx.backupFingerprint(withOne), ctx.backupFingerprint(withOther));
+});
+
+test('popup update nudge: a missing attestation helper is never a complete backup', async () => {
+  const state = { startedAt: 1234, journal: [] };
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    manifestVersion: '3.6.1',
+    state,
+    attest: null,
+  });
+  await settle();
+  await click('update-backup');
+  await settle();
+  const record = sandbox._stored.get('pt_last_backup');
+  assert.equal(record.chainMissing, true);
+  assert.match(sandbox._els['update-backup-state'].textContent,
+    /exported without the verification chain/);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  await settle();
+  assert.equal(event.prevented, true);
+  assert.match(sandbox._els['update-backup-state'].textContent,
+    /verification chain.*click again to update anyway/);
+});
+
+test('popup update nudge: a chain append after export is uncovered', async () => {
+  const at = Date.now() - 2 * 24 * 60 * 60 * 1000;
+  const state = { startedAt: 1234, journal: [{}] };
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    manifestVersion: '3.6.1',
+    lastBackup: { at, startedAt: 1234, trades: 1, fingerprint: '__from_state__' },
+    backupFingerprintData: { pt_state: state },
+    state,
+    chainMeta: { segCount: 1, length: 1, head: 'link-hash-1' },
+  });
+  await settle();
+  assert.equal(sandbox._els['update-backup-state'].textContent,
+    `Last backup: ${new Date(at).toISOString().slice(0, 10)} — new verified fills since. Back up again.`);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  await settle();
+  assert.equal(event.prevented, true);
+  assert.equal(sandbox._tabs.length, 0);
+  assert.match(sandbox._els['update-backup-state'].textContent,
+    /new verified fills since.*click again to update anyway/);
+});
+
+test('popup update nudge: an empty chain install stays coverable', async () => {
+  const at = Date.now() - 2 * 24 * 60 * 60 * 1000;
+  const state = { startedAt: 1234, journal: [] };
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    manifestVersion: '3.6.1',
+    lastBackup: { at, startedAt: 1234, trades: 0, fingerprint: '__from_state__' },
+    backupFingerprintData: { pt_state: state },
+    state,
+    chainMeta: { segCount: 0, length: 0, head: 'papertrench-genesis-v1' },
+  });
+  await settle();
+  assert.match(sandbox._els['update-backup-state'].textContent, /· exported — check the file/);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  await settle();
+  assert.equal(event.prevented, true);
+  assert.equal(sandbox._tabs.length, 1);
+});
+
+test('popup update nudge: a failing chain meta read is unconfirmable', async () => {
+  const at = Date.now() - 2 * 24 * 60 * 60 * 1000;
+  const state = { startedAt: 1234, journal: [] };
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    manifestVersion: '3.6.1',
+    lastBackup: { at, startedAt: 1234, trades: 0, fingerprint: '__from_state__' },
+    backupFingerprintData: { pt_state: state },
+    state,
+    storageMetaGetThrows: true,
+  });
+  await settle();
+  assert.equal(sandbox._els['update-banner'].hidden, false);
+  assert.equal(sandbox._els['update-backup-state'].textContent,
+    'Backup exists, but the wallet could not be read, so coverage cannot be confirmed. Back up again to be safe.');
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  await settle();
+  assert.equal(event.prevented, true);
+  assert.equal(sandbox._tabs.length, 0);
 });

--- a/extension/test/updatebanner.test.js
+++ b/extension/test/updatebanner.test.js
@@ -22,7 +22,7 @@ const vm = require('node:vm');
 const ROOT = path.join(__dirname, '..');
 
 function loadPopupPage({
-  release, checkedAt, seenVersion, lastBackup, state, manifestVersion,
+  release, checkedAt, seenVersion, lastBackup, state, backupFingerprintState, manifestVersion,
   storageGetThrows = false, storageStateGetThrows = false,
 }) {
   const html = fs.readFileSync(path.join(ROOT, 'popup.html'), 'utf8');
@@ -129,6 +129,14 @@ function loadPopupPage({
   const ctx = vm.createContext(sandbox);
   const src = fs.readFileSync(path.join(ROOT, 'popup.js'), 'utf8');
   vm.runInContext(src, ctx, { filename: 'popup.js' });
+  if (lastBackup && lastBackup.fingerprint === '__from_state__') {
+    stored.set('pt_last_backup', {
+      ...lastBackup,
+      fingerprint: typeof ctx.stateFingerprint === 'function'
+        ? ctx.stateFingerprint(backupFingerprintState || state)
+        : 'missing-fingerprint',
+    });
+  }
   return { ctx, sandbox, click: (id, ev = {}) => sandbox._listeners.get(id + ':click')?.(ev) };
 }
 
@@ -167,8 +175,8 @@ test('popup update nudge: no backup shows the backup control and warning', async
 });
 
 test('popup update nudge: backup control exports and records its timestamp', async () => {
-  const state = { startedAt: 1234, journal: [{}, {}] };
-  const { sandbox, click } = loadPopupPage({
+  const state = { startedAt: 1234, journal: [{}, {}], attestChain: ['link-before-export'] };
+  const { ctx, sandbox, click } = loadPopupPage({
     release: { tag_name: 'v9.9.9' },
     manifestVersion: '3.6.1',
     state,
@@ -181,6 +189,8 @@ test('popup update nudge: backup control exports and records its timestamp', asy
   assert.equal(record.version, '3.6.1');
   assert.equal(record.startedAt, state.startedAt);
   assert.equal(record.trades, state.journal.length);
+  assert.equal(typeof record.fingerprint, 'string');
+  assert.equal(record.fingerprint, ctx.stateFingerprint(state));
   assert.equal(sandbox._els['update-backup-state'].textContent,
     `Last backup: ${new Date(record.at).toISOString().slice(0, 10)}`);
   const event = { prevented: false, preventDefault() { this.prevented = true; } };
@@ -193,7 +203,7 @@ test('popup update nudge: an existing backup shows its date and never arms the l
   const state = { startedAt: 1234, journal: [{}, {}] };
   const { sandbox, click } = loadPopupPage({
     release: { tag_name: 'v9.9.9' },
-    lastBackup: { at, version: '3.6.0', startedAt: state.startedAt, trades: state.journal.length },
+    lastBackup: { at, version: '3.6.0', startedAt: state.startedAt, trades: state.journal.length, fingerprint: '__from_state__' },
     state,
     manifestVersion: '3.6.1',
   });
@@ -276,7 +286,7 @@ test('popup update nudge: a matching wallet generation and trade count bypasses 
   const state = { startedAt: 1234, journal: [{}] };
   const { sandbox, click } = loadPopupPage({
     release: { tag_name: 'v9.9.9' },
-    lastBackup: { at, version: '3.6.0', startedAt: state.startedAt, trades: state.journal.length },
+    lastBackup: { at, version: '3.6.0', startedAt: state.startedAt, trades: state.journal.length, fingerprint: '__from_state__' },
     state,
     manifestVersion: '3.6.1',
   });
@@ -286,6 +296,127 @@ test('popup update nudge: a matching wallet generation and trade count bypasses 
   const event = { prevented: false, preventDefault() { this.prevented = true; } };
   await click('update-link', event);
   assert.equal(event.prevented, false);
+});
+
+test('popup update nudge: a thesis added after export is uncovered', async () => {
+  const at = Date.now() - 2 * 24 * 60 * 60 * 1000;
+  const before = {
+    startedAt: 1234,
+    journal: [],
+    positions: { MINT: { thesis: 'old' } },
+  };
+  const state = {
+    ...before,
+    positions: { MINT: { thesis: 'new' } },
+  };
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    lastBackup: { at, startedAt: 1234, trades: 0, fingerprint: '__from_state__' },
+    backupFingerprintState: before,
+    state,
+    manifestVersion: '3.6.1',
+  });
+  await settle();
+  assert.match(sandbox._els['update-backup-state'].textContent, /wallet changed since/);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  assert.equal(event.prevented, true);
+});
+
+test('popup update nudge: an armed alert after export is uncovered', async () => {
+  const at = Date.now() - 2 * 24 * 60 * 60 * 1000;
+  const before = { startedAt: 1234, journal: [], alerts: {} };
+  const state = { ...before, alerts: { MINT: [{ id: 'alert-1', triggerMcap: 1000 }] } };
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    lastBackup: { at, startedAt: 1234, trades: 0, fingerprint: '__from_state__' },
+    backupFingerprintState: before,
+    state,
+    manifestVersion: '3.6.1',
+  });
+  await settle();
+  assert.match(sandbox._els['update-backup-state'].textContent, /wallet changed since/);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  assert.equal(event.prevented, true);
+});
+
+test('popup update nudge: heartbeat-only state changes stay covered', async () => {
+  const at = Date.now() - 2 * 24 * 60 * 60 * 1000;
+  const before = {
+    startedAt: 1234,
+    seq: 1,
+    updatedAt: 10,
+    journal: [],
+    positions: {
+      MINT: {
+        thesis: 'keep',
+        lastPriceNative: 1,
+        lastPriceUsd: 2,
+        peakPnlSol: 3,
+        troughPnlSol: -1,
+      },
+    },
+  };
+  const state = {
+    ...before,
+    seq: 99,
+    updatedAt: 900,
+    positions: {
+      MINT: {
+        ...before.positions.MINT,
+        lastPriceNative: 5,
+        lastPriceUsd: 6,
+        peakPnlSol: 7,
+        troughPnlSol: -4,
+      },
+    },
+  };
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    lastBackup: { at, startedAt: 1234, trades: 0, fingerprint: '__from_state__' },
+    backupFingerprintState: before,
+    state,
+    manifestVersion: '3.6.1',
+  });
+  await settle();
+  assert.equal(sandbox._els['update-backup-state'].textContent,
+    `Last backup: ${new Date(at).toISOString().slice(0, 10)}`);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  assert.equal(event.prevented, false);
+});
+
+test('popup update nudge: a decreased trade count says wallet history changed', async () => {
+  const at = Date.now() - 2 * 24 * 60 * 60 * 1000;
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    lastBackup: { at, startedAt: 1234, trades: 3, fingerprint: 'old-fingerprint' },
+    state: { startedAt: 1234, journal: [{}] },
+    manifestVersion: '3.6.1',
+  });
+  await settle();
+  assert.match(sandbox._els['update-backup-state'].textContent, /wallet history changed/);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  assert.equal(event.prevented, true);
+});
+
+test('popup update nudge: a stored backup with unreadable wallet is unconfirmable', async () => {
+  const at = Date.now() - 2 * 24 * 60 * 60 * 1000;
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    lastBackup: { at, startedAt: 1234, trades: 0, fingerprint: 'known-fingerprint' },
+    manifestVersion: '3.6.1',
+    storageStateGetThrows: true,
+  });
+  await settle();
+  assert.equal(sandbox._els['update-banner'].hidden, false);
+  assert.match(sandbox._els['update-backup-state'].textContent, /wallet could not be read/);
+  assert.match(sandbox._els['update-backup-state'].textContent, /coverage cannot be confirmed/);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  assert.equal(event.prevented, true);
 });
 
 test('popup update nudge: dismiss still records the seen version and hides the banner', async () => {

--- a/extension/test/updatebanner.test.js
+++ b/extension/test/updatebanner.test.js
@@ -21,15 +21,20 @@ const vm = require('node:vm');
 
 const ROOT = path.join(__dirname, '..');
 
-function loadPopupPage({ release, checkedAt, seenVersion, lastBackup, manifestVersion, storageGetThrows = false }) {
+function loadPopupPage({
+  release, checkedAt, seenVersion, lastBackup, state, manifestVersion,
+  storageGetThrows = false, storageStateGetThrows = false,
+}) {
   const html = fs.readFileSync(path.join(ROOT, 'popup.html'), 'utf8');
   const stored = new Map();
   if (checkedAt !== undefined) stored.set('pt_update_check', { checkedAt });
   if (seenVersion !== undefined) stored.set('pt_update_seen', { version: seenVersion, at: Date.now() });
   if (lastBackup !== undefined) stored.set('pt_last_backup', lastBackup);
+  if (state !== undefined) stored.set('pt_state', state);
 
   const storageGet = async (keys) => {
     if (storageGetThrows) throw new Error('storage unavailable');
+    if (storageStateGetThrows && keys.includes('pt_state')) throw new Error('state unavailable');
     const out = {};
     for (const k of keys) if (stored.has(k)) out[k] = stored.get(k);
     return out;
@@ -162,9 +167,11 @@ test('popup update nudge: no backup shows the backup control and warning', async
 });
 
 test('popup update nudge: backup control exports and records its timestamp', async () => {
+  const state = { startedAt: 1234, journal: [{}, {}] };
   const { sandbox, click } = loadPopupPage({
     release: { tag_name: 'v9.9.9' },
     manifestVersion: '3.6.1',
+    state,
   });
   await settle();
   await click('update-backup');
@@ -172,6 +179,8 @@ test('popup update nudge: backup control exports and records its timestamp', asy
   const record = sandbox._stored.get('pt_last_backup');
   assert.ok(record && Number.isFinite(record.at));
   assert.equal(record.version, '3.6.1');
+  assert.equal(record.startedAt, state.startedAt);
+  assert.equal(record.trades, state.journal.length);
   assert.equal(sandbox._els['update-backup-state'].textContent,
     `Last backup: ${new Date(record.at).toISOString().slice(0, 10)}`);
   const event = { prevented: false, preventDefault() { this.prevented = true; } };
@@ -181,9 +190,11 @@ test('popup update nudge: backup control exports and records its timestamp', asy
 
 test('popup update nudge: an existing backup shows its date and never arms the link', async () => {
   const at = Date.now() - 2 * 24 * 60 * 60 * 1000;
+  const state = { startedAt: 1234, journal: [{}, {}] };
   const { sandbox, click } = loadPopupPage({
     release: { tag_name: 'v9.9.9' },
-    lastBackup: { at, version: '3.6.0' },
+    lastBackup: { at, version: '3.6.0', startedAt: state.startedAt, trades: state.journal.length },
+    state,
     manifestVersion: '3.6.1',
   });
   await settle();
@@ -208,6 +219,73 @@ test('popup update nudge: no backup arms the first download click only', async (
   const second = { prevented: false, preventDefault() { this.prevented = true; } };
   await click('update-link', second);
   assert.equal(second.prevented, false);
+});
+
+test('popup update nudge: a fill after export makes the backup stale and arms the link', async () => {
+  const at = Date.now() - 2 * 24 * 60 * 60 * 1000;
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    lastBackup: { at, version: '3.6.0', startedAt: 1234, trades: 0 },
+    state: { startedAt: 1234, journal: [{}] },
+    manifestVersion: '3.6.1',
+  });
+  await settle();
+  assert.equal(sandbox._els['update-backup-state'].textContent,
+    `Last backup: ${new Date(at).toISOString().slice(0, 10)} — 1 trade since. Back up again.`);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  assert.equal(event.prevented, true);
+  const confirmation = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', confirmation);
+  assert.equal(confirmation.prevented, false);
+});
+
+test('popup update nudge: a reset-style wallet generation change is uncovered', async () => {
+  const at = Date.now() - 2 * 24 * 60 * 60 * 1000;
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    lastBackup: { at, version: '3.6.0', startedAt: 1234, trades: 2 },
+    state: { startedAt: 5678, journal: [{}, {}] },
+    manifestVersion: '3.6.1',
+  });
+  await settle();
+  assert.equal(sandbox._els['update-backup-state'].textContent,
+    `Last backup: ${new Date(at).toISOString().slice(0, 10)} — different wallet since. Back up again.`);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  assert.equal(event.prevented, true);
+});
+
+test('popup update nudge: a restored wallet with mismatched identity is uncovered', async () => {
+  const at = Date.now() - 2 * 24 * 60 * 60 * 1000;
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    lastBackup: { at, version: '3.6.0', startedAt: 1234, trades: 1 },
+    state: { startedAt: 9999, journal: [{}] },
+    manifestVersion: '3.6.1',
+  });
+  await settle();
+  assert.match(sandbox._els['update-backup-state'].textContent, /different wallet since/);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  assert.equal(event.prevented, true);
+});
+
+test('popup update nudge: a matching wallet generation and trade count bypasses interception', async () => {
+  const at = Date.now() - 2 * 24 * 60 * 60 * 1000;
+  const state = { startedAt: 1234, journal: [{}] };
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    lastBackup: { at, version: '3.6.0', startedAt: state.startedAt, trades: state.journal.length },
+    state,
+    manifestVersion: '3.6.1',
+  });
+  await settle();
+  assert.equal(sandbox._els['update-backup-state'].textContent,
+    `Last backup: ${new Date(at).toISOString().slice(0, 10)}`);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  assert.equal(event.prevented, false);
 });
 
 test('popup update nudge: dismiss still records the seen version and hides the banner', async () => {
@@ -303,6 +381,21 @@ test('popup update nudge: storage read failure still shows the warning and arms 
     release: { tag_name: 'v9.9.9' },
     manifestVersion: '3.6.1',
     storageGetThrows: true,
+  });
+  await settle();
+  assert.equal(sandbox._els['update-banner'].hidden, false);
+  assert.equal(sandbox._els['update-backup-state'].textContent,
+    'No backup yet — updating into a new folder looks like a fresh install.');
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  assert.equal(event.prevented, true);
+});
+
+test('popup update nudge: pt_state read failure still shows the warning and arms the link', async () => {
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    manifestVersion: '3.6.1',
+    storageStateGetThrows: true,
   });
   await settle();
   assert.equal(sandbox._els['update-banner'].hidden, false);

--- a/extension/test/updatebanner.test.js
+++ b/extension/test/updatebanner.test.js
@@ -22,7 +22,8 @@ const vm = require('node:vm');
 const ROOT = path.join(__dirname, '..');
 
 function loadPopupPage({
-  release, checkedAt, seenVersion, lastBackup, state, backupFingerprintState, manifestVersion,
+  release, checkedAt, seenVersion, lastBackup, state, settings, frames, replays,
+  backupFingerprintState, backupFingerprintData, manifestVersion, attest,
   storageGetThrows = false, storageStateGetThrows = false,
 }) {
   const html = fs.readFileSync(path.join(ROOT, 'popup.html'), 'utf8');
@@ -31,6 +32,9 @@ function loadPopupPage({
   if (seenVersion !== undefined) stored.set('pt_update_seen', { version: seenVersion, at: Date.now() });
   if (lastBackup !== undefined) stored.set('pt_last_backup', lastBackup);
   if (state !== undefined) stored.set('pt_state', state);
+  if (settings !== undefined) stored.set('pt_settings', settings);
+  if (frames !== undefined) stored.set('pt_frames', frames);
+  if (replays !== undefined) stored.set('pt_replays', replays);
 
   const storageGet = async (keys) => {
     if (storageGetThrows) throw new Error('storage unavailable');
@@ -91,6 +95,7 @@ function loadPopupPage({
     querySelectorAll: () => [],
   };
 
+  const opens = [];
   const sandbox = {
     document: documentStub,
     console,
@@ -121,10 +126,13 @@ function loadPopupPage({
     },
     Blob: class Blob {},
     URL: { createObjectURL: () => 'blob:backup', revokeObjectURL: () => {} },
+    open: (...args) => { opens.push(args); },
     _els: els,
     _stored: stored,
     _listeners: listeners,
+    _opens: opens,
   };
+  if (attest) sandbox.PTAttest = attest;
   sandbox.window = sandbox;
   const ctx = vm.createContext(sandbox);
   const src = fs.readFileSync(path.join(ROOT, 'popup.js'), 'utf8');
@@ -132,12 +140,20 @@ function loadPopupPage({
   if (lastBackup && lastBackup.fingerprint === '__from_state__') {
     stored.set('pt_last_backup', {
       ...lastBackup,
-      fingerprint: typeof ctx.stateFingerprint === 'function'
-        ? ctx.stateFingerprint(backupFingerprintState || state)
+      fingerprint: typeof ctx.backupFingerprint === 'function'
+        ? ctx.backupFingerprint(backupFingerprintData || {
+          pt_state: backupFingerprintState || state,
+          pt_settings: undefined,
+          pt_frames: undefined,
+          pt_replays: undefined,
+        })
         : 'missing-fingerprint',
     });
   }
-  return { ctx, sandbox, click: (id, ev = {}) => sandbox._listeners.get(id + ':click')?.(ev) };
+  return {
+    ctx, sandbox, opens,
+    click: (id, ev = {}) => sandbox._listeners.get(id + ':click')?.(ev),
+  };
 }
 
 // render() is async — after load, kick the microtask queue and settle it.
@@ -174,7 +190,7 @@ test('popup update nudge: no backup shows the backup control and warning', async
     'No backup yet — updating into a new folder looks like a fresh install.');
 });
 
-test('popup update nudge: backup control exports and records its timestamp', async () => {
+test('popup update nudge: backup control exports and records its fingerprint', async () => {
   const state = { startedAt: 1234, journal: [{}, {}], attestChain: ['link-before-export'] };
   const { ctx, sandbox, click } = loadPopupPage({
     release: { tag_name: 'v9.9.9' },
@@ -190,12 +206,14 @@ test('popup update nudge: backup control exports and records its timestamp', asy
   assert.equal(record.startedAt, state.startedAt);
   assert.equal(record.trades, state.journal.length);
   assert.equal(typeof record.fingerprint, 'string');
-  assert.equal(record.fingerprint, ctx.stateFingerprint(state));
+  assert.equal(record.fingerprint, ctx.backupFingerprint({ pt_state: state }));
   assert.equal(sandbox._els['update-backup-state'].textContent,
-    `Last backup: ${new Date(record.at).toISOString().slice(0, 10)}`);
+    `Last backup: ${new Date(record.at).toISOString().slice(0, 10)} · exported — check the file is in your downloads`);
   const event = { prevented: false, preventDefault() { this.prevented = true; } };
   await click('update-link', event);
-  assert.equal(event.prevented, false);
+  await settle();
+  assert.equal(event.prevented, true);
+  assert.equal(sandbox._opens.length, 1);
 });
 
 test('popup update nudge: an existing backup shows its date and never arms the link', async () => {
@@ -209,10 +227,14 @@ test('popup update nudge: an existing backup shows its date and never arms the l
   });
   await settle();
   assert.equal(sandbox._els['update-backup-state'].textContent,
-    `Last backup: ${new Date(at).toISOString().slice(0, 10)}`);
+    `Last backup: ${new Date(at).toISOString().slice(0, 10)} · exported — check the file is in your downloads`);
   const event = { prevented: false, preventDefault() { this.prevented = true; } };
-  await click('update-link', event);
-  assert.equal(event.prevented, false);
+  const duplicate = { prevented: false, preventDefault() { this.prevented = true; } };
+  await Promise.all([click('update-link', event), click('update-link', duplicate)]);
+  await settle();
+  assert.equal(event.prevented, true);
+  assert.equal(duplicate.prevented, true);
+  assert.equal(sandbox._opens.length, 1);
 });
 
 test('popup update nudge: no backup arms the first download click only', async () => {
@@ -228,7 +250,9 @@ test('popup update nudge: no backup arms the first download click only', async (
     'No backup yet — click again to update anyway');
   const second = { prevented: false, preventDefault() { this.prevented = true; } };
   await click('update-link', second);
-  assert.equal(second.prevented, false);
+  await settle();
+  assert.equal(second.prevented, true);
+  assert.equal(sandbox._opens.length, 1);
 });
 
 test('popup update nudge: a fill after export makes the backup stale and arms the link', async () => {
@@ -247,7 +271,9 @@ test('popup update nudge: a fill after export makes the backup stale and arms th
   assert.equal(event.prevented, true);
   const confirmation = { prevented: false, preventDefault() { this.prevented = true; } };
   await click('update-link', confirmation);
-  assert.equal(confirmation.prevented, false);
+  await settle();
+  assert.equal(confirmation.prevented, true);
+  assert.equal(sandbox._opens.length, 1);
 });
 
 test('popup update nudge: a reset-style wallet generation change is uncovered', async () => {
@@ -292,10 +318,12 @@ test('popup update nudge: a matching wallet generation and trade count bypasses 
   });
   await settle();
   assert.equal(sandbox._els['update-backup-state'].textContent,
-    `Last backup: ${new Date(at).toISOString().slice(0, 10)}`);
+    `Last backup: ${new Date(at).toISOString().slice(0, 10)} · exported — check the file is in your downloads`);
   const event = { prevented: false, preventDefault() { this.prevented = true; } };
   await click('update-link', event);
-  assert.equal(event.prevented, false);
+  await settle();
+  assert.equal(event.prevented, true);
+  assert.equal(sandbox._opens.length, 1);
 });
 
 test('popup update nudge: a thesis added after export is uncovered', async () => {
@@ -341,6 +369,120 @@ test('popup update nudge: an armed alert after export is uncovered', async () =>
   assert.equal(event.prevented, true);
 });
 
+test('popup update nudge: settings changed after export are uncovered', async () => {
+  const at = Date.now() - 2 * 24 * 60 * 60 * 1000;
+  const state = { startedAt: 1234, journal: [] };
+  const beforeSettings = { theme: 'light' };
+  const currentSettings = { theme: 'dark' };
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    lastBackup: { at, startedAt: 1234, trades: 0, fingerprint: '__from_state__' },
+    backupFingerprintData: {
+      pt_state: state, pt_settings: beforeSettings, pt_frames: [], pt_replays: [],
+    },
+    state,
+    settings: currentSettings,
+    frames: [],
+    replays: [],
+    manifestVersion: '3.6.1',
+  });
+  await settle();
+  assert.match(sandbox._els['update-backup-state'].textContent, /wallet changed since/);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  await settle();
+  assert.equal(event.prevented, true);
+});
+
+test('popup update nudge: a new frame after export is uncovered', async () => {
+  const at = Date.now() - 2 * 24 * 60 * 60 * 1000;
+  const state = { startedAt: 1234, journal: [] };
+  const beforeFrames = [{ id: 'before', t: 1, dataUrl: 'data:image/jpeg;base64,old' }];
+  const currentFrames = [...beforeFrames, { id: 'after', t: 2, dataUrl: 'data:image/jpeg;base64,new' }];
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    lastBackup: { at, startedAt: 1234, trades: 0, fingerprint: '__from_state__' },
+    backupFingerprintData: {
+      pt_state: state, pt_settings: undefined, pt_frames: beforeFrames, pt_replays: undefined,
+    },
+    state,
+    frames: currentFrames,
+    manifestVersion: '3.6.1',
+  });
+  await settle();
+  assert.match(sandbox._els['update-backup-state'].textContent, /wallet changed since/);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  await settle();
+  assert.equal(event.prevented, true);
+});
+
+test('popup update nudge: frame image bytes alone stay covered', async () => {
+  const at = Date.now() - 2 * 24 * 60 * 60 * 1000;
+  const state = { startedAt: 1234, journal: [] };
+  const beforeFrames = [{ id: 'same', t: 1, dataUrl: 'data:image/jpeg;base64,old' }];
+  const currentFrames = [{ id: 'same', t: 1, dataUrl: 'data:image/jpeg;base64,new' }];
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    lastBackup: { at, startedAt: 1234, trades: 0, fingerprint: '__from_state__' },
+    backupFingerprintData: {
+      pt_state: state, pt_settings: undefined, pt_frames: beforeFrames, pt_replays: undefined,
+    },
+    state,
+    frames: currentFrames,
+    manifestVersion: '3.6.1',
+  });
+  await settle();
+  assert.match(sandbox._els['update-backup-state'].textContent, /· exported — check the file/);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  await settle();
+  assert.equal(event.prevented, true);
+  assert.equal(sandbox._opens.length, 1);
+});
+
+test('popup update nudge: chain-missing export is never covered', async () => {
+  const state = { startedAt: 1234, journal: [] };
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    state,
+    manifestVersion: '3.6.1',
+    attest: { readChainStore: async () => { throw new Error('chain unavailable'); } },
+  });
+  await settle();
+  await click('update-backup');
+  await settle();
+  const record = sandbox._stored.get('pt_last_backup');
+  assert.equal(record.chainMissing, true);
+  assert.match(sandbox._els['update-backup-state'].textContent,
+    /exported without the verification chain/);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  await settle();
+  assert.equal(event.prevented, true);
+});
+
+test('popup update nudge: click re-reads state before opening a covered link', async () => {
+  const at = Date.now() - 2 * 24 * 60 * 60 * 1000;
+  const before = { startedAt: 1234, journal: [] };
+  const after = { startedAt: 1234, journal: [{}] };
+  const { sandbox, click } = loadPopupPage({
+    release: { tag_name: 'v9.9.9' },
+    lastBackup: { at, startedAt: 1234, trades: 0, fingerprint: '__from_state__' },
+    backupFingerprintData: { pt_state: before },
+    state: before,
+    manifestVersion: '3.6.1',
+  });
+  await settle();
+  sandbox._stored.set('pt_state', after);
+  const event = { prevented: false, preventDefault() { this.prevented = true; } };
+  await click('update-link', event);
+  await settle();
+  assert.equal(event.prevented, true);
+  assert.equal(sandbox._opens.length, 0);
+  assert.match(sandbox._els['update-backup-state'].textContent, /1 trade since/);
+});
+
 test('popup update nudge: heartbeat-only state changes stay covered', async () => {
   const at = Date.now() - 2 * 24 * 60 * 60 * 1000;
   const before = {
@@ -381,10 +523,12 @@ test('popup update nudge: heartbeat-only state changes stay covered', async () =
   });
   await settle();
   assert.equal(sandbox._els['update-backup-state'].textContent,
-    `Last backup: ${new Date(at).toISOString().slice(0, 10)}`);
+    `Last backup: ${new Date(at).toISOString().slice(0, 10)} · exported — check the file is in your downloads`);
   const event = { prevented: false, preventDefault() { this.prevented = true; } };
   await click('update-link', event);
-  assert.equal(event.prevented, false);
+  await settle();
+  assert.equal(event.prevented, true);
+  assert.equal(sandbox._opens.length, 1);
 });
 
 test('popup update nudge: a decreased trade count says wallet history changed', async () => {


### PR DESCRIPTION
## Summary

Wallets disappear when people update by hand. The mechanism is already documented in `popup.js`'s backup block: an unpacked extension keys storage by install folder, so unzipping a release into a *new* folder reads as a fresh install. Backup/Restore has existed the whole time — but the one moment we know a wipe is imminent, the update banner, said nothing about it and offered a bare `Download the update →` straight into the data-loss path.

The banner now carries the backup:

- **`Back up wallet first`** → the existing `backupWallet()`, then re-reads storage so the state line updates without reopening the popup.
- **A state line that says whether this wallet is actually covered.**
- **Arm-once on the download link,** modelled on `onQuickResetTap`: an uncovered click is `preventDefault()`ed and the line gains ` — click again to update anyway`; a second click within 10s opens it. The link is never disabled and keeps its real `href`.

The substance is in what "covered" means, because a weak answer is worse than none — it's false reassurance in front of the one action that destroys the wallet. A bare `{ at }` timestamp says "safe" after a week of trading, after `resetWallet()`, after a restore. Counting trades is better and still wrong: a thesis (`setThesis`), an alert, a TP/SL, a limit buy all live in `pt_state`, all come back from the file, and none move `journal.length`. And `pt_state` is only one of the four keys the file carries.

So the record fingerprints everything the backup actually contains, one helper used by both the write and the check:

```js
pt_last_backup = { at, version, startedAt, trades, fingerprint, chainMissing, chainLength, chainHead }
// covered ⇔ fingerprint matches ∧ chain meta unmoved ∧ the export wasn't chainless
```

`backupFingerprint` canonicalises `pt_state`, `pt_settings`, `pt_frames`, `pt_replays` with sorted keys and hashes them (FNV-1a over UTF-16 units — synchronous, because the click path can't await a digest, and unit-wise so an emoji-only thesis edit can't collide on a shared high surrogate). Excluded, deliberately and with the reason in a comment:

- `seq`, `updatedAt`, and per position `lastPriceNative` / `lastPriceUsd` / `peakPnlSol` / `troughPnlSol` — everything `markPosition` writes on a tick. This is why `state.seq`, the obvious revision marker, was unusable: it advances on a wallet nobody has traded, so the banner would nag forever and people would learn to click through it. A test pins that: a heartbeat-only change stays covered.
- each frame's `dataUrl` — a downscaled JPEG; frames are append-and-evict, so the surviving metadata still moves on every add or eviction, without hashing megabytes on each popup open.
- `attestChain`, which `backupWallet` embeds into the *file's* copy of `pt_state` for downgrade safety and which isn't in the live one.

Two things the fingerprint alone cannot see:

- **The attestation chain is committed separately from the wallet.** An export landing between a fill's `pt_state` write and its chain append bundles a fill whose verification link is missing — and the state fingerprint would match forever after. The record stores the `length`/`head` of the chain it exported and coverage requires the live meta to still match, so a later append reads `new verified fills since`. An empty chain stays coverable; older records without the field fall through to the fingerprint.
- **A chainless export isn't a complete backup.** `chainMissing` is now `!AT` as well as the read failure, so both an absent `PTAttest` and a failed `readChainStore` say `exported without the verification chain` instead of claiming coverage.

`startedAt` and `trades` survive only to phrase *why* a backup is stale, never to invent a statistic — a restore landing *fewer* trades of the same generation says `wallet history changed`, not `0 trades since`.

Coverage is decided at click time, not at render: another tab can fill while the popup sits open, so the handler `preventDefault()`s first, re-reads and re-fingerprints, then either opens the release itself (`chrome.tabs.create`, with a `window.open` fallback) or arms and repaints with what it just found.

Where it can't know something, it says so rather than guessing: an unreadable `pt_last_backup` reports that backup *status* couldn't be read (not that no backup exists), an unreadable wallet reports that coverage can't be confirmed, and both stay uncovered and armed. A covered wallet reads `Last backup: <date> · exported — check the file is in your downloads` — the extension has no `downloads` permission and can't witness the file land, so the line doesn't pretend to. Adding that permission for one anchor click means a new install-time prompt, and a permanently "unconfirmed" state would nag after every good backup, which is the same trained-to-click-through failure.

`pt_last_backup` is deliberately **not** in `BACKUP_KEYS`: importing a foreign machine's record would make this install claim a backup it doesn't have, and the fingerprint catches it even if one arrives. Fail-open is preserved throughout — each key is read in its own `try`, a throwing read never suppresses the banner and never reads as coverage.

`updatebanner.test.js` (41 cases) covers no record, a fresh export being immediately covered through the `attestChain` embedding, thesis / alert / settings / frame edits, a `dataUrl`-only frame change staying covered, heartbeat-only staying covered, emoji-only fingerprint divergence, more trades, decreased history, a reset-style generation, a restored foreign wallet, a chain append after export, an empty-chain install, a missing `PTAttest`, failing marker / wallet / chain-meta reads, the post-render fill race, single-open on a covered click, and the untouched dismiss + no-newer-release + fetch-failure paths.

Extension suite 2,176 passed / 0 failed; server 279 passed / 0 failed / 10 skipped. Verified in the test harness, not yet in a live popup.


Link to Devin session: https://app.devin.ai/sessions/b676704d774f4aa099ba7f31381b036f
Open in Devin Desktop: https://app.devin.ai/desktop/session/b676704d774f4aa099ba7f31381b036f?variant=devin
Requested by: @OnlyTerp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/papertrench/pull/98" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->