### PR TITLE
feat(panel): show lifetime bought / held / sold in the trade panel

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -2193,6 +2193,9 @@
     renderBalance();
     renderPosition();
     renderClosedPnl();
+    // A fill in another tab changes the wallet-wide flow just like the
+    // balance and positions bar; repaint it with the adopted state.
+    renderFlow();
     // A fill in ANOTHER tab changes the portfolio too; without this the bar
     // would keep showing a chip for a position that is already closed.
     renderPositionsBar();
@@ -5737,9 +5740,16 @@
   function renderFlow() {
     if (!els.flow || !state) return;
     const stats = E.sessionStats(state, settings);
+    const base = `In ${E.fmt(stats.boughtSol, 2)} · holding ${E.fmt(stats.heldSol, 2)} · out ${E.fmt(stats.soldSol, 2)} SOL`;
     // Lifetime book totals span coins, so a current foreign-chain rate cannot
     // honestly convert them; keep this line in SOL everywhere.
-    els.flow.textContent = `In ${E.fmt(stats.boughtSol, 2)} · holding ${E.fmt(stats.heldSol, 2)} · out ${E.fmt(stats.soldSol, 2)} SOL`;
+    if (stats.flowTruncated) {
+      els.flow.textContent = `${base} · bought/sold cover newest ${E.JOURNAL_CAP} fills`;
+      els.flow.title = `Lifetime flow: total bought, cost still held open, total sold back out. Bought and sold cover only the newest ${E.JOURNAL_CAP} fills; holding remains exact from open positions.`;
+      return;
+    }
+    els.flow.textContent = base;
+    els.flow.title = 'Lifetime flow: total bought, cost still held open, total sold back out.';
   }
 
   /* ---------------- panel denomination ----------------
@@ -6900,6 +6910,9 @@
     // position shows up in the rail instantly, chart one click away.
     pollPositionPrices();
     renderPositionsBar();
+    // A row fill changes the wallet-wide flow even when this chart shows
+    // another token, so keep that summary in step without a full rebuild.
+    renderFlow();
     // If this token's chart happens to be on screen, refresh the card too.
     if (token && token.mint === data.mint) renderAll();
     return result;

--- a/extension/content.js
+++ b/extension/content.js
@@ -4026,6 +4026,7 @@
     .pt-box.pt-micro .pt-limit-row,
     .pt-box.pt-micro #pt-thesis,
     .pt-box.pt-micro #pt-closed,
+    .pt-box.pt-micro #pt-flow,
     .pt-box.pt-micro .pt-editor,
     .pt-box.pt-micro .pt-footer,
     .pt-box.pt-micro .pt-pos .pt-detail,
@@ -4674,6 +4675,12 @@
       transition: color 0.16s, border-color 0.16s;
     }
     .pt-footer a:hover { color: var(--pt-amber); border-color: var(--pt-amber); }
+    .pt-flow {
+      margin-top: 7px;
+      color: var(--pt-faint);
+      font-size: 10px;
+      font-variant-numeric: tabular-nums;
+    }
 
     /* ---------------- semantic colors ---------------- */
 
@@ -5287,6 +5294,7 @@
             <div id="pt-alerts"></div>
             <div id="pt-thesis"></div>
             <div id="pt-closed"></div>
+            <div class="pt-flow" id="pt-flow" title="Lifetime flow: total bought, cost still held open, total sold back out."></div>
           </div>
           <div class="pt-footer">
             <span id="pt-site"></span>
@@ -5341,6 +5349,7 @@
     els.alerts = shadow.getElementById('pt-alerts');
     els.thesis = shadow.getElementById('pt-thesis');
     els.closed = shadow.getElementById('pt-closed');
+    els.flow = shadow.getElementById('pt-flow');
     els.effects = shadow.getElementById('pt-effects');
     els.footSite = shadow.getElementById('pt-site');
     els.subtitle = shadow.getElementById('pt-subtitle');
@@ -5725,6 +5734,14 @@
     }
   }
 
+  function renderFlow() {
+    if (!els.flow || !state) return;
+    const stats = E.sessionStats(state, settings);
+    // Lifetime book totals span coins, so a current foreign-chain rate cannot
+    // honestly convert them; keep this line in SOL everywhere.
+    els.flow.textContent = `In ${E.fmt(stats.boughtSol, 2)} · holding ${E.fmt(stats.heldSol, 2)} · out ${E.fmt(stats.soldSol, 2)} SOL`;
+  }
+
   /* ---------------- panel denomination ----------------
    * Foreign-chain panels denominate in DOLLARS. Read off the live site
    * (2026-08-05): fomo's own quick buys on a BNB token are $10/$100/$500/
@@ -6084,6 +6101,7 @@
     renderHeader();
     renderBalance();
     renderMicroWallet();
+    renderFlow();
     renderPosition();
     renderAlerts();
     renderBuyButton();

--- a/extension/engine.js
+++ b/extension/engine.js
@@ -17,6 +17,7 @@
     replays: 'pt_replays',
   };
   const EPS = 1e-9;
+  const JOURNAL_CAP = 2000;
 
   // Bumped when a default changes in a way existing users should receive.
   // Stored settings normally win over defaults, so without this a user who
@@ -1380,6 +1381,9 @@
       equityVsStart: eq - anchorStartSol(state, settings),
       feesPaidSol: Number(st.feesPaidSol) || 0,
       trades: state.journal.length,
+      // The journal keeps only the newest fills, so at the cap bought/sold
+      // may omit older history even though open-position cost remains exact.
+      flowTruncated: state.journal.length >= JOURNAL_CAP,
       // jb (#ideas): "able to see how much u've bought/held/sold whilst
       // trading". Bought/sold are the journal's NET SOL per fill (what the
       // wallet actually moved); held is open positions at cost basis —
@@ -2421,7 +2425,7 @@
   }
 
   function pruneJournal(state) {
-    if (state.journal.length > 2000) state.journal.length = 2000;
+    if (state.journal.length > JOURNAL_CAP) state.journal.length = JOURNAL_CAP;
   }
 
   function short(addr) {
@@ -2445,6 +2449,7 @@
 
   const _PaperEngine = {
     STORAGE_KEYS,
+    JOURNAL_CAP,
     DEFAULT_SETTINGS,
     defaultSettings,
     mergeSettings,

--- a/extension/test/statepersist.test.js
+++ b/extension/test/statepersist.test.js
@@ -313,6 +313,8 @@ function runOverlay(priceSeries, opts) {
     failGets: (n) => { failGets = n; },
     /** A write from "another tab" whose adoption event this tab misses. */
     externalWriteSilently: (obj) => Object.assign(storage, obj),
+    /** A write from "another tab" that reaches this tab's storage listener. */
+    externalWrite: (obj) => sandbox.chrome.storage.local.set(obj),
     setValue: (id, v) => { if (shadowNodes[id]) shadowNodes[id].value = String(v); },
     clickById: (id) => { if (shadowNodes[id]) shadowNodes[id].click(); },
     nextPrice: () => { priceIdx++; },
@@ -400,10 +402,54 @@ test('the panel flow line mirrors engine totals after a real panel fill', async 
   const settings = Object.assign(E.defaultSettings(), ov.storage().pt_settings || {});
   const state = ov.storage().pt_state;
   const stats = E.sessionStats(state, settings);
+  assert.equal(stats.flowTruncated, false);
   assert.equal(
     ov.shadowNodes['pt-flow'].textContent,
     `In ${E.fmt(stats.boughtSol, 2)} · holding ${E.fmt(stats.heldSol, 2)} · out ${E.fmt(stats.soldSol, 2)} SOL`,
   );
+});
+
+test('an adopted external fill refreshes the lifetime flow immediately', async () => {
+  const ov = runOverlay([0.001, 0.0012]);
+  await ov.advance(1200);
+  const settings = Object.assign(E.defaultSettings(), ov.storage().pt_settings || {});
+  const foreign = E.defaultState(settings);
+  const amount = settings.presetsBuy[0];
+  E.buy(foreign, settings, {
+    ts: 1_500_000, mint: BONK, symbol: 'BONK', site: 'axiom',
+    priceNative: 0.001, priceUsd: 0.2, solAmount: amount,
+  });
+  await ov.externalWrite({ pt_state: foreign });
+  const stats = E.sessionStats(foreign, settings);
+  assert.equal(
+    ov.shadowNodes['pt-flow'].textContent,
+    `In ${E.fmt(stats.boughtSol, 2)} · holding ${E.fmt(stats.heldSol, 2)} · out ${E.fmt(stats.soldSol, 2)} SOL`,
+  );
+});
+
+test('a capped journal qualifies bought and sold while holding stays exact', async () => {
+  const ov = runOverlay([0.001]);
+  await ov.advance(1200);
+  const settings = Object.assign(E.defaultSettings(), ov.storage().pt_settings || {});
+  settings.balanceStartSol = (E.JOURNAL_CAP + 1) * settings.presetsBuy[0] * 2;
+  const capped = E.defaultState(settings);
+  const amount = settings.presetsBuy[0];
+  for (let i = 0; i <= E.JOURNAL_CAP; i++) {
+    E.buy(capped, settings, {
+      ts: i + 1, mint: BONK, symbol: 'BONK', site: 'axiom',
+      priceNative: 0.001, priceUsd: 0.2, solAmount: amount,
+    });
+  }
+  await ov.externalWrite({ pt_state: capped });
+  const stats = E.sessionStats(capped, settings);
+  assert.equal(stats.flowTruncated, true);
+  assert.match(ov.shadowNodes['pt-flow'].textContent,
+    new RegExp(`bought/sold cover newest ${E.JOURNAL_CAP} fills`));
+  assert.match(ov.shadowNodes['pt-flow'].textContent,
+    new RegExp(`holding ${E.fmt(stats.heldSol, 2)}`));
+  assert.match(ov.shadowNodes['pt-flow'].title,
+    new RegExp(`newest ${E.JOURNAL_CAP} fills`));
+  assert.match(ov.shadowNodes['pt-flow'].title, /holding remains exact/);
 });
 
 test('the panel flow line updates when a position is sold', async () => {

--- a/extension/test/statepersist.test.js
+++ b/extension/test/statepersist.test.js
@@ -67,6 +67,13 @@ function runOverlay(priceSeries, opts) {
           this._fields[m[1]] = child;
           this.children.push(child);
         }
+        const presets = /<button class="(pt-preset[^"]*)" data-amt="([^"]+)"/g;
+        while ((m = presets.exec(v))) {
+          const child = makeNode('button');
+          child.className = m[1];
+          child.dataset.amt = m[2];
+          this.children.push(child);
+        }
       },
       get innerHTML() { return this._h || ''; },
       appendChild(c) { this.children.push(c); this.childNodes = this.children; c._parent = this; return c; },
@@ -84,7 +91,12 @@ function runOverlay(priceSeries, opts) {
         if (m && this._fields && this._fields[m[1]]) return this._fields[m[1]];
         return makeNode('span');
       },
-      querySelectorAll() { return []; },
+      querySelectorAll(sel) {
+        if (sel === '.pt-preset') {
+          return this.children.filter((c) => String(c.className || '').startsWith('pt-preset'));
+        }
+        return [];
+      },
       getBoundingClientRect() { return { top: 0 }; },
       attachShadow() { return shadowRoot; },
       focus() {}, closest() { return null; },
@@ -175,6 +187,9 @@ function runOverlay(priceSeries, opts) {
           // F-14: the worker owns the attest chain; the harness acks appends
           // so a fill does not trip the F-28 failure toast mid-test.
           if (msg.type === 'pt_attest_append') return Promise.resolve({ ok: true, seq: 0, head: 'pt-test-head' });
+          if (msg.type === 'pt_resolve' && options.resolveRecord) {
+            return Promise.resolve({ ...options.resolveRecord });
+          }
           const R = win.PaperTrenchResolver;
           if (!R) return Promise.resolve({});
           if (msg.type === 'pt_resolve') return R.resolve(msg.address);
@@ -271,9 +286,18 @@ function runOverlay(priceSeries, opts) {
     return row.children.filter((c) => c.className === 'pt-sell');
   }
 
+  function clickPreset(index) {
+    const presets = shadowNodes['pt-buy-presets'] && shadowNodes['pt-buy-presets'].children;
+    const button = presets && presets[index];
+    if (!button) throw new Error(`missing buy preset ${index}`);
+    button.click();
+    return button;
+  }
+
   return {
     advance,
     openPaperPosition,
+    clickPreset,
     sellButtons,
     storage: () => storage,
     shadowNodes,
@@ -364,6 +388,87 @@ test('the quick-sell buttons render for a position adopted from another tab', as
   const buttons = ov.sellButtons();
   assert.equal(buttons.length, 4, 'the position card must offer the four quick-sell buttons');
   assert.deepEqual(buttons.map((b) => b.textContent), ['25%', '50%', '75%', '100%']);
+});
+
+test('the panel flow line mirrors engine totals after a real panel fill', async () => {
+  const ov = runOverlay([0.001, 0.0012]);
+  await ov.advance(1200);
+
+  ov.clickPreset(0);
+  await ov.advance(1500);
+
+  const settings = Object.assign(E.defaultSettings(), ov.storage().pt_settings || {});
+  const state = ov.storage().pt_state;
+  const stats = E.sessionStats(state, settings);
+  assert.equal(
+    ov.shadowNodes['pt-flow'].textContent,
+    `In ${E.fmt(stats.boughtSol, 2)} · holding ${E.fmt(stats.heldSol, 2)} · out ${E.fmt(stats.soldSol, 2)} SOL`,
+  );
+});
+
+test('the panel flow line updates when a position is sold', async () => {
+  const ov = runOverlay([0.001, 0.0012]);
+  await ov.advance(1200);
+
+  ov.clickPreset(0);
+  await ov.advance(1500);
+  const settings = Object.assign(E.defaultSettings(), ov.storage().pt_settings || {});
+  const before = E.sessionStats(ov.storage().pt_state, settings);
+
+  const sell = ov.sellButtons()[1];
+  assert.ok(sell, 'the 50% sell button must render after the panel fill');
+  sell.click();
+  await ov.advance(1500);
+
+  const after = E.sessionStats(ov.storage().pt_state, settings);
+  assert.ok(after.soldSol > before.soldSol, 'selling increases lifetime outflow');
+  assert.ok(after.heldSol < before.heldSol, 'selling reduces open cost basis');
+  assert.equal(
+    ov.shadowNodes['pt-flow'].textContent,
+    `In ${E.fmt(after.boughtSol, 2)} · holding ${E.fmt(after.heldSol, 2)} · out ${E.fmt(after.soldSol, 2)} SOL`,
+  );
+});
+
+test('a fresh wallet renders zero lifetime flow values', async () => {
+  const ov = runOverlay([0.001]);
+  await ov.advance(1200);
+
+  const settings = Object.assign(E.defaultSettings(), ov.storage().pt_settings || {});
+  const stats = E.sessionStats(E.defaultState(settings), settings);
+  assert.equal(
+    ov.shadowNodes['pt-flow'].textContent,
+    `In ${E.fmt(stats.boughtSol, 2)} · holding ${E.fmt(stats.heldSol, 2)} · out ${E.fmt(stats.soldSol, 2)} SOL`,
+  );
+});
+
+test('foreign-chain panels keep lifetime flow denominated in SOL', async () => {
+  const ov = runOverlay([0.001], {
+    resolveRecord: {
+      mint: BONK, pairAddress: 'PAIR1', symbol: 'BONK', name: 'Bonk',
+      priceNative: 0.001, priceUsd: 0.2, chain: 'bsc', solUsdAtResolve: 200,
+    },
+  });
+  await ov.advance(1200);
+
+  assert.match(ov.shadowNodes['pt-flow'].textContent, /SOL$/,
+    'lifetime flow must keep its SOL label on foreign-chain panels');
+  assert.doesNotMatch(ov.shadowNodes['pt-flow'].textContent, /\$/,
+    'lifetime flow must not use the current token USD denomination');
+});
+
+test('the lifetime flow line is hidden by micro density', () => {
+  const content = fs.readFileSync(path.join(__dirname, '..', 'content.js'), 'utf8');
+  assert.match(content,
+    /<div class="pt-flow" id="pt-flow" title="Lifetime flow: total bought, cost still held open, total sold back out\."><\/div>/,
+    'the panel body must carry the lifetime flow element and tooltip');
+  assert.match(content, /els\.flow = shadow\.getElementById\('pt-flow'\);/,
+    'the lifetime flow element must be registered with the panel elements');
+  const micro = content.slice(
+    content.indexOf('.pt-box.pt-micro #pt-thesis'),
+    content.indexOf('.pt-box.pt-focus', content.indexOf('.pt-box.pt-micro #pt-thesis')),
+  );
+  assert.match(micro, /\.pt-box\.pt-micro #pt-flow/,
+    'micro density must hide the lifetime flow line');
 });
 
 /* ---------------- overlay buy-section toggles ----------------


### PR DESCRIPTION
## Summary

Requested in #ideas: "able to see how much u've bought/held/sold whilst trading". The popup and the dashboard sidebar both show it; the panel that is actually on screen while trading did not. The panel's `.pt-ledger` is per-position (`Invested / Sold / Remaining`), so it never answered the lifetime question.

New `#pt-flow` line in the panel body:

```
In 3.00 · holding 0.25 · out 1.25 SOL
```

It reads `boughtSol` / `heldSol` / `soldSol` straight off `E.sessionStats(state, settings)` — the derivation the popup and dashboard already agree with. No second accounting path: popup.js only carries its own `journalFlow` copy because the popup deliberately has no engine dependency, and content.js already has `E`.

Two things are load-bearing beyond the wiring.

**Currency.** A foreign-chain panel denominates the charted token in dollars, but these are lifetime *book* totals spanning many coins, so converting them at the currently-charted coin's rate would invent a number. The line is always SOL and always labelled SOL, and does not go through the `money()` helper `renderPositionLedger` uses. A test pins that on the `panelUsd()` path.

**"Lifetime" is a claim the data can't always support.** `pruneJournal` keeps the newest 2,000 fills, so past the cap `boughtSol`/`soldSol` under-report and each new fill drops an old one — the total can go *down*. Rather than persist new cumulative counters (a schema change, and a second accounting path beside the journal), the code says so, the way `equityCurvePoints` already does for this same cap (D-51):

```js
const JOURNAL_CAP = 2000;                                  // was a bare literal in pruneJournal
flowTruncated: state.journal.length >= JOURNAL_CAP         // from sessionStats
```

At the cap the line appends `· bought/sold cover newest 2000 fills` and the tooltip says which parts are affected — `holding` comes from open positions, so it stays exact either way. Below the cap nothing changes. popup.js and dashboard.js inherit the same cap and label it loosely today; that predates this PR and is a follow-up.

Rendered from `renderAll()`, and also from the two paths that change the wallet without one: `adoptState()` (a fill in another tab) and `fillRowBuy()` (a screener-row fill while this chart shows a different token). `textContent` only; joins the existing micro-density hide group; stays visible in focus mode.

Tests assert the rendered text against `E.sessionStats` output for the same state rather than string literals, so the line cannot drift from the engine: fills through the harness, a sell moving `out` down `holding`, honest zeros on a fresh wallet, a foreign-chain panel, adoption of an external write, and a journal crossing the cap. Reverting the markup, the renderer, the adoption call, the CSS, or the cap metadata each reds a distinct test.

Extension suite 2,165 passed / 0 failed; server 279 passed / 0 failed / 10 skipped. Harness-verified, not yet seen in a live panel.

Link to Devin session: https://app.devin.ai/sessions/b676704d774f4aa099ba7f31381b036f
Open in Devin Desktop: https://app.devin.ai/desktop/session/b676704d774f4aa099ba7f31381b036f?variant=devin
Requested by: @OnlyTerp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/papertrench/pull/99" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->