### PR TITLE
fix(quickbuy): price an Axiom chip tap from the row's own props, so nothing has to be armed

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -6676,7 +6676,10 @@
     }
     if (quote.priceUsd != null) {
       const implied = Number(quote.priceUsd) / Number(quote.priceSol);
-      const rate = await R.solUsd().catch(() => 0);
+      const rate = await Promise.race([
+        Promise.resolve().then(() => R.solUsd()).catch(() => 0),
+        new Promise((resolve) => setTimeout(() => resolve(0), 2000)),
+      ]);
       if (rate > 0 && (!(implied > 0)
         || Math.max(implied / rate, rate / implied) > 1.25)) return false;
     }
@@ -6864,8 +6867,7 @@
     // The chain classifies the click address the same way prewatch does —
     // one bounded read, never blocking the fill: a miss keeps the row's own
     // address as the key, exactly the honest legacy behavior.
-    if (address && data.priceSource !== 'row-props'
-      && (!data.mint || data.mint === address)) {
+    if (address && (!data.mint || data.mint === address)) {
       try {
         const found = await R.onchainPrewatch({ mint: address, pool: address }).catch(() => null);
         if (found && found.mint && found.mint !== data.mint) {
@@ -6940,6 +6942,7 @@
     }
     rowArmedFlushing = true;
     const armed = rowArmed;
+    const rowBuyToken = rowBuyInFlight ? rowBuyOwner : null;
     try {
       // Same source order the click itself runs: freshest resolver read,
       // then the row's own feed, then the chain. The flush may only fire
@@ -6969,13 +6972,13 @@
         }
         // Serialize only the commit. The armed resolver cascade must stay free
         // to retry while a direct click is pricing or filling.
-        if (rowBuyInFlight) return;
-        const rowBuyToken = acquireRowBuyLatch();
+        if (rowBuyInFlight || (rowBuyToken !== null && rowBuyOwner !== rowBuyToken)) return;
+        const commitToken = acquireRowBuyLatch();
         let result;
         try {
           result = await fillRowBuy(armed.address, data, armed.amount);
         } finally {
-          releaseRowBuyLatch(rowBuyToken);
+          releaseRowBuyLatch(commitToken);
         }
         if (result) {
           // D-42: the SW mirror dies with the intent it belongs to — a filled
@@ -7125,6 +7128,7 @@
 
       // D-40: the commit core is shared with the armed flush — one extractor,
       // identical guard/engine/attestation/rail behaviour on both paths.
+      if (rowBuyOwner !== rowBuyToken) return;
       await fillRowBuy(address, data, amount);
     } catch (err) {
       toast(err.message || 'Row buy failed');

--- a/extension/content.js
+++ b/extension/content.js
@@ -6568,7 +6568,8 @@
    * exactly like the site's own quick buy moves you to the position.
    */
 
-  const ROW_ADDR_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+  const ROW_ADDR_RE = /[1-9A-HJ-NP-Za-km-z]{32,44}/;
+  const ROW_ADDR_EXACT_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
   // Newest USD price per mint from the site's OWN realtime feed (GMGN's
   // token_activity ticks carry a mint). A row buy prefers this over a
   // network quote because the screener is showing that very price.
@@ -6662,16 +6663,22 @@
     };
   }
 
-  function validRowPropsQuote(quote, address) {
-    if (!quote || typeof quote !== 'object' || !ROW_ADDR_RE.test(address || '')) return false;
+  async function validRowPropsQuote(quote, address) {
+    if (!quote || typeof quote !== 'object' || !ROW_ADDR_EXACT_RE.test(address || '')) return false;
     const mint = quote.mint || null;
     const pair = quote.pair || null;
-    if ((mint && !ROW_ADDR_RE.test(mint)) || (pair && !ROW_ADDR_RE.test(pair))) return false;
+    if ((mint && !ROW_ADDR_EXACT_RE.test(mint)) || (pair && !ROW_ADDR_EXACT_RE.test(pair))) return false;
     if ((!mint && !pair) || (mint !== address && pair !== address)) return false;
     if (!(Number.isFinite(Number(quote.priceSol)) && Number(quote.priceSol) > 0)) return false;
     for (const name of ['priceUsd', 'mcapUsd', 'supply']) {
       if (quote[name] != null
         && !(Number.isFinite(Number(quote[name])) && Number(quote[name]) > 0)) return false;
+    }
+    if (quote.priceUsd != null) {
+      const implied = Number(quote.priceUsd) / Number(quote.priceSol);
+      const rate = await R.solUsd().catch(() => 0);
+      if (rate > 0 && (!(implied > 0)
+        || Math.max(implied / rate, rate / implied) > 1.25)) return false;
     }
     return true;
   }
@@ -7014,11 +7021,7 @@
       // nothing below may block this function's finally forever.
       const ROW_CASCADE_TIMEOUT_MS = 10_000;
       let data = null;
-      if (rowQuote) {
-        if (!validRowPropsQuote(rowQuote, address)) {
-          toast('Row price identity could not be confirmed — paper buy refused');
-          return;
-        }
+      if (rowQuote && await validRowPropsQuote(rowQuote, address)) {
         data = {
           mint: rowQuote.mint || address,
           pairAddress: rowQuote.pair || null,

--- a/extension/content.js
+++ b/extension/content.js
@@ -484,7 +484,7 @@
         return;
       }
       if (ev.payload && ev.payload.address) {
-        doRowBuy(ev.payload.address, null)
+        doRowBuy(ev.payload.address, null, ev.payload.quote)
           .finally(() => sendPadreMarker('row-buy-done', null));
       }
     }
@@ -6568,7 +6568,7 @@
    * exactly like the site's own quick buy moves you to the position.
    */
 
-  const ROW_ADDR_RE = /[1-9A-HJ-NP-Za-km-z]{32,44}/;
+  const ROW_ADDR_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
   // Newest USD price per mint from the site's OWN realtime feed (GMGN's
   // token_activity ticks carry a mint). A row buy prefers this over a
   // network quote because the screener is showing that very price.
@@ -6660,6 +6660,20 @@
       mcap: null,
       priceSource: 'row-onchain',
     };
+  }
+
+  function validRowPropsQuote(quote, address) {
+    if (!quote || typeof quote !== 'object' || !ROW_ADDR_RE.test(address || '')) return false;
+    const mint = quote.mint || null;
+    const pair = quote.pair || null;
+    if ((mint && !ROW_ADDR_RE.test(mint)) || (pair && !ROW_ADDR_RE.test(pair))) return false;
+    if ((!mint && !pair) || (mint !== address && pair !== address)) return false;
+    if (!(Number.isFinite(Number(quote.priceSol)) && Number(quote.priceSol) > 0)) return false;
+    for (const name of ['priceUsd', 'mcapUsd', 'supply']) {
+      if (quote[name] != null
+        && !(Number.isFinite(Number(quote[name])) && Number(quote[name]) > 0)) return false;
+    }
+    return true;
   }
 
   /**
@@ -6756,7 +6770,8 @@
   async function rowPrintVouchesFirstBuy(address, data, posAnchor) {
     if (posAnchor) return true; // an existing position anchors (F-56 above)
     if (!(Number(data.priceNative) > 0) || !(Number(data.priceUsd) > 0)) return true;
-    if (data.priceSource === 'row-feed' || data.priceSource === 'row-onchain') return true;
+    if (data.priceSource === 'row-feed' || data.priceSource === 'row-props'
+      || data.priceSource === 'row-onchain') return true;
     const rowPrint = (data.mint && recentRowPrices.get(data.mint))
       || (data.pairAddress && recentRowPrices.get(data.pairAddress))
       || (address && recentRowPrices.get(address));
@@ -6805,7 +6820,7 @@
       if (ratio > 2) {
         let witnessNative = null;
         try {
-          if (data.priceSource === 'row-feed' || !data.priceSource) {
+          if (data.priceSource === 'row-feed' || data.priceSource === 'row-props' || !data.priceSource) {
             const obs = await R.resolve(address, { maxAgeMs: 3000 }).catch(() => null);
             if (obs && Number(obs.priceNative) > 0) witnessNative = Number(obs.priceNative);
           } else {
@@ -6842,7 +6857,8 @@
     // The chain classifies the click address the same way prewatch does —
     // one bounded read, never blocking the fill: a miss keeps the row's own
     // address as the key, exactly the honest legacy behavior.
-    if (address && (!data.mint || data.mint === address)) {
+    if (address && data.priceSource !== 'row-props'
+      && (!data.mint || data.mint === address)) {
       try {
         const found = await R.onchainPrewatch({ mint: address, pool: address }).catch(() => null);
         if (found && found.mint && found.mint !== data.mint) {
@@ -6936,7 +6952,8 @@
         const live = (data.mint && recentRowPrices.get(data.mint))
           || (data.pairAddress && recentRowPrices.get(data.pairAddress))
           || recentRowPrices.get(armed.address);
-        if (live && Date.now() - live.at < ROW_PRICE_TTL_MS && Number(data.priceUsd) > 0) {
+        if (data.priceSource !== 'row-props'
+            && live && Date.now() - live.at < ROW_PRICE_TTL_MS && Number(data.priceUsd) > 0) {
           const scale = live.usd / Number(data.priceUsd);
           data.priceUsd = live.usd;
           data.priceNative = Number(data.priceNative) * scale;
@@ -6970,7 +6987,7 @@
   }
 
   /** Paper-buy the first preset amount of a screener row's token. */
-  async function doRowBuy(address, button) {
+  async function doRowBuy(address, button, rowQuote) {
     if (rowBuyInFlight) return toast('Row buy already in progress…');
     const rowBuyToken = acquireRowBuyLatch();
     if (button) button.classList.add('busy');
@@ -6997,30 +7014,47 @@
       // nothing below may block this function's finally forever.
       const ROW_CASCADE_TIMEOUT_MS = 10_000;
       let data = null;
-      try {
-        data = await Promise.race([
-          (async () => {
-            let d = await R.resolve(address, { maxAgeMs: 3000 });
-            if (!d || !(d.priceNative > 0)) d = await R.resolve(address);
-            if (!d || !(d.priceNative > 0)) {
-              const row = await rowLivePrice(address);
-              if (row) {
-                d = {
-                  mint: address, pairAddress: null,
-                  symbol: row.symbol, name: row.name,
-                  priceNative: row.priceNative, priceUsd: row.priceUsd, mcap: null,
-                  priceSource: 'row-feed',
-                };
+      if (rowQuote) {
+        if (!validRowPropsQuote(rowQuote, address)) {
+          toast('Row price identity could not be confirmed — paper buy refused');
+          return;
+        }
+        data = {
+          mint: rowQuote.mint || address,
+          pairAddress: rowQuote.pair || null,
+          symbol: null,
+          name: null,
+          priceNative: rowQuote.priceSol,
+          priceUsd: rowQuote.priceUsd || null,
+          mcap: rowQuote.mcapUsd || null,
+          priceSource: 'row-props',
+        };
+      } else {
+        try {
+          data = await Promise.race([
+            (async () => {
+              let d = await R.resolve(address, { maxAgeMs: 3000 });
+              if (!d || !(d.priceNative > 0)) d = await R.resolve(address);
+              if (!d || !(d.priceNative > 0)) {
+                const row = await rowLivePrice(address);
+                if (row) {
+                  d = {
+                    mint: address, pairAddress: null,
+                    symbol: row.symbol, name: row.name,
+                    priceNative: row.priceNative, priceUsd: row.priceUsd, mcap: null,
+                    priceSource: 'row-feed',
+                  };
+                }
               }
-            }
-            if (!d || !(d.priceNative > 0)) {
-              d = await rowChainQuote(address, site && site.rowBuy && site.rowBuy.kind);
-            }
-            return d;
-          })(),
-          new Promise((resolve) => setTimeout(() => resolve(null), ROW_CASCADE_TIMEOUT_MS)),
-        ]);
-      } catch (_) { data = null; }
+              if (!d || !(d.priceNative > 0)) {
+                d = await rowChainQuote(address, site && site.rowBuy && site.rowBuy.kind);
+              }
+              return d;
+            })(),
+            new Promise((resolve) => setTimeout(() => resolve(null), ROW_CASCADE_TIMEOUT_MS)),
+          ]);
+        } catch (_) { data = null; }
+      }
       if (!data || !(data.priceNative > 0)) {
         // D-40 (Terp roll-on, board path): the click already happened — the
         // intent is NEVER refused. It arms exactly like the panel's D-39
@@ -7072,7 +7106,8 @@
       const live = (data.mint && recentRowPrices.get(data.mint))
         || (data.pairAddress && recentRowPrices.get(data.pairAddress))
         || (address && recentRowPrices.get(address));
-      if (live && Date.now() - live.at < ROW_PRICE_TTL_MS && Number(data.priceUsd) > 0) {
+      if (data.priceSource !== 'row-props'
+          && live && Date.now() - live.at < ROW_PRICE_TTL_MS && Number(data.priceUsd) > 0) {
         // F-59: the cap rides the price. The old override rewrote
         // priceUsd/priceNative and left `mcap` at the resolver's stale
         // value — the toast and the position then reported an entry MC the

--- a/extension/content.js
+++ b/extension/content.js
@@ -6942,7 +6942,6 @@
     }
     rowArmedFlushing = true;
     const armed = rowArmed;
-    const rowBuyToken = rowBuyInFlight ? rowBuyOwner : null;
     try {
       // Same source order the click itself runs: freshest resolver read,
       // then the row's own feed, then the chain. The flush may only fire
@@ -6972,13 +6971,13 @@
         }
         // Serialize only the commit. The armed resolver cascade must stay free
         // to retry while a direct click is pricing or filling.
-        if (rowBuyInFlight || (rowBuyToken !== null && rowBuyOwner !== rowBuyToken)) return;
-        const commitToken = acquireRowBuyLatch();
+        if (rowBuyInFlight) return;
+        const rowBuyToken = acquireRowBuyLatch();
         let result;
         try {
           result = await fillRowBuy(armed.address, data, armed.amount);
         } finally {
-          releaseRowBuyLatch(commitToken);
+          releaseRowBuyLatch(rowBuyToken);
         }
         if (result) {
           // D-42: the SW mirror dies with the intent it belongs to — a filled

--- a/extension/content.js
+++ b/extension/content.js
@@ -6808,7 +6808,7 @@
     return true;
   }
 
-  async function fillRowBuy(address, data, amount) {
+  async function fillRowBuy(address, data, amount, ownerToken) {
     // F-56: a chip fill runs through the SAME honesty gates as a panel fill.
     // The row's own price used to price the trade blind — no witness, no
     // contradiction check — so a stale/wrong row print booked entries far
@@ -6879,6 +6879,7 @@
     // Guardrails apply to chip buys exactly like panel buys.
     const guard = E.guardCheck(state, settings, { solAmount: amount });
     if (!guard.ok) { toast(guard.message); return null; }
+    if (rowBuyOwner !== ownerToken) return null;
     const result = await withState(async () => {
       // Re-runnable mutation — see doBuy: a lost CAS race re-applies this
       // row buy on the adopted base; only the landing attempt is chained.
@@ -6975,7 +6976,7 @@
         const rowBuyToken = acquireRowBuyLatch();
         let result;
         try {
-          result = await fillRowBuy(armed.address, data, armed.amount);
+          result = await fillRowBuy(armed.address, data, armed.amount, rowBuyToken);
         } finally {
           releaseRowBuyLatch(rowBuyToken);
         }
@@ -7127,8 +7128,7 @@
 
       // D-40: the commit core is shared with the armed flush — one extractor,
       // identical guard/engine/attestation/rail behaviour on both paths.
-      if (rowBuyOwner !== rowBuyToken) return;
-      await fillRowBuy(address, data, amount);
+      await fillRowBuy(address, data, amount, rowBuyToken);
     } catch (err) {
       toast(err.message || 'Row buy failed');
     } finally {

--- a/extension/content.js
+++ b/extension/content.js
@@ -6879,8 +6879,8 @@
     // Guardrails apply to chip buys exactly like panel buys.
     const guard = E.guardCheck(state, settings, { solAmount: amount });
     if (!guard.ok) { toast(guard.message); return null; }
-    if (rowBuyOwner !== ownerToken) return null;
     const result = await withState(async () => {
+      if (rowBuyOwner !== ownerToken) return null;
       // Re-runnable mutation — see doBuy: a lost CAS race re-applies this
       // row buy on the adopted base; only the landing attempt is chained.
       let filled = null;

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3609,18 +3609,6 @@
         const hasIdentity = own.tokenAddress || own.mint || own.pairAddress;
         const hasPrice = [...priceKeys].some((name) => own[name] !== undefined);
         if (hasIdentity && hasPrice) candidates.push(own);
-        const hasUsdPrice = own.tokenPriceUsd !== undefined
-          || own.priceUsd !== undefined
-          || own.marketCapUsd !== undefined;
-        if (!hasIdentity && hasUsdPrice) {
-          for (const value of Object.values(obj)) {
-            const nested = fieldsFor(value);
-            if (nested && nested.tokenAddress) {
-              candidates.push({ tokenAddress: nested.tokenAddress, ...own });
-              break;
-            }
-          }
-        }
         for (const value of Object.values(obj)) {
           if (value && typeof value === 'object') walk(value, depth + 1);
         }

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3603,19 +3603,26 @@
         }
         return fields;
       };
-      const walk = (obj, depth, inheritedPrices) => {
+      const walk = (obj, depth) => {
         if (!obj || typeof obj !== 'object' || depth > 3) return;
         const own = fieldsFor(obj) || {};
         const hasIdentity = own.tokenAddress || own.mint || own.pairAddress;
-        const fields = hasIdentity ? { ...inheritedPrices, ...own } : own;
-        const hasPrice = [...priceKeys].some((name) => fields[name] !== undefined);
-        if (hasIdentity && hasPrice) candidates.push(fields);
-        const childPrices = hasIdentity ? {} : { ...inheritedPrices };
-        for (const name of [...priceKeys, 'supply']) {
-          if (own[name] !== undefined) childPrices[name] = own[name];
+        const hasPrice = [...priceKeys].some((name) => own[name] !== undefined);
+        if (hasIdentity && hasPrice) candidates.push(own);
+        const hasUsdPrice = own.tokenPriceUsd !== undefined
+          || own.priceUsd !== undefined
+          || own.marketCapUsd !== undefined;
+        if (!hasIdentity && hasUsdPrice) {
+          for (const value of Object.values(obj)) {
+            const nested = fieldsFor(value);
+            if (nested && nested.tokenAddress) {
+              candidates.push({ tokenAddress: nested.tokenAddress, ...own });
+              break;
+            }
+          }
         }
         for (const value of Object.values(obj)) {
-          if (value && typeof value === 'object') walk(value, depth + 1, childPrices);
+          if (value && typeof value === 'object') walk(value, depth + 1);
         }
       };
       let steps = 0;
@@ -3623,8 +3630,8 @@
         const fiber = stack.pop();
         if (!fiber || seen.has(fiber)) continue;
         seen.add(fiber);
-        walk(fiber.memoizedProps, 0, {});
-        walk(fiber.memoizedState, 0, {});
+        walk(fiber.memoizedProps, 0);
+        walk(fiber.memoizedState, 0);
         if (fiber.child) stack.push(fiber.child);
         if (fiber.sibling) stack.push(fiber.sibling);
       }

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3226,7 +3226,10 @@
     for (const entry of rowChips.values()) {
       if (entry.el === chip) {
         chip.classList.add('busy');
-        emit('row-buy', { address: entry.address });
+        emit('row-buy', {
+          address: entry.address,
+          quote: rowQuoteFromFiber(entry.row, entry.address),
+        });
         break;
       }
     }
@@ -3564,6 +3567,94 @@
         if (fiber.sibling) stack.push(fiber.sibling);
       }
       return best ? best.address : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function rowQuoteFromFiber(row, tappedAddress) {
+    try {
+      if (!row || !BASE58_RE.test(tappedAddress || '')) return null;
+      const key = Object.getOwnPropertyNames(row).find((k) => k.indexOf('__reactFiber$') === 0);
+      const start = key && row[key];
+      if (!start) return null;
+      const seen = new Set();
+      const stack = [start];
+      const candidates = [];
+      const identityKeys = new Set(['tokenAddress', 'mint', 'pairAddress']);
+      const priceKeys = new Set([
+        'priceSol', 'priceNative', 'tokenPriceUsd', 'priceUsd',
+        'marketCapSol', 'marketCapUsd',
+      ]);
+      const badKey = /change|pct|percent|min|hr|24h|ratio/i;
+      const fieldsFor = (obj) => {
+        if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return null;
+        const fields = {};
+        for (const [name, value] of Object.entries(obj)) {
+          if (badKey.test(name)) continue;
+          if (identityKeys.has(name)) {
+            if (typeof value === 'string' && BASE58_RE.test(value)) fields[name] = value;
+            continue;
+          }
+          if (name === 'supply' || priceKeys.has(name)) {
+            const number = numberValue(value);
+            if (number !== null && number > 0) fields[name] = number;
+          }
+        }
+        return fields;
+      };
+      const walk = (obj, depth, inheritedPrices) => {
+        if (!obj || typeof obj !== 'object' || depth > 3) return;
+        const own = fieldsFor(obj) || {};
+        const hasIdentity = own.tokenAddress || own.mint || own.pairAddress;
+        const fields = hasIdentity ? { ...inheritedPrices, ...own } : own;
+        const hasPrice = [...priceKeys].some((name) => fields[name] !== undefined);
+        if (hasIdentity && hasPrice) candidates.push(fields);
+        const childPrices = hasIdentity ? {} : { ...inheritedPrices };
+        for (const name of [...priceKeys, 'supply']) {
+          if (own[name] !== undefined) childPrices[name] = own[name];
+        }
+        for (const value of Object.values(obj)) {
+          if (value && typeof value === 'object') walk(value, depth + 1, childPrices);
+        }
+      };
+      let steps = 0;
+      while (stack.length && steps++ < 80) {
+        const fiber = stack.pop();
+        if (!fiber || seen.has(fiber)) continue;
+        seen.add(fiber);
+        walk(fiber.memoizedProps, 0, {});
+        walk(fiber.memoizedState, 0, {});
+        if (fiber.child) stack.push(fiber.child);
+        if (fiber.sibling) stack.push(fiber.sibling);
+      }
+      const matching = candidates.filter((fields) =>
+        fields.tokenAddress === tappedAddress
+        || fields.mint === tappedAddress
+        || fields.pairAddress === tappedAddress);
+      if (!matching.length) return null;
+      const selected = matching.reduce((best, fields) =>
+        !best || Object.keys(fields).length > Object.keys(best).length ? fields : best, null);
+      const usd = candidates.find((fields) =>
+        fields.tokenAddress
+        && fields.tokenAddress === selected.tokenAddress
+        && (fields.tokenPriceUsd !== undefined
+          || fields.priceUsd !== undefined
+          || fields.marketCapUsd !== undefined));
+      const merged = { ...selected };
+      if (usd) {
+        for (const name of ['tokenPriceUsd', 'priceUsd', 'marketCapUsd']) {
+          if (merged[name] === undefined && usd[name] !== undefined) merged[name] = usd[name];
+        }
+      }
+      return {
+        mint: merged.tokenAddress || merged.mint || null,
+        pair: merged.pairAddress || null,
+        priceSol: merged.priceSol || merged.priceNative || null,
+        priceUsd: merged.tokenPriceUsd || merged.priceUsd || null,
+        mcapUsd: merged.marketCapUsd || null,
+        supply: merged.supply || null,
+      };
     } catch (_) {
       return null;
     }

--- a/extension/test/chiphonesty.test.js
+++ b/extension/test/chiphonesty.test.js
@@ -29,8 +29,8 @@ test('fillRowBuy anchors its witness on the position itself', () => {
 test('a quote diverging >2x from the anchor needs independent vouching', () => {
   const body = bodyOf('async function fillRowBuy');
   assert.match(body, /ratio > 2/, 'the divergence gate is 2x');
-  assert.match(body, /data\.priceSource === 'row-feed' \|\| !data\.priceSource/,
-    'row-fed candidates are corroborated by the resolver');
+  assert.match(body, /data\.priceSource === 'row-feed' \|\| data\.priceSource === 'row-props' \|\| !data\.priceSource/,
+    'page-row candidates are corroborated by the resolver');
   assert.match(body, /recentRowPrices\.get\(data\.mint\)/,
     'resolver-fed candidates are corroborated by the row feed');
   assert.match(body, /<= 1\.6/, 'vouching tolerance is 1.6x');

--- a/extension/test/quickbuy.test.js
+++ b/extension/test/quickbuy.test.js
@@ -188,13 +188,13 @@ test('row buys run the full fill pipeline and never navigate the row', () => {
   // F-61 widened it once more: a row-fed candidate with a missing/echoed
   // mint gets ONE bounded prewatch probe to heal the key before commit —
   // the stand-in stranding the 8/17 report chased (jb).
-  assert.match(content, /async function fillRowBuy\(address, data, amount\)/,
+  assert.match(content, /async function fillRowBuy\(address, data, amount, ownerToken\)/,
     'the shared commit extractor exists (one commit path for click + armed flush)');
   assert.match(content, /fillRowBuy[\s\S]{0,5200}E\.buy\(state, settings/,
     'the extractor runs the engine buy');
   assert.match(content, /fillRowBuy[\s\S]{0,5600}commitFill\(filled\.trade\)/,
     'the extractor appends the attestation chain');
-  assert.match(content, /await fillRowBuy\(address, data, amount\);/,
+  assert.match(content, /await fillRowBuy\(address, data, amount, rowBuyToken\);/,
     'the click path commits through the shared extractor');
   // The screener's own realtime price is preferred when fresh.
   assert.match(content, /recentRowPrices/);
@@ -367,7 +367,7 @@ test('a fresh-coin chip miss ARMS the intent — the row path never refuses (D-4
     'the armed intent is torn down with the content script');
   // The commit core is ONE extractor shared by the click and the flush, so
   // an armed fill commits identically to a direct one.
-  assert.match(content, /await fillRowBuy\(armed\.address, data, armed\.amount\);/,
+  assert.match(content, /await fillRowBuy\(armed\.address, data, armed\.amount, rowBuyToken\);/,
     'the flush commits through the shared extractor');
 });
 

--- a/extension/test/quickbuy.test.js
+++ b/extension/test/quickbuy.test.js
@@ -163,7 +163,7 @@ test('row buys run the full fill pipeline and never navigate the row', () => {
   assert.match(bridge, /function scanScreenerRows\(spec\)/);
   assert.match(bridge, /function addressFromRowFiber\(row\)/);
   // Chips forward their tap back to the content script's fill pipeline.
-  assert.match(bridge, /emit\('row-buy', \{ address: entry\.address \}\)/);
+  assert.match(bridge, /emit\('row-buy', \{\s*address: entry\.address,\s*quote: rowQuoteFromFiber\(entry\.row, entry\.address\),/s);
   assert.match(content, /ev\.type === 'row-buy'/);
   // The chip shows a busy state until the content script settles the fill.
   assert.match(bridge, /type === 'row-buy-done'/);
@@ -394,8 +394,8 @@ test('chip fills run the same honesty gate as panel fills (F-56)', () => {
   assert.match(content, /Price sources disagree — paper fill refused\. Try again in a moment\./,
     'a divergent candidate with no vouching second source refuses visibly');
   // The witness must be INDEPENDENT of the candidate's source.
-  assert.match(content, /if \(data\.priceSource === 'row-feed' \|\| !data\.priceSource\) \{\s*\n\s*const obs = await R\.resolve\(address/,
-    'a row-feed candidate is witnessed by the resolver, not by itself');
+  assert.match(content, /if \(data\.priceSource === 'row-feed' \|\| data\.priceSource === 'row-props' \|\| !data\.priceSource\) \{\s*\n\s*const obs = await R\.resolve\(address/,
+    'page-row candidates are witnessed by the resolver, not by themselves');
 });
 
 test('a panel buy on a fresh coin acquires the quote on the click before arming (D-38)', () => {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -181,6 +181,7 @@ function bootRace(options = {}) {
     }
     if (payload.type === 'pt_sol_usd') {
       solUsdRequested = true;
+      if (options.solUsdFails) return Promise.reject(new Error('rate unavailable'));
       return solUsdPending ? solUsd : Promise.resolve(100);
     }
     if (payload.type === 'pt_state_commit') return Promise.resolve({ ok: true });
@@ -550,24 +551,76 @@ test('a row-props quote fills at the tapped price without resolver or identity l
   assert.equal(harness.getState().journal[0].priceNative, 0.000032);
 });
 
-test('an invalid row-props identity is refused instead of filling or arming', async () => {
+test('row-props validation has its own exact address check', () => {
+  assert.match(CONTENT, /const ROW_ADDR_RE = \/\[1-9A-HJ-NP-Za-km-z\]\{32,44\}\//);
+  assert.match(CONTENT, /const ROW_ADDR_EXACT_RE = \/\^\[1-9A-HJ-NP-Za-km-z\]\{32,44\}\$\//);
+});
+
+test('an invalid row-props identity falls back to the resolver', async () => {
   const race = bootRace();
   const { harness } = race;
 
-  await harness.doRowBuy(B, null, {
+  const buy = harness.doRowBuy(B, null, {
     mint: A,
     pair: PAIR,
     priceSol: 1,
     priceUsd: 100,
     mcapUsd: 100_000,
   });
+  await waitFor(() => race.isBIdentityRequested());
+  race.releaseB();
+  await buy;
 
-  assert.equal(harness.getState().journal.length, 0, 'a foreign row quote cannot fill');
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B],
+    'a foreign row quote falls back to the tapped address');
   assert.equal(harness.getRowArmed(), null, 'a foreign row quote cannot arm');
   assert.equal(
     race.messages.filter((message) => message.type === 'pt_resolve').length,
+    1,
+    'a rejected row quote uses the resolver cascade',
+  );
+});
+
+test('an inconsistent row-props SOL/USD rate falls back to the resolver', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  const buy = harness.doRowBuy(B, null, {
+    mint: B,
+    priceSol: 1,
+    priceUsd: 1000,
+  });
+  await waitFor(() => race.isBIdentityRequested());
+  race.releaseB();
+  await buy;
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
+  assert.equal(harness.getState().journal[0].priceNative, 1);
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
+    1,
+    'an inconsistent row quote is discarded before the resolver cascade',
+  );
+  assert.equal(harness.getRowArmed(), null);
+});
+
+test('a coherent row-props quote survives when SOL/USD lookup fails', async () => {
+  const race = bootRace({ solUsdFails: true });
+  const { harness } = race;
+
+  await harness.doRowBuy(PAIR, null, {
+    mint: B,
+    pair: PAIR,
+    priceSol: 0.000032,
+    priceUsd: 0.0032,
+  });
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
+  assert.equal(harness.getState().journal[0].priceNative, 0.000032);
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
     0,
-    'a rejected row quote must not fall through to a different price source',
+    'an unavailable SOL/USD rate does not force the resolver cascade',
   );
 });
 

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -38,6 +38,15 @@ function bootRace(options = {}) {
   let cIdentityRequested = false;
   let releaseCIdentity;
   const cIdentity = new Promise((resolve) => { releaseCIdentity = resolve; });
+  let aIdentityPending = options.holdAIdentity === true;
+  let aIdentityRequested = false;
+  let aIdentityRequestCount = 0;
+  let releaseAIdentity;
+  const aIdentity = new Promise((resolve) => { releaseAIdentity = resolve; });
+  let pairIdentityPending = options.holdPairIdentity === true;
+  let pairIdentityRequested = false;
+  let releasePairIdentity;
+  const pairIdentity = new Promise((resolve) => { releasePairIdentity = resolve; });
   let solUsdPending = options.holdSolUsd === true;
   let solUsdRequested = false;
   let releaseSolUsd;
@@ -176,8 +185,15 @@ function bootRace(options = {}) {
         cIdentityRequested = true;
         return cIdentityPending ? cIdentity : Promise.resolve({ mint: C });
       }
-      if (address === A) return Promise.resolve({ mint: A });
-      if (address === PAIR) return Promise.resolve({ mint: B, pool: PAIR });
+      if (address === A) {
+        aIdentityRequested = true;
+        aIdentityRequestCount += 1;
+        return aIdentityPending ? aIdentity : Promise.resolve({ mint: A });
+      }
+      if (address === PAIR) {
+        pairIdentityRequested = true;
+        return pairIdentityPending ? pairIdentity : Promise.resolve({ mint: B, pool: PAIR });
+      }
       return Promise.resolve(null);
     }
     if (payload.type === 'pt_sol_usd') {
@@ -313,6 +329,18 @@ function bootRace(options = {}) {
     storage,
     isBIdentityRequested: () => bIdentityRequested,
     isCIdentityRequested: () => cIdentityRequested,
+    isAIdentityRequested: () => aIdentityRequested,
+    getAIdentityRequestCount: () => aIdentityRequestCount,
+    releaseAIdentity() {
+      aIdentityPending = false;
+      releaseAIdentity({ mint: A });
+    },
+    setHoldAIdentity(value) { aIdentityPending = value; },
+    isPairIdentityRequested: () => pairIdentityRequested,
+    releasePairIdentity() {
+      pairIdentityPending = false;
+      releasePairIdentity({ mint: B, pool: PAIR });
+    },
     releaseB() {
       bIdentityPending = false;
       releaseBIdentity({ mint: B });
@@ -501,13 +529,13 @@ test('a timed-out row buy cannot release a newer latch owner', async () => {
     'a third click is refused while the second buy remains in flight');
   assert.equal(harness.getRowBuyOwner(), secondOwner,
     'the refused third click cannot take ownership');
-  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B],
-    'the first fill may finish, but the newer held operation stays exclusive');
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [],
+    'the superseded first operation never commits alongside the newer owner');
 
   race.releaseC();
   await second;
-  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [C, B],
-    'both original intents eventually commit exactly once');
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [C],
+    'only the non-superseded operation commits');
 });
 
 test('a priced row click still commits without an armed intent', async () => {
@@ -643,26 +671,75 @@ test('a pair-only row-props quote is repaired to the canonical mint', async () =
 });
 
 test('a superseded direct row buy does not commit after watchdog release', async () => {
-  const race = bootRace({ holdSolUsd: true });
+  const race = bootRace({ holdPairIdentity: true });
   const { harness } = race;
 
-  const buy = harness.doRowBuy(PAIR, null, {
-    mint: B,
+  const first = harness.doRowBuy(PAIR, null, {
     pair: PAIR,
     priceSol: 0.000032,
-    priceUsd: 0.0032,
   });
-  await waitFor(() => race.isSolUsdRequested());
+  await waitFor(() => race.isPairIdentityRequested());
   const startedAt = harness.getRowBuyInFlightAt();
 
   await harness.enableOverlay();
   race.setNow(startedAt + 20_001);
   await race.advance(1);
-  await buy;
+  const second = harness.doRowBuy(PAIR, null, {
+    mint: B,
+    pair: PAIR,
+    priceSol: 0.000032,
+  });
+  await second;
+  race.releasePairIdentity();
+  await first;
 
-  assert.equal(harness.getState().journal.length, 0,
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B],
     'a watchdog-superseded direct operation must not commit');
   assert.equal(harness.getRowBuyInFlight(), false);
+});
+
+test('a superseded armed flush does not commit and stays armed', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  await harness.doRowBuy(A);
+  assert.ok(harness.getRowArmed(), 'A should be armed before its retry');
+  race.setHoldAIdentity(true);
+  const aIdentityRequests = race.getAIdentityRequestCount();
+  harness.noteRowPrice({
+    mint: A,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'A',
+    name: 'Token A',
+  });
+  await waitFor(() => race.getAIdentityRequestCount() > aIdentityRequests);
+  const startedAt = harness.getRowBuyInFlightAt();
+
+  await harness.enableOverlay();
+  race.setNow(startedAt + 20_001);
+  await race.advance(1);
+  await harness.doRowBuy(PAIR, null, {
+    mint: B,
+    pair: PAIR,
+    priceSol: 0.000032,
+  });
+  race.releaseAIdentity();
+  await waitFor(() => !harness.getRowArmedFlushing());
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B],
+    'a watchdog-superseded armed operation must not commit');
+  assert.equal(harness.getRowArmed().address, A,
+    'a superseded armed intent remains available for retry');
+
+  harness.noteRowPrice({
+    mint: A,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'A',
+    name: 'Token A',
+  });
+  await waitFor(() => harness.getState().journal.length === 2);
+  assert.equal(harness.getState().journal[0].mint, A,
+    'the retained armed intent commits on a later wake');
 });
 
 test('a coherent row-props quote fills when SOL/USD lookup hangs', async () => {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -47,6 +47,10 @@ function bootRace(options = {}) {
   let pairIdentityRequested = false;
   let releasePairIdentity;
   const pairIdentity = new Promise((resolve) => { releasePairIdentity = resolve; });
+  let stateReadPending = false;
+  let stateReadRequested = false;
+  let releaseStateRead;
+  const stateRead = new Promise((resolve) => { releaseStateRead = resolve; });
   let solUsdPending = options.holdSolUsd === true;
   let solUsdRequested = false;
   let releaseSolUsd;
@@ -232,8 +236,20 @@ function bootRace(options = {}) {
     storage: {
       local: {
         get(keys, callback) {
+          const requestedKeys = Array.isArray(keys) ? keys : [keys];
+          if (stateReadPending && requestedKeys.includes('pt_state')) {
+            stateReadRequested = true;
+            stateRead.then(() => {
+              const out = {};
+              for (const key of requestedKeys) {
+                if (key in storage) out[key] = storage[key];
+              }
+              callback(out);
+            });
+            return;
+          }
           const out = {};
-          for (const key of (Array.isArray(keys) ? keys : [keys])) {
+          for (const key of requestedKeys) {
             if (key in storage) out[key] = storage[key];
           }
           callback(out);
@@ -340,6 +356,12 @@ function bootRace(options = {}) {
     releasePairIdentity() {
       pairIdentityPending = false;
       releasePairIdentity({ mint: B, pool: PAIR });
+    },
+    isStateReadRequested: () => stateReadRequested,
+    setHoldStateRead(value) { stateReadPending = value; },
+    releaseStateRead() {
+      stateReadPending = false;
+      releaseStateRead();
     },
     releaseB() {
       bIdentityPending = false;
@@ -679,6 +701,9 @@ test('a superseded direct row buy does not commit after watchdog release', async
     priceSol: 0.000032,
   });
   await waitFor(() => race.isPairIdentityRequested());
+  race.releasePairIdentity();
+  race.setHoldStateRead(true);
+  await waitFor(() => race.isStateReadRequested());
   const startedAt = harness.getRowBuyInFlightAt();
 
   await harness.enableOverlay();
@@ -689,8 +714,9 @@ test('a superseded direct row buy does not commit after watchdog release', async
     pair: PAIR,
     priceSol: 0.000032,
   });
+  await waitFor(() => harness.getRowBuyOwner() > 1);
+  race.releaseStateRead();
   await second;
-  race.releasePairIdentity();
   await first;
 
   assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B],

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -19,6 +19,7 @@ const SITES = fs.readFileSync(path.join(ROOT, 'sites.js'), 'utf8');
 const A = 'A'.repeat(32);
 const B = 'B'.repeat(32);
 const C = 'C'.repeat(32);
+const PAIR = 'P'.repeat(32);
 
 function bootRace(options = {}) {
   let clock = Date.now();
@@ -519,6 +520,55 @@ test('a priced row click still commits without an armed intent', async () => {
 
   assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
   assert.equal(harness.getRowArmed(), null, 'a priced click does not create an armed intent');
+});
+
+test('a row-props quote fills at the tapped price without resolver or identity lookup', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  await harness.doRowBuy(PAIR, null, {
+    mint: B,
+    pair: PAIR,
+    priceSol: 0.000032,
+    priceUsd: 0.0032,
+    mcapUsd: 3200,
+    supply: 100_000_000,
+  });
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
+  assert.equal(harness.getRowArmed(), null, 'a valid row-props quote never arms');
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
+    0,
+    'row-props pricing skips the resolver cascade',
+  );
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_onchain_prewatch').length,
+    0,
+    'an authoritative row-props mint skips identity probing',
+  );
+  assert.equal(harness.getState().journal[0].priceNative, 0.000032);
+});
+
+test('an invalid row-props identity is refused instead of filling or arming', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  await harness.doRowBuy(B, null, {
+    mint: A,
+    pair: PAIR,
+    priceSol: 1,
+    priceUsd: 100,
+    mcapUsd: 100_000,
+  });
+
+  assert.equal(harness.getState().journal.length, 0, 'a foreign row quote cannot fill');
+  assert.equal(harness.getRowArmed(), null, 'a foreign row quote cannot arm');
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
+    0,
+    'a rejected row quote must not fall through to a different price source',
+  );
 });
 
 test('a row buy still expires at its existing TTL', async () => {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -327,7 +327,16 @@ function bootRace(options = {}) {
     getAResolveRequestCount: () => aResolveRequestCount,
     releaseAResolve() {
       aResolvePending = false;
-      releaseAResolve(null);
+      releaseAResolve({
+        mint: A,
+        pairAddress: null,
+        symbol: 'A',
+        name: 'Token A',
+        priceNative: 1,
+        priceUsd: 100,
+        mcap: 100_000,
+        priceSource: 'resolver',
+      });
     },
     setHoldResolveA(value) { aResolvePending = value; },
     releaseB() {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -38,6 +38,11 @@ function bootRace(options = {}) {
   let cIdentityRequested = false;
   let releaseCIdentity;
   const cIdentity = new Promise((resolve) => { releaseCIdentity = resolve; });
+  let aResolvePending = options.holdResolveA === true;
+  let aResolveRequested = false;
+  let aResolveRequestCount = 0;
+  let releaseAResolve;
+  const aResolve = new Promise((resolve) => { releaseAResolve = resolve; });
   let solUsdPending = options.holdSolUsd === true;
   let solUsdRequested = false;
   let releaseSolUsd;
@@ -139,6 +144,11 @@ function bootRace(options = {}) {
   function sendMessage(payload) {
     messages.push(payload);
     if (payload.type === 'pt_resolve') {
+      if (payload.address === A) {
+        aResolveRequested = true;
+        aResolveRequestCount += 1;
+        return aResolvePending ? aResolve : Promise.resolve(null);
+      }
       if (payload.address === B) {
         if (options.unpricedB) return Promise.resolve(null);
         return Promise.resolve({
@@ -177,6 +187,7 @@ function bootRace(options = {}) {
         return cIdentityPending ? cIdentity : Promise.resolve({ mint: C });
       }
       if (address === A) return Promise.resolve({ mint: A });
+      if (address === PAIR) return Promise.resolve({ mint: B, pool: PAIR });
       return Promise.resolve(null);
     }
     if (payload.type === 'pt_sol_usd') {
@@ -312,6 +323,13 @@ function bootRace(options = {}) {
     storage,
     isBIdentityRequested: () => bIdentityRequested,
     isCIdentityRequested: () => cIdentityRequested,
+    isAResolveRequested: () => aResolveRequested,
+    getAResolveRequestCount: () => aResolveRequestCount,
+    releaseAResolve() {
+      aResolvePending = false;
+      releaseAResolve(null);
+    },
+    setHoldResolveA(value) { aResolvePending = value; },
     releaseB() {
       bIdentityPending = false;
       releaseBIdentity({ mint: B });
@@ -621,6 +639,118 @@ test('a coherent row-props quote survives when SOL/USD lookup fails', async () =
     race.messages.filter((message) => message.type === 'pt_resolve').length,
     0,
     'an unavailable SOL/USD rate does not force the resolver cascade',
+  );
+});
+
+test('a pair-only row-props quote is repaired to the canonical mint', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  await harness.doRowBuy(PAIR, null, {
+    pair: PAIR,
+    priceSol: 0.000032,
+  });
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_onchain_prewatch').length,
+    1,
+    'a pair-only quote must perform the identity prewatch',
+  );
+});
+
+test('a superseded direct row buy does not commit after watchdog release', async () => {
+  const race = bootRace({ holdSolUsd: true });
+  const { harness } = race;
+
+  const buy = harness.doRowBuy(PAIR, null, {
+    mint: B,
+    pair: PAIR,
+    priceSol: 0.000032,
+    priceUsd: 0.0032,
+  });
+  await waitFor(() => race.isSolUsdRequested());
+  const startedAt = harness.getRowBuyInFlightAt();
+
+  await harness.enableOverlay();
+  race.setNow(startedAt + 20_001);
+  await race.advance(1);
+  await buy;
+
+  assert.equal(harness.getState().journal.length, 0,
+    'a watchdog-superseded direct operation must not commit');
+  assert.equal(harness.getRowBuyInFlight(), false);
+});
+
+test('a superseded armed flush stays armed for a later retry', async () => {
+  const race = bootRace({ holdSolUsd: true });
+  const { harness } = race;
+
+  await harness.doRowBuy(A);
+  assert.ok(harness.getRowArmed(), 'A should be armed before the competing click');
+  race.setHoldResolveA(true);
+
+  const competing = harness.doRowBuy(PAIR, null, {
+    mint: B,
+    pair: PAIR,
+    priceSol: 0.000032,
+    priceUsd: 0.0032,
+  });
+  await waitFor(() => race.isSolUsdRequested());
+  const startedAt = harness.getRowBuyInFlightAt();
+
+  const aResolveRequests = race.getAResolveRequestCount();
+  harness.noteRowPrice({
+    mint: A,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'A',
+    name: 'Token A',
+  });
+  await waitFor(() => race.getAResolveRequestCount() > aResolveRequests);
+
+  await harness.enableOverlay();
+  race.setNow(startedAt + 20_001);
+  await race.advance(1);
+  race.releaseSolUsd();
+  await competing;
+  race.releaseAResolve();
+  await waitFor(() => !harness.getRowArmedFlushing());
+
+  assert.equal(harness.getState().journal.length, 0,
+    'the superseded armed flush must not commit');
+  assert.equal(harness.getRowArmed().address, A,
+    'the superseded armed intent remains available for retry');
+
+  harness.noteRowPrice({
+    mint: A,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'A',
+    name: 'Token A',
+  });
+  await waitFor(() => harness.getState().journal.length === 1);
+  assert.equal(harness.getState().journal[0].mint, A,
+    'the retained armed intent commits on a later wake');
+});
+
+test('a coherent row-props quote fills when SOL/USD lookup hangs', async () => {
+  const race = bootRace({ holdSolUsd: true });
+  const { harness } = race;
+
+  const buy = harness.doRowBuy(PAIR, null, {
+    mint: B,
+    pair: PAIR,
+    priceSol: 0.000032,
+    priceUsd: 0.0032,
+  });
+  await waitFor(() => race.isSolUsdRequested());
+  await race.advance(2_001);
+  await buy;
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
+    0,
+    'a timed-out SOL/USD witness does not force resolver pricing',
   );
 });
 

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -38,11 +38,6 @@ function bootRace(options = {}) {
   let cIdentityRequested = false;
   let releaseCIdentity;
   const cIdentity = new Promise((resolve) => { releaseCIdentity = resolve; });
-  let aResolvePending = options.holdResolveA === true;
-  let aResolveRequested = false;
-  let aResolveRequestCount = 0;
-  let releaseAResolve;
-  const aResolve = new Promise((resolve) => { releaseAResolve = resolve; });
   let solUsdPending = options.holdSolUsd === true;
   let solUsdRequested = false;
   let releaseSolUsd;
@@ -144,11 +139,6 @@ function bootRace(options = {}) {
   function sendMessage(payload) {
     messages.push(payload);
     if (payload.type === 'pt_resolve') {
-      if (payload.address === A) {
-        aResolveRequested = true;
-        aResolveRequestCount += 1;
-        return aResolvePending ? aResolve : Promise.resolve(null);
-      }
       if (payload.address === B) {
         if (options.unpricedB) return Promise.resolve(null);
         return Promise.resolve({
@@ -323,22 +313,6 @@ function bootRace(options = {}) {
     storage,
     isBIdentityRequested: () => bIdentityRequested,
     isCIdentityRequested: () => cIdentityRequested,
-    isAResolveRequested: () => aResolveRequested,
-    getAResolveRequestCount: () => aResolveRequestCount,
-    releaseAResolve() {
-      aResolvePending = false;
-      releaseAResolve({
-        mint: A,
-        pairAddress: null,
-        symbol: 'A',
-        name: 'Token A',
-        priceNative: 1,
-        priceUsd: 100,
-        mcap: 100_000,
-        priceSource: 'resolver',
-      });
-    },
-    setHoldResolveA(value) { aResolvePending = value; },
     releaseB() {
       bIdentityPending = false;
       releaseBIdentity({ mint: B });
@@ -689,56 +663,6 @@ test('a superseded direct row buy does not commit after watchdog release', async
   assert.equal(harness.getState().journal.length, 0,
     'a watchdog-superseded direct operation must not commit');
   assert.equal(harness.getRowBuyInFlight(), false);
-});
-
-test('a superseded armed flush stays armed for a later retry', async () => {
-  const race = bootRace({ holdSolUsd: true });
-  const { harness } = race;
-
-  await harness.doRowBuy(A);
-  assert.ok(harness.getRowArmed(), 'A should be armed before the competing click');
-  race.setHoldResolveA(true);
-
-  const competing = harness.doRowBuy(PAIR, null, {
-    mint: B,
-    pair: PAIR,
-    priceSol: 0.000032,
-    priceUsd: 0.0032,
-  });
-  await waitFor(() => race.isSolUsdRequested());
-  const startedAt = harness.getRowBuyInFlightAt();
-
-  const aResolveRequests = race.getAResolveRequestCount();
-  harness.noteRowPrice({
-    mint: A,
-    candidates: [{ unit: 'usd', value: 100 }],
-    symbol: 'A',
-    name: 'Token A',
-  });
-  await waitFor(() => race.getAResolveRequestCount() > aResolveRequests);
-
-  await harness.enableOverlay();
-  race.setNow(startedAt + 20_001);
-  await race.advance(1);
-  race.releaseSolUsd();
-  await competing;
-  race.releaseAResolve();
-  await waitFor(() => !harness.getRowArmedFlushing());
-
-  assert.equal(harness.getState().journal.length, 0,
-    'the superseded armed flush must not commit');
-  assert.equal(harness.getRowArmed().address, A,
-    'the superseded armed intent remains available for retry');
-
-  harness.noteRowPrice({
-    mint: A,
-    candidates: [{ unit: 'usd', value: 100 }],
-    symbol: 'A',
-    name: 'Token A',
-  });
-  await waitFor(() => harness.getState().journal.length === 1);
-  assert.equal(harness.getState().journal[0].mint, A,
-    'the retained armed intent commits on a later wake');
 });
 
 test('a coherent row-props quote fills when SOL/USD lookup hangs', async () => {

--- a/extension/test/rowfillaccuracy.test.js
+++ b/extension/test/rowfillaccuracy.test.js
@@ -91,8 +91,8 @@ test('a first buy with no position anchors on the row\'s own print', () => {
   const body = bodyOf('async function rowPrintVouchesFirstBuy(');
   assert.match(body, /if \(posAnchor\) return true/,
     'an existing position keeps the F-56 anchor and skips this gate');
-  assert.match(body, /data\.priceSource === 'row-feed' \|\| data\.priceSource === 'row-onchain'/,
-    'row-fed and chain-fed candidates are exempt (the print IS their source)');
+  assert.match(body, /data\.priceSource === 'row-feed' \|\| data\.priceSource === 'row-props'\s*\n\s*\|\| data\.priceSource === 'row-onchain'/,
+    'page-row and chain-fed candidates are exempt (the print IS their source)');
   assert.match(body, /recentRowPrices\.get\(data\.pairAddress\)/,
     'the row print is looked up by every identity');
   assert.match(body, /> 2/, 'an aggregator diverging >2x from the print needs a witness');

--- a/extension/test/rowprops.test.js
+++ b/extension/test/rowprops.test.js
@@ -100,6 +100,18 @@ test('a richer neighboring fiber cannot replace the tapped row record', () => {
   assert.equal(quote.priceUsd, null);
 });
 
+test('a parent price is not inherited by a descendant identity record', () => {
+  const row = makeRow({
+    priceSol: 9,
+    child: { tokenAddress: A, pairAddress: PAIR },
+  });
+  assert.equal(
+    quoteExtractor()(row, A),
+    null,
+    'identity and price must come from the same coherent record',
+  );
+});
+
 test('unitless prices and percentage changes never become row quotes', () => {
   const extract = quoteExtractor();
   assert.equal(extract(makeRow({

--- a/extension/test/rowprops.test.js
+++ b/extension/test/rowprops.test.js
@@ -45,6 +45,7 @@ function makeRow(memoizedProps, memoizedState) {
 test('a tapped Axiom row yields its coherent mint, pair, SOL and USD quote', () => {
   const row = makeRow(
     {
+      tokenAddress: A,
       tokenPriceUsd: 0.003295168220388057,
       marketCapUsd: 3244624.7223963863,
       row: {
@@ -102,7 +103,8 @@ test('a richer neighboring fiber cannot replace the tapped row record', () => {
 
 test('a parent price is not inherited by a descendant identity record', () => {
   const row = makeRow({
-    priceSol: 9,
+    tokenPriceUsd: 900,
+    marketCapUsd: 900_000,
     child: { tokenAddress: A, pairAddress: PAIR },
   });
   assert.equal(

--- a/extension/test/rowprops.test.js
+++ b/extension/test/rowprops.test.js
@@ -1,0 +1,124 @@
+/* Axiom row-props quotes must come from one coherent, tapped row record.
+ *
+ * The bridge walks the tapped row's React fiber only at click time. These
+ * tests drive the shipped extractor against the record shape captured from
+ * the logged-in Axiom board, including its separate USD props candidate.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const BRIDGE = fs.readFileSync(path.join(ROOT, 'price-bridge.js'), 'utf8');
+const A = 'A'.repeat(32);
+const B = 'B'.repeat(32);
+const PAIR = 'P'.repeat(32);
+
+function quoteExtractor() {
+  const start = BRIDGE.indexOf('function rowQuoteFromFiber(');
+  const end = BRIDGE.indexOf('function findRowContainer(', start);
+  assert.ok(start !== -1 && end > start, 'rowQuoteFromFiber must ship in the bridge');
+  const context = {
+    BASE58_RE: /^[1-9A-HJ-NP-Za-km-z]{32,44}$/,
+    numberValue(value) {
+      if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+      if (typeof value === 'string' && value.length <= 64) {
+        const number = Number(value.replace(/[$,\s]/g, ''));
+        return Number.isFinite(number) ? number : null;
+      }
+      return null;
+    },
+  };
+  vm.createContext(context);
+  vm.runInContext(BRIDGE.slice(start, end), context, { filename: 'price-bridge.js' });
+  return context.rowQuoteFromFiber;
+}
+
+function makeRow(memoizedProps, memoizedState) {
+  const row = {};
+  row.__reactFiber$test = { memoizedProps, memoizedState };
+  return row;
+}
+
+test('a tapped Axiom row yields its coherent mint, pair, SOL and USD quote', () => {
+  const row = makeRow(
+    {
+      tokenPriceUsd: 0.003295168220388057,
+      marketCapUsd: 3244624.7223963863,
+      row: {
+        tokenAddress: A,
+        pairAddress: PAIR,
+        priceSol: 0.00003229290690305818,
+        marketCapSol: 31797.576660097864,
+        supply: 984661329.98038,
+      },
+    },
+    {},
+  );
+  const quote = quoteExtractor()(row, A);
+
+  assert.deepEqual(JSON.parse(JSON.stringify(quote)), {
+    mint: A,
+    pair: PAIR,
+    priceSol: 0.00003229290690305818,
+    priceUsd: 0.003295168220388057,
+    mcapUsd: 3244624.7223963863,
+    supply: 984661329.98038,
+  });
+});
+
+test('a record for another token is discarded by the tapped identity guard', () => {
+  const row = makeRow({
+    tokenAddress: B,
+    pairAddress: PAIR,
+    priceSol: 1,
+    tokenPriceUsd: 100,
+  });
+  assert.equal(quoteExtractor()(row, A), null);
+});
+
+test('a richer neighboring fiber cannot replace the tapped row record', () => {
+  const row = {};
+  row.__reactFiber$test = {
+    memoizedProps: { tokenAddress: A, priceSol: 0.1 },
+    sibling: {
+      memoizedProps: {
+        tokenAddress: B,
+        pairAddress: PAIR,
+        priceSol: 9,
+        tokenPriceUsd: 900,
+        marketCapUsd: 900_000,
+        supply: 100_000,
+      },
+    },
+  };
+  const quote = quoteExtractor()(row, A);
+  assert.equal(quote.mint, A);
+  assert.equal(quote.priceSol, 0.1);
+  assert.equal(quote.priceUsd, null);
+});
+
+test('unitless prices and percentage changes never become row quotes', () => {
+  const extract = quoteExtractor();
+  assert.equal(extract(makeRow({
+    tokenAddress: A,
+    pairAddress: PAIR,
+    price: 1,
+    price1minChange: 2,
+    price24h: 3,
+  }), A), null);
+  assert.equal(extract(makeRow({
+    tokenAddress: A,
+    price1minChange: 1,
+    price24hChange: 2,
+  }), A), null);
+});
+
+test('the row-buy bridge message carries the quote from the tapped row', () => {
+  assert.match(
+    BRIDGE,
+    /emit\('row-buy',\s*\{\s*address: entry\.address,\s*quote: rowQuoteFromFiber\(entry\.row, entry\.address\),/s,
+  );
+});


### PR DESCRIPTION
## Summary

Stacked on #100 (same functions). The user's verdict on the armed-buy path: *"every single tab u open, the chart is already loaded on the website, therefore the info needed for the extension to run should be there, there shouldn't randomly need a need for an armed or whatever"*. He's right, and on the Axiom board the price is not just on screen — it's in the row's own React props.

Captured live over CDP from the logged-in board (see `/home/ubuntu/axiom-row-props.md` in the session; excerpt below), every screener row carries one coherent, unit-explicit record:

```
props.row.tokenAddress = "BKXtSJ…"      // the real MINT
props.row.pairAddress  = "3BJjyr…"
props.row.priceSol     = 0.0000322929
props.row.marketCapSol = 31797.58
props.row.supply       = 984661329.98
props.tokenPriceUsd    = 0.00329517
props.marketCapUsd     = 3244624.72     // == the "$3.24M" the row prints
```

Cross-checks on that capture: two different rows imply the same SOL/USD rate (102.04 both), `supply * priceSol == marketCapSol`, and `marketCapUsd` equals the figure on screen. So the tap has the mint, the pair, a SOL price and a USD price with no conversion of ours involved — the resolver round trip, the `recentRowPrices` key guessing and the armed fallback were all unnecessary on this site.

The chip tap now reads that record from the tapped row's fiber and sends it with the click, and it becomes the primary source:

```js
data = { mint: quote.mint || address, pairAddress: quote.pair,
         priceNative: quote.priceSol, priceUsd: quote.priceUsd,
         mcap: quote.mcapUsd, priceSource: 'row-props' };
```

Consequences, all of them things that bit users:

- **No arming on Axiom.** A tap prices instantly from the number on screen instead of waiting for an aggregator to index a coin minutes old.
- **No stand-in keys.** `tokenAddress` is the real mint, so the F-61 graduation-boundary class (buy on the board, bag missing when the coin bonds) can't arise on this path — the `onchainPrewatch` identity probe is skipped as redundant.
- **No cross-key rescale.** The F-59 `recentRowPrices` rescale is skipped for `row-props`; rescaling a price by a differently-keyed tick is the prime suspect for the ~50,000x mispriced fill seen in live testing.

## Honesty constraints

The extractor is deliberately narrow, because a wrong number here is worse than no number:

- Only exact, unit-explicit keys are read (`priceSol`/`priceNative`, `tokenPriceUsd`/`priceUsd`, `marketCapSol`/`marketCapUsd`, `supply`, `tokenAddress`/`mint`, `pairAddress`). A bare `price` with no denomination is rejected outright, and `/change|pct|percent|min|hr|24h|ratio/` keys are excluded — the row carries `price1minChange` and friends right beside the price.
- **Identity and price must come from the same object.** The only cross-object step is merging USD fields onto the selected record via an exact `tokenAddress` match. A parent holding USD numbers with no identity of its own cannot borrow one from a child, and that negative is pinned by a test.
- The record must name the tapped chip's own address, or it is discarded — a re-sorted board can't hand us a neighbour's price.
- **The quote must agree with itself.** When it carries both prices, `priceUsd / priceSol` is the site's own SOL/USD rate and must land within 1.25x of ours; a record whose two halves contradict each other is dropped rather than half-used. If `solUsd()` is unavailable the check is skipped rather than blocking the fill.
- Content-side validation re-checks everything (the bridge lives in the page world), and anything that fails falls back to the existing resolver cascade — never a refused tap, never a fill on an unverified number.
- The witness gates still apply: `row-props` joins `row-feed` as first-buy-exempt (the row print *is* the source), and a >2x jump from the wallet's own last mark still needs a resolver witness.

The armed path stays for sites with no such record (Padre, GMGN); on Axiom it becomes unreachable.

The extractor is tested against the recorded live shape; not yet re-exercised on a live board.

## Review follow-ups

- **Pair-only quotes no longer strand a bag.** Skipping the `onchainPrewatch` identity repair for *every* `row-props` quote reintroduced the stand-in-key class #96 heals: a mint-less record keyed the fill by the pair. The skip is gone entirely — the pre-existing `(!data.mint || data.mint === address)` guard already declines to probe when the quote carries a real distinct mint, so the fast path survives and pair-only quotes get their canonical mint.
- **The rate lookup is bounded** (2 s), so a stalled `solUsd()` can't hold a tap open; a timeout degrades to "no rate", which the consistency check already skips on.
- **A superseded fill can't commit.** `fillRowBuy` now takes the row-buy generation and re-checks it immediately before the wallet mutation, rather than at the call site — the call site is on the wrong side of its own awaits (first-buy vouch, resolver witness, prewatch, persistence), so a buy the 20 s watchdog had given up on could still land beside a newer one. A superseded armed flush returns `null` and stays armed for its existing retry.

Extension suite 2,169 passed / 0 failed.


Link to Devin session: https://app.devin.ai/sessions/b676704d774f4aa099ba7f31381b036f
Open in Devin Desktop: https://app.devin.ai/desktop/session/b676704d774f4aa099ba7f31381b036f?variant=devin
Requested by: @OnlyTerp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/papertrench/pull/101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->