### PR TITLE
fix(content): stop an armed row snipe from filling on top of a live chip buy

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -6954,11 +6954,11 @@
           releaseRowBuyLatch(rowBuyToken);
         }
         if (result) {
-          rowArmed = null;
+          if (rowArmed === armed) {
+            rowArmed = null;
+            sendMessage({ type: 'pt_armed_row_clear' }).catch(() => {});
+          }
           sendPadreMarker('row-buy-done', null);
-          // D-42: the SW mirror dies with the local intent — a filled snipe
-          // must never be adopted by the chart page and filled twice.
-          sendMessage({ type: 'pt_armed_row_clear' }).catch(() => {});
         }
       }
     } catch (_) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -6581,6 +6581,20 @@
   // once left "Row buy already in progress…" on every coin until reload —
   // live report). A settled finally clears the latch long before this ages.
   let rowBuyInFlightAt = 0;
+  let rowBuyOwner = 0;
+
+  function acquireRowBuyLatch() {
+    rowBuyInFlight = true;
+    rowBuyInFlightAt = Date.now();
+    rowBuyOwner += 1;
+    return rowBuyOwner;
+  }
+
+  function releaseRowBuyLatch(token) {
+    if (rowBuyOwner !== token) return;
+    rowBuyInFlight = false;
+    rowBuyInFlightAt = 0;
+  }
 
   function noteRowPrice(payload) {
     if (!payload || typeof payload.mint !== 'string' || !ROW_ADDR_RE.test(payload.mint)) return;
@@ -6932,14 +6946,12 @@
         // Serialize only the commit. The armed resolver cascade must stay free
         // to retry while a direct click is pricing or filling.
         if (rowBuyInFlight) return;
-        rowBuyInFlight = true;
-        rowBuyInFlightAt = Date.now();
+        const rowBuyToken = acquireRowBuyLatch();
         let result;
         try {
           result = await fillRowBuy(armed.address, data, armed.amount);
         } finally {
-          rowBuyInFlight = false;
-          rowBuyInFlightAt = 0;
+          releaseRowBuyLatch(rowBuyToken);
         }
         if (result) {
           rowArmed = null;
@@ -6957,8 +6969,7 @@
   /** Paper-buy the first preset amount of a screener row's token. */
   async function doRowBuy(address, button) {
     if (rowBuyInFlight) return toast('Row buy already in progress…');
-    rowBuyInFlight = true;
-    rowBuyInFlightAt = Date.now();
+    const rowBuyToken = acquireRowBuyLatch();
     if (button) button.classList.add('busy');
     primeAudio();
     try {
@@ -7077,7 +7088,7 @@
     } catch (err) {
       toast(err.message || 'Row buy failed');
     } finally {
-      rowBuyInFlight = false;
+      releaseRowBuyLatch(rowBuyToken);
       if (button) button.classList.remove('busy');
     }
   }
@@ -9041,10 +9052,11 @@
       // D-41 latch hygiene: an in-flight buy/sell whose await never settled
       // (hung resolver, dying SW) must not wedge every later trade behind
       // "already in progress". A live cascade never takes 20 s; if the
-      // latch is that old the operation is dead, so free it. The eventual
-      // finally is idempotent — it only clears, never re-arms.
+      // latch is that old the operation is dead, so free it. The generation
+      // token keeps its eventual finally from releasing a newer operation.
       const LATCH_MAX_AGE_MS = 20_000;
       if (rowBuyInFlight && rowBuyInFlightAt && Date.now() - rowBuyInFlightAt > LATCH_MAX_AGE_MS) {
+        rowBuyOwner += 1;
         rowBuyInFlight = false;
         rowBuyInFlightAt = 0;
         toast('A stuck row buy was released — try again');

--- a/extension/content.js
+++ b/extension/content.js
@@ -6929,7 +6929,18 @@
           if (Number(data.mcap) > 0) data.mcap = Number(data.mcap) * scale;
           data.priceSource = 'row-feed';
         }
-        const result = await fillRowBuy(armed.address, data, armed.amount);
+        // Serialize only the commit. The armed resolver cascade must stay free
+        // to retry while a direct click is pricing or filling.
+        if (rowBuyInFlight) return;
+        rowBuyInFlight = true;
+        rowBuyInFlightAt = Date.now();
+        let result;
+        try {
+          result = await fillRowBuy(armed.address, data, armed.amount);
+        } finally {
+          rowBuyInFlight = false;
+          rowBuyInFlightAt = 0;
+        }
         if (result) {
           rowArmed = null;
           sendPadreMarker('row-buy-done', null);

--- a/extension/content.js
+++ b/extension/content.js
@@ -6954,6 +6954,9 @@
           releaseRowBuyLatch(rowBuyToken);
         }
         if (result) {
+          // D-42: the SW mirror dies with the intent it belongs to — a filled
+          // snipe must never be adopted by the chart page and filled twice,
+          // and a newer intent must keep both its slot and its mirror.
           if (rowArmed === armed) {
             rowArmed = null;
             sendMessage({ type: 'pt_armed_row_clear' }).catch(() => {});

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -1,0 +1,320 @@
+/* Regression harness for the two independent row-buy entry paths.
+ *
+ * The test boots the shipped content script with a deferred identity lookup
+ * for the clicked row. That leaves its real doRowBuy path in flight while a
+ * board tick wakes the armed-row path for another token.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const CONTENT = fs.readFileSync(path.join(ROOT, 'content.js'), 'utf8');
+const ENGINE = fs.readFileSync(path.join(ROOT, 'engine.js'), 'utf8');
+
+const A = 'A'.repeat(32);
+const B = 'B'.repeat(32);
+
+function bootRace() {
+  let clock = Date.now();
+  class HarnessDate extends Date {
+    constructor(...args) { super(...(args.length ? args : [clock])); }
+    static now() { return clock; }
+  }
+  const listeners = new Map();
+  const storage = {};
+  let bIdentityPending = true;
+  let bIdentityRequested = false;
+  let releaseBIdentity;
+  const bIdentity = new Promise((resolve) => { releaseBIdentity = resolve; });
+  const messages = [];
+  let settings;
+  let initialState;
+
+  const win = {
+    PaperEngine: null,
+    PaperQuote: {
+      STALE_AFTER_MS: 60_000,
+      positionRows: () => [],
+      portfolioSummary: () => ({ up: false }),
+    },
+    PaperTrenchSites: {},
+    PaperTrenchResolver: {},
+    PTChartMarkers: {},
+    PTTitleFeed: {},
+    addEventListener(type, fn) {
+      if (!listeners.has(type)) listeners.set(type, []);
+      listeners.get(type).push(fn);
+    },
+    removeEventListener() {},
+    postMessage() {},
+    location: {
+      href: 'https://axiom.trade/pulse',
+      hostname: 'axiom.trade',
+      pathname: '/pulse',
+      search: '',
+    },
+  };
+
+  function sendMessage(payload) {
+    messages.push(payload);
+    if (payload.type === 'pt_resolve') {
+      if (payload.address === B) {
+        return Promise.resolve({
+          mint: B,
+          pairAddress: null,
+          symbol: 'B',
+          name: 'Token B',
+          priceNative: 1,
+          priceUsd: 100,
+          mcap: 100_000,
+          priceSource: 'resolver',
+        });
+      }
+      return Promise.resolve(null);
+    }
+    if (payload.type === 'pt_onchain_prewatch') {
+      const address = payload.mint || payload.pool;
+      if (address === B) {
+        bIdentityRequested = true;
+        return bIdentityPending ? bIdentity : Promise.resolve({ mint: B });
+      }
+      if (address === A) return Promise.resolve({ mint: A });
+      return Promise.resolve(null);
+    }
+    if (payload.type === 'pt_sol_usd') return Promise.resolve(100);
+    if (payload.type === 'pt_state_commit') return Promise.resolve({ ok: true });
+    if (payload.type === 'pt_attest_append') return Promise.resolve({ ok: true });
+    return Promise.resolve({});
+  }
+
+  const document = {
+    readyState: 'loading',
+    hidden: false,
+    body: null,
+    documentElement: {},
+    addEventListener(type, fn) {
+      if (!listeners.has(`document:${type}`)) listeners.set(`document:${type}`, []);
+      listeners.get(`document:${type}`).push(fn);
+    },
+    removeEventListener() {},
+    createElement: () => ({
+      style: {},
+      classList: { add() {}, remove() {}, toggle() {} },
+      appendChild() {},
+      addEventListener() {},
+    }),
+    querySelector: () => null,
+    querySelectorAll: () => [],
+  };
+
+  const chrome = {
+    runtime: {
+      id: 'papertrench-test',
+      lastError: null,
+      sendMessage,
+      onMessage: { addListener() {} },
+    },
+    storage: {
+      local: {
+        get(keys, callback) {
+          const out = {};
+          for (const key of (Array.isArray(keys) ? keys : [keys])) {
+            if (key in storage) out[key] = storage[key];
+          }
+          callback(out);
+        },
+        set(values, callback) {
+          Object.assign(storage, values);
+          if (callback) callback();
+        },
+      },
+      onChanged: { addListener() {}, removeListener() {} },
+    },
+  };
+
+  const sandbox = {
+    window: win,
+    self: win,
+    document,
+    location: win.location,
+    chrome,
+    console,
+    URL,
+    URLSearchParams,
+    Promise,
+    JSON,
+    Math,
+    Date: HarnessDate,
+    Number,
+    String,
+    Array,
+    Object,
+    Boolean,
+    RegExp,
+    Error,
+    Set,
+    Map,
+    WeakSet,
+    WeakMap,
+    Infinity,
+    NaN,
+    parseInt,
+    parseFloat,
+    isNaN,
+    AbortController: function () { this.signal = {}; this.abort = () => {}; },
+    MutationObserver: function () { this.observe = () => {}; this.disconnect = () => {}; },
+    ResizeObserver: function () { this.observe = () => {}; this.disconnect = () => {}; },
+    NodeFilter: { SHOW_TEXT: 4 },
+    fetch: () => Promise.resolve({ ok: false, status: 404, json: async () => ({}) }),
+    setTimeout: () => 1,
+    clearTimeout() {},
+    setInterval: () => 1,
+    clearInterval() {},
+    requestAnimationFrame: (fn) => { fn(); return 1; },
+    cancelAnimationFrame() {},
+    performance: { now: () => 1 },
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(ENGINE, sandbox, { filename: 'engine.js' });
+  win.PaperEngine = sandbox.window.PaperEngine;
+  settings = win.PaperEngine.defaultSettings();
+  settings.balanceStartSol = 100;
+  initialState = win.PaperEngine.defaultState(settings);
+  storage.pt_state = initialState;
+  storage.pt_settings = settings;
+
+  const end = CONTENT.lastIndexOf('\n})();');
+  assert.ok(end > 0, 'content script has its IIFE terminator');
+  const instrumented = CONTENT.slice(0, end)
+    + `
+  window.__rowHarness = {
+    doRowBuy,
+    noteRowPrice,
+    flushRowArmed,
+    getState: () => state,
+    setSite: (next) => { site = next; },
+    getRowArmed: () => rowArmed,
+    getRowArmedFlushing: () => rowArmedFlushing,
+  };
+`
+    + CONTENT.slice(end);
+  vm.runInContext(instrumented, sandbox, { filename: 'content.js' });
+  const harness = sandbox.window.__rowHarness;
+  harness.setSite({ id: 'axiom', rowBuy: { kind: 'pair' } });
+
+  return {
+    harness,
+    storage,
+    isBIdentityRequested: () => bIdentityRequested,
+    releaseB() {
+      bIdentityPending = false;
+      releaseBIdentity({ mint: B });
+    },
+    messages,
+    setNow(next) { clock = next; },
+  };
+}
+
+async function waitFor(predicate) {
+  for (let i = 0; i < 2000; i++) {
+    if (predicate()) return;
+    await Promise.resolve();
+  }
+  assert.fail('timed out waiting for the row-buy harness');
+}
+
+test('an armed row fill defers behind a different clicked row fill', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  // Drive A through the real cascade miss so it arms rather than touching
+  // the closure's rowArmed state directly.
+  const arm = harness.doRowBuy(A);
+  await arm;
+  assert.ok(harness.getRowArmed(), 'A should remain armed after an unpriced click');
+
+  // B has a price, but its identity lookup is intentionally held open. This
+  // is the in-flight window in which the board tick for A can wake its flush.
+  const clickB = harness.doRowBuy(B);
+  await waitFor(() => race.isBIdentityRequested());
+  assert.equal(race.isBIdentityRequested(), true, 'B should be mid-fill before the tick');
+
+  harness.noteRowPrice({
+    mint: A,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'A',
+    name: 'Token A',
+  });
+  await waitFor(() => harness.getRowArmedFlushing());
+  await waitFor(() => !harness.getRowArmedFlushing());
+
+  const midJournal = Array.from(harness.getState().journal, (trade) => trade.mint);
+  assert.deepEqual(midJournal, [],
+    'the armed A fill stays deferred while clicked B is still in flight');
+  assert.ok(harness.getRowArmed(), 'the deferred A intent must remain armed');
+
+  race.releaseB();
+  await clickB;
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B],
+    'the direct B intent commits exactly once');
+
+  // The next board wake retries the still-armed intent after the direct
+  // commit releases the shared latch.
+  harness.noteRowPrice({
+    mint: A,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'A',
+    name: 'Token A',
+  });
+  await waitFor(() => harness.getState().journal.length === 2);
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [A, B],
+    'the deferred A intent commits exactly once on a later wake');
+});
+
+test('an armed row fill commits on its first available price without competition', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  await harness.doRowBuy(A);
+  assert.ok(harness.getRowArmed(), 'A should arm when its cascade cannot price');
+  harness.noteRowPrice({
+    mint: A,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'A',
+    name: 'Token A',
+  });
+  await waitFor(() => harness.getState().journal.length === 1 && !harness.getRowArmed());
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [A]);
+  assert.equal(harness.getRowArmed(), null, 'a successful armed fill clears its intent');
+});
+
+test('a priced row click still commits without an armed intent', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  const clickB = harness.doRowBuy(B);
+  await waitFor(() => race.isBIdentityRequested());
+  race.releaseB();
+  await clickB;
+  await waitFor(() => harness.getState().journal.length === 1);
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
+  assert.equal(harness.getRowArmed(), null, 'a priced click does not create an armed intent');
+});
+
+test('a row buy still expires at its existing TTL', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  await harness.doRowBuy(A);
+  const armedAt = harness.getRowArmed().at;
+  race.setNow(armedAt + 60_001);
+  await harness.flushRowArmed();
+
+  assert.equal(harness.getRowArmed(), null, 'an expired armed intent is cleared');
+  assert.equal(harness.getState().journal.length, 0, 'an expired intent does not fill');
+});

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -20,7 +20,7 @@ const A = 'A'.repeat(32);
 const B = 'B'.repeat(32);
 const C = 'C'.repeat(32);
 
-function bootRace() {
+function bootRace(options = {}) {
   let clock = Date.now();
   class HarnessDate extends Date {
     constructor(...args) { super(...(args.length ? args : [clock])); }
@@ -37,6 +37,10 @@ function bootRace() {
   let cIdentityRequested = false;
   let releaseCIdentity;
   const cIdentity = new Promise((resolve) => { releaseCIdentity = resolve; });
+  let solUsdPending = options.holdSolUsd === true;
+  let solUsdRequested = false;
+  let releaseSolUsd;
+  const solUsd = new Promise((resolve) => { releaseSolUsd = resolve; });
   const messages = [];
   let settings;
   let initialState;
@@ -135,6 +139,7 @@ function bootRace() {
     messages.push(payload);
     if (payload.type === 'pt_resolve') {
       if (payload.address === B) {
+        if (options.unpricedB) return Promise.resolve(null);
         return Promise.resolve({
           mint: B,
           pairAddress: null,
@@ -173,7 +178,10 @@ function bootRace() {
       if (address === A) return Promise.resolve({ mint: A });
       return Promise.resolve(null);
     }
-    if (payload.type === 'pt_sol_usd') return Promise.resolve(100);
+    if (payload.type === 'pt_sol_usd') {
+      solUsdRequested = true;
+      return solUsdPending ? solUsd : Promise.resolve(100);
+    }
     if (payload.type === 'pt_state_commit') return Promise.resolve({ ok: true });
     if (payload.type === 'pt_attest_append') return Promise.resolve({ ok: true });
     return Promise.resolve({});
@@ -289,6 +297,7 @@ function bootRace() {
     getRowBuyInFlight: () => rowBuyInFlight,
     getRowBuyInFlightAt: () => rowBuyInFlightAt,
     getRowBuyOwner: () => rowBuyOwner,
+    getRowArmedFlushTimer: () => rowArmedFlushTimer,
   };
 `
     + CONTENT.slice(end);
@@ -308,6 +317,11 @@ function bootRace() {
     releaseC() {
       cIdentityPending = false;
       releaseCIdentity({ mint: C });
+    },
+    isSolUsdRequested: () => solUsdRequested,
+    releaseSolUsd() {
+      solUsdPending = false;
+      releaseSolUsd(100);
     },
     messages,
     setNow(next) { clock = next; },
@@ -387,6 +401,66 @@ test('an armed row fill commits on its first available price without competition
 
   assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [A]);
   assert.equal(harness.getRowArmed(), null, 'a successful armed fill clears its intent');
+});
+
+test('a newer armed intent survives an older flush commit', async () => {
+  const race = bootRace({ unpricedB: true, holdSolUsd: true });
+  const { harness } = race;
+
+  await harness.doRowBuy(A);
+  const firstIntent = harness.getRowArmed();
+  assert.ok(firstIntent, 'A should arm when its cascade cannot price');
+
+  harness.noteRowPrice({
+    mint: A,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'A',
+    name: 'Token A',
+  });
+  await waitFor(() => race.isSolUsdRequested());
+  assert.equal(harness.getRowArmedFlushing(), true, 'A should be flushing its newly available price');
+
+  race.releaseB();
+  await harness.doRowBuy(B);
+  const secondIntent = harness.getRowArmed();
+  assert.ok(secondIntent, 'B should arm after its own cascade misses');
+  assert.notEqual(secondIntent, firstIntent, 'each unpriced click gets a fresh intent object');
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_armed_row_arm').length,
+    2,
+    'the service worker receives both armed intents',
+  );
+
+  race.releaseSolUsd();
+  await waitFor(() => harness.getState().journal.length === 1);
+  await waitFor(() => !harness.getRowArmedFlushing());
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [A]);
+  assert.equal(harness.getRowArmed(), secondIntent,
+    'the older A flush cannot discard newer B');
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_armed_row_clear').length,
+    0,
+    'the older flush cannot clear B from the service worker',
+  );
+  assert.ok(harness.getRowArmedFlushTimer(),
+    'the repeating armed flush remains alive for B');
+
+  harness.noteRowPrice({
+    mint: B,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'B',
+    name: 'Token B',
+  });
+  await waitFor(() => harness.getState().journal.length === 2);
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B, A],
+    'the newer B intent subsequently commits exactly once');
+  await waitFor(() => harness.getRowArmed() === null);
+  assert.equal(harness.getRowArmed(), null, 'B clears only after its own successful fill');
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_armed_row_clear').length,
+    1,
+    'the service worker mirror clears once for the filled B intent',
+  );
 });
 
 test('a timed-out row buy cannot release a newer latch owner', async () => {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -13,9 +13,12 @@ const vm = require('node:vm');
 const ROOT = path.join(__dirname, '..');
 const CONTENT = fs.readFileSync(path.join(ROOT, 'content.js'), 'utf8');
 const ENGINE = fs.readFileSync(path.join(ROOT, 'engine.js'), 'utf8');
+const QUOTE = fs.readFileSync(path.join(ROOT, 'quote.js'), 'utf8');
+const SITES = fs.readFileSync(path.join(ROOT, 'sites.js'), 'utf8');
 
 const A = 'A'.repeat(32);
 const B = 'B'.repeat(32);
+const C = 'C'.repeat(32);
 
 function bootRace() {
   let clock = Date.now();
@@ -24,14 +27,82 @@ function bootRace() {
     static now() { return clock; }
   }
   const listeners = new Map();
+  const timers = [];
   const storage = {};
   let bIdentityPending = true;
   let bIdentityRequested = false;
   let releaseBIdentity;
   const bIdentity = new Promise((resolve) => { releaseBIdentity = resolve; });
+  let cIdentityPending = true;
+  let cIdentityRequested = false;
+  let releaseCIdentity;
+  const cIdentity = new Promise((resolve) => { releaseCIdentity = resolve; });
   const messages = [];
   let settings;
   let initialState;
+
+  function scheduleTimer(fn, ms, every) {
+    timers.push({ fn, at: clock + (ms || 0), every: every || 0, dead: false });
+    return timers.length;
+  }
+
+  function clearTimer(id) {
+    if (timers[id - 1]) timers[id - 1].dead = true;
+  }
+
+  async function advance(ms, step) {
+    step = step || 100;
+    for (let left = ms; left > 0; left -= step) {
+      clock += Math.min(step, left);
+      for (const timer of timers) {
+        if (timer.dead || timer.at > clock) continue;
+        if (timer.every) timer.at = clock + timer.every;
+        else timer.dead = true;
+        timer.fn();
+      }
+      for (let i = 0; i < 8; i++) await Promise.resolve();
+    }
+  }
+
+  const nodesById = {};
+  function makeNode(tag) {
+    return {
+      tag,
+      id: '',
+      style: { setProperty() {}, removeProperty() {} },
+      dataset: {},
+      className: '',
+      classList: { add() {}, remove() {}, toggle() {}, contains() { return false; } },
+      children: [],
+      get childNodes() { return this.children; },
+      appendChild(child) { this.children.push(child); return child; },
+      querySelector() { return makeNode('div'); },
+      querySelectorAll() { return []; },
+      remove() {},
+      addEventListener() {},
+      removeEventListener() {},
+      setAttribute() {},
+      getAttribute() { return null; },
+      getBoundingClientRect() { return { top: 0, left: 0, right: 0, width: 0, height: 0 }; },
+      attachShadow() { return shadowRoot; },
+      focus() {},
+      set innerHTML(value) { this._html = value; },
+      get innerHTML() { return this._html || ''; },
+      textContent: '',
+      offsetWidth: 1,
+    };
+  }
+  const shadowRoot = {
+    set innerHTML(value) { this._html = value; },
+    get innerHTML() { return this._html || ''; },
+    getElementById(id) {
+      if (!nodesById[id]) nodesById[id] = makeNode('div');
+      return nodesById[id];
+    },
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+    appendChild() {},
+  };
 
   const win = {
     PaperEngine: null,
@@ -42,8 +113,10 @@ function bootRace() {
     },
     PaperTrenchSites: {},
     PaperTrenchResolver: {},
-    PTChartMarkers: {},
+    PTChartMarkers: { destroyChartMarkers() {} },
     PTTitleFeed: {},
+    innerWidth: 1400,
+    innerHeight: 1050,
     addEventListener(type, fn) {
       if (!listeners.has(type)) listeners.set(type, []);
       listeners.get(type).push(fn);
@@ -73,6 +146,18 @@ function bootRace() {
           priceSource: 'resolver',
         });
       }
+      if (payload.address === C) {
+        return Promise.resolve({
+          mint: C,
+          pairAddress: null,
+          symbol: 'C',
+          name: 'Token C',
+          priceNative: 1,
+          priceUsd: 100,
+          mcap: 100_000,
+          priceSource: 'resolver',
+        });
+      }
       return Promise.resolve(null);
     }
     if (payload.type === 'pt_onchain_prewatch') {
@@ -80,6 +165,10 @@ function bootRace() {
       if (address === B) {
         bIdentityRequested = true;
         return bIdentityPending ? bIdentity : Promise.resolve({ mint: B });
+      }
+      if (address === C) {
+        cIdentityRequested = true;
+        return cIdentityPending ? cIdentity : Promise.resolve({ mint: C });
       }
       if (address === A) return Promise.resolve({ mint: A });
       return Promise.resolve(null);
@@ -93,19 +182,15 @@ function bootRace() {
   const document = {
     readyState: 'loading',
     hidden: false,
-    body: null,
+    body: makeNode('body'),
     documentElement: {},
     addEventListener(type, fn) {
       if (!listeners.has(`document:${type}`)) listeners.set(`document:${type}`, []);
       listeners.get(`document:${type}`).push(fn);
     },
     removeEventListener() {},
-    createElement: () => ({
-      style: {},
-      classList: { add() {}, remove() {}, toggle() {} },
-      appendChild() {},
-      addEventListener() {},
-    }),
+    createElement: (tag) => makeNode(tag),
+    getElementById: () => null,
     querySelector: () => null,
     querySelectorAll: () => [],
   };
@@ -169,16 +254,18 @@ function bootRace() {
     ResizeObserver: function () { this.observe = () => {}; this.disconnect = () => {}; },
     NodeFilter: { SHOW_TEXT: 4 },
     fetch: () => Promise.resolve({ ok: false, status: 404, json: async () => ({}) }),
-    setTimeout: () => 1,
-    clearTimeout() {},
-    setInterval: () => 1,
-    clearInterval() {},
+    setTimeout: (fn, ms) => scheduleTimer(fn, ms),
+    clearTimeout: clearTimer,
+    setInterval: (fn, ms) => scheduleTimer(fn, ms, ms),
+    clearInterval: clearTimer,
     requestAnimationFrame: (fn) => { fn(); return 1; },
     cancelAnimationFrame() {},
     performance: { now: () => 1 },
   };
   vm.createContext(sandbox);
   vm.runInContext(ENGINE, sandbox, { filename: 'engine.js' });
+  vm.runInContext(QUOTE, sandbox, { filename: 'quote.js' });
+  vm.runInContext(SITES, sandbox, { filename: 'sites.js' });
   win.PaperEngine = sandbox.window.PaperEngine;
   settings = win.PaperEngine.defaultSettings();
   settings.balanceStartSol = 100;
@@ -194,10 +281,14 @@ function bootRace() {
     doRowBuy,
     noteRowPrice,
     flushRowArmed,
+    enableOverlay,
     getState: () => state,
     setSite: (next) => { site = next; },
     getRowArmed: () => rowArmed,
     getRowArmedFlushing: () => rowArmedFlushing,
+    getRowBuyInFlight: () => rowBuyInFlight,
+    getRowBuyInFlightAt: () => rowBuyInFlightAt,
+    getRowBuyOwner: () => rowBuyOwner,
   };
 `
     + CONTENT.slice(end);
@@ -209,12 +300,18 @@ function bootRace() {
     harness,
     storage,
     isBIdentityRequested: () => bIdentityRequested,
+    isCIdentityRequested: () => cIdentityRequested,
     releaseB() {
       bIdentityPending = false;
       releaseBIdentity({ mint: B });
     },
+    releaseC() {
+      cIdentityPending = false;
+      releaseCIdentity({ mint: C });
+    },
     messages,
     setNow(next) { clock = next; },
+    advance,
   };
 }
 
@@ -290,6 +387,50 @@ test('an armed row fill commits on its first available price without competition
 
   assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [A]);
   assert.equal(harness.getRowArmed(), null, 'a successful armed fill clears its intent');
+});
+
+test('a timed-out row buy cannot release a newer latch owner', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  const first = harness.doRowBuy(B);
+  await waitFor(() => race.isBIdentityRequested());
+  const firstAt = harness.getRowBuyInFlightAt();
+  const firstOwner = harness.getRowBuyOwner();
+
+  await harness.enableOverlay();
+  race.setNow(firstAt + 20_001);
+  await race.advance(1);
+  assert.equal(harness.getRowBuyInFlight(), false,
+    'the bar watchdog releases a buy that exceeds the latch age');
+  assert.notEqual(harness.getRowBuyOwner(), firstOwner,
+    'the watchdog supersedes the timed-out operation');
+
+  const second = harness.doRowBuy(C);
+  await waitFor(() => race.isCIdentityRequested());
+  const secondOwner = harness.getRowBuyOwner();
+  assert.equal(harness.getRowBuyInFlight(), true, 'the second buy acquires the freed latch');
+  assert.notEqual(secondOwner, firstOwner, 'the second buy has a new generation');
+
+  race.releaseB();
+  await first;
+  assert.equal(harness.getRowBuyInFlight(), true,
+    'the first buy finishing cannot clear the second buy latch');
+  assert.equal(harness.getRowBuyOwner(), secondOwner,
+    'the second buy remains the latch owner');
+
+  await harness.doRowBuy(A);
+  assert.equal(harness.getRowBuyInFlight(), true,
+    'a third click is refused while the second buy remains in flight');
+  assert.equal(harness.getRowBuyOwner(), secondOwner,
+    'the refused third click cannot take ownership');
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B],
+    'the first fill may finish, but the newer held operation stays exclusive');
+
+  race.releaseC();
+  await second;
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [C, B],
+    'both original intents eventually commit exactly once');
 });
 
 test('a priced row click still commits without an armed intent', async () => {


### PR DESCRIPTION
## Summary

Live testing on a logged-in Axiom board caught a single row-chip click committing **two fills on two different tokens** milliseconds apart. This is the mechanism behind it.

A row chip reaches `fillRowBuy` by two paths, and only one of them is single-flight:

- `doRowBuy()` takes `rowBuyInFlight` synchronously at entry, so click-vs-click is safe.
- `flushRowArmed()` — the D-40 armed intent, where a tap that could not be priced stays armed and fires on the first fillable price — guards only against itself (`rowArmedFlushing`) and calls `fillRowBuy` directly. It never reads `rowBuyInFlight`, and `noteRowPrice()` wakes it on *every* board tick, including the ticks flowing while a fresh click is mid-fill.

So an intent armed on coin A commits inside the window where a click on coin B is committing. To the trader that is one click and two fills. `fillRowBuy` has no dedupe of its own, so nothing downstream catches it.

The fix serialises the **commit** and only the commit:

```js
if (rowBuyInFlight) return;               // intent stays armed; the 1.5s flush retries
rowBuyInFlight = true; rowBuyInFlightAt = Date.now();
try { result = await fillRowBuy(armed.address, data, armed.amount); }
finally { rowBuyInFlight = false; rowBuyInFlightAt = 0; }
```

Deliberately *not* held across the armed cascade's price lookups: those can take seconds, and answering a user's click with `Row buy already in progress…` would be worse than the bug. Nothing is dropped — a deferred intent is left armed and the existing 1.5 s interval commits it once the click's fill completes. Setting `rowBuyInFlightAt` keeps the 20 s stuck-latch watchdog honest for this path too.

`rowbuyrace.test.js` drives the real `doRowBuy` arm path, holds a second click's fill at identity resolution, and delivers the armed coin's board tick into that window. Without the latch it reproduces the report — the armed coin lands in the journal while the clicked coin is still in flight; with it, the intent defers and then commits exactly once. Ordinary armed fills, ordinary clicks and TTL expiry are pinned unchanged.

What this does **not** change: an unpriced tap still stays armed and fires later, which is the shipped D-40 doctrine. That an intent can fire with no visible sign that it was ever armed is a separate product question, raised with the user.

Extension suite 2,152 passed / 0 failed. Found in live testing; the fix itself is verified in the harness, not yet re-tested on a live board.

## Latch ownership (review follow-up)

The D-41 watchdog force-releases the latch after 20 s on purpose — a wedged latch that refuses every trade is worse than a rare overlap. But the `finally` blocks cleared it unconditionally, so an operation the watchdog had already given up on could clear a latch a *newer* buy had since acquired, leaving two fills overlapping with the latch reading free. That hole predates this PR on the click path; the armed path would have widened it.

Both paths now acquire a generation token and release only their own:

```js
function releaseRowBuyLatch(token) {
  if (rowBuyOwner !== token) return;   // the watchdog already superseded us
  rowBuyInFlight = false;
  rowBuyInFlightAt = 0;
}
```

The watchdog bumps `rowBuyOwner` as it clears, so the straggler's release becomes a no-op. Covered by a test that ages a fill past the watchdog, lets a second buy take the freed latch, then finishes the first — the second keeps ownership and a third buy in that window is refused. Extension suite 2,153 passed / 0 failed.

## A second silent-loss bug in the same window

Review then caught a preexisting one of the "buy did nothing, no message" family. `flushRowArmed` captures `const armed = rowArmed` and awaits its cascade; since the latch is deliberately not held there, a second unpriced click can replace `rowArmed` with intent B in that window. The older flush then filled A and cleared `rowArmed` unconditionally — B discarded, and because the repeating flush self-clears on a null intent, B never filled, never expired, and said nothing.

Only the intent that was actually filled is now cleared, mirror included:

```js
if (rowArmed === armed) {          // a newer unpriced click may have replaced it
  rowArmed = null;
  sendMessage({ type: 'pt_armed_row_clear' }).catch(() => {});
}
```

Clearing the mirror unconditionally would drop B from the service worker too, which is how the chart page would lose it on navigation. Pinned by a test that holds A's lookup, arms B through the real unpriced cascade, commits A, and asserts B survives (slot, mirror, live flush timer) and later commits exactly once. Extension suite 2,154 passed / 0 failed.

Still a single intent slot, so B replacing A drops A — a capacity/product question, not a race, and raised with the user rather than changed here.


Link to Devin session: https://app.devin.ai/sessions/b676704d774f4aa099ba7f31381b036f
Open in Devin Desktop: https://app.devin.ai/desktop/session/b676704d774f4aa099ba7f31381b036f?variant=devin
Requested by: @OnlyTerp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/papertrench/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->