### PR TITLE
feat(quickbuy): price a GMGN chip tap from the row's own props, with the price unit proven

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -6669,12 +6669,27 @@
     const pair = quote.pair || null;
     if ((mint && !ROW_ADDR_EXACT_RE.test(mint)) || (pair && !ROW_ADDR_EXACT_RE.test(pair))) return false;
     if ((!mint && !pair) || (mint !== address && pair !== address)) return false;
-    if (!(Number.isFinite(Number(quote.priceSol)) && Number(quote.priceSol) > 0)) return false;
+    const hasPriceSol = quote.priceSol != null;
+    const hasPriceUsd = quote.priceUsd != null;
+    if (!hasPriceSol && !hasPriceUsd) return false;
     for (const name of ['priceUsd', 'mcapUsd', 'supply']) {
       if (quote[name] != null
         && !(Number.isFinite(Number(quote[name])) && Number(quote[name]) > 0)) return false;
     }
-    if (quote.priceUsd != null) {
+    if (hasPriceSol
+        && !(Number.isFinite(Number(quote.priceSol)) && Number(quote.priceSol) > 0)) return false;
+    if (hasPriceUsd && !hasPriceSol) {
+      if (!(quote.supply > 0 && quote.mcapUsd > 0)
+          || Math.abs(Number(quote.priceUsd) * Number(quote.supply)
+            / Number(quote.mcapUsd) - 1) > 0.02) return false;
+      const rate = await Promise.race([
+        Promise.resolve().then(() => R.solUsd()).catch(() => 0),
+        new Promise((resolve) => setTimeout(() => resolve(0), 2000)),
+      ]);
+      if (!(rate > 0)) return false;
+      return { ...quote, priceSol: Number(quote.priceUsd) / Number(rate) };
+    }
+    if (hasPriceUsd) {
       const implied = Number(quote.priceUsd) / Number(quote.priceSol);
       const rate = await Promise.race([
         Promise.resolve().then(() => R.solUsd()).catch(() => 0),
@@ -6683,7 +6698,7 @@
       if (rate > 0 && (!(implied > 0)
         || Math.max(implied / rate, rate / implied) > 1.25)) return false;
     }
-    return true;
+    return { ...quote, priceSol: Number(quote.priceSol) };
   }
 
   /**
@@ -7024,15 +7039,16 @@
       // nothing below may block this function's finally forever.
       const ROW_CASCADE_TIMEOUT_MS = 10_000;
       let data = null;
-      if (rowQuote && await validRowPropsQuote(rowQuote, address)) {
+      const validRowQuote = rowQuote && await validRowPropsQuote(rowQuote, address);
+      if (validRowQuote) {
         data = {
-          mint: rowQuote.mint || address,
-          pairAddress: rowQuote.pair || null,
+          mint: validRowQuote.mint || address,
+          pairAddress: validRowQuote.pair || null,
           symbol: null,
           name: null,
-          priceNative: rowQuote.priceSol,
-          priceUsd: rowQuote.priceUsd || null,
-          mcap: rowQuote.mcapUsd || null,
+          priceNative: validRowQuote.priceSol,
+          priceUsd: validRowQuote.priceUsd || null,
+          mcap: validRowQuote.mcapUsd || null,
           priceSource: 'row-props',
         };
       } else {

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3594,11 +3594,11 @@
         const fields = {};
         let barePrice = null;
         for (const [name, value] of Object.entries(obj)) {
-          if (badKey.test(name)) continue;
           if (identityKeys.has(name)) {
             if (typeof value === 'string' && BASE58_RE.test(value)) fields[name] = value;
             continue;
           }
+          if (badKey.test(name)) continue;
           if (name === 'supply' || name === 'total_supply' || name === 'totalSupply'
               || priceKeys.has(name)) {
             const number = numberValue(value);
@@ -3610,11 +3610,13 @@
             if (number !== null && number > 0) barePrice = number;
           }
         }
-        if (fields.address !== undefined) fields.mint = fields.address;
-        if (fields.pool_address !== undefined) fields.pair = fields.pool_address;
-        if (fields.total_supply !== undefined) fields.supply = fields.total_supply;
-        if (fields.totalSupply !== undefined) fields.supply = fields.totalSupply;
-        if (fields.usd_market_cap !== undefined) fields.mcapUsd = fields.usd_market_cap;
+        if (fields.address !== undefined && fields.mint === undefined) fields.mint = fields.address;
+        if (fields.pool_address !== undefined && fields.pair === undefined) fields.pair = fields.pool_address;
+        if (fields.total_supply !== undefined && fields.supply === undefined) fields.supply = fields.total_supply;
+        if (fields.totalSupply !== undefined && fields.supply === undefined) fields.supply = fields.totalSupply;
+        if (fields.usd_market_cap !== undefined && fields.mcapUsd === undefined) {
+          fields.mcapUsd = fields.usd_market_cap;
+        }
         const barePriceProven = barePrice !== null && fields.supply > 0 && fields.mcapUsd > 0
           && Math.abs(barePrice * fields.supply / fields.mcapUsd - 1) <= 0.02;
         if (barePriceProven) {

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3581,26 +3581,48 @@
       const seen = new Set();
       const stack = [start];
       const candidates = [];
-      const identityKeys = new Set(['tokenAddress', 'mint', 'pairAddress']);
+      const identityKeys = new Set([
+        'tokenAddress', 'mint', 'address', 'pairAddress', 'pool_address',
+      ]);
       const priceKeys = new Set([
         'priceSol', 'priceNative', 'tokenPriceUsd', 'priceUsd',
-        'marketCapSol', 'marketCapUsd',
+        'marketCapSol', 'marketCapUsd', 'usd_market_cap',
       ]);
       const badKey = /change|pct|percent|min|hr|24h|ratio/i;
       const fieldsFor = (obj) => {
         if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return null;
         const fields = {};
+        let barePrice = null;
         for (const [name, value] of Object.entries(obj)) {
           if (badKey.test(name)) continue;
           if (identityKeys.has(name)) {
             if (typeof value === 'string' && BASE58_RE.test(value)) fields[name] = value;
             continue;
           }
-          if (name === 'supply' || priceKeys.has(name)) {
+          if (name === 'supply' || name === 'total_supply' || name === 'totalSupply'
+              || priceKeys.has(name)) {
             const number = numberValue(value);
             if (number !== null && number > 0) fields[name] = number;
+            continue;
+          }
+          if (name === 'price') {
+            const number = numberValue(value);
+            if (number !== null && number > 0) barePrice = number;
           }
         }
+        if (fields.address !== undefined) fields.mint = fields.address;
+        if (fields.pool_address !== undefined) fields.pair = fields.pool_address;
+        if (fields.total_supply !== undefined) fields.supply = fields.total_supply;
+        if (fields.totalSupply !== undefined) fields.supply = fields.totalSupply;
+        if (fields.usd_market_cap !== undefined) fields.mcapUsd = fields.usd_market_cap;
+        const barePriceProven = barePrice !== null && fields.supply > 0 && fields.mcapUsd > 0
+          && Math.abs(barePrice * fields.supply / fields.mcapUsd - 1) <= 0.02;
+        if (barePriceProven) {
+          fields.priceUsd = barePrice;
+        }
+        const hasExplicitPrice = fields.priceSol !== undefined || fields.priceNative !== undefined
+          || fields.tokenPriceUsd !== undefined || fields.priceUsd !== undefined;
+        if (barePrice !== null && !barePriceProven && !hasExplicitPrice) return null;
         return fields;
       };
       const walk = (obj, depth) => {
@@ -3626,7 +3648,9 @@
       const matching = candidates.filter((fields) =>
         fields.tokenAddress === tappedAddress
         || fields.mint === tappedAddress
-        || fields.pairAddress === tappedAddress);
+        || fields.address === tappedAddress
+        || fields.pairAddress === tappedAddress
+        || fields.pair === tappedAddress);
       if (!matching.length) return null;
       const selected = matching.reduce((best, fields) =>
         !best || Object.keys(fields).length > Object.keys(best).length ? fields : best, null);
@@ -3643,12 +3667,12 @@
         }
       }
       return {
-        mint: merged.tokenAddress || merged.mint || null,
-        pair: merged.pairAddress || null,
+        mint: merged.tokenAddress || merged.mint || merged.address || null,
+        pair: merged.pairAddress || merged.pair || merged.pool_address || null,
         priceSol: merged.priceSol || merged.priceNative || null,
         priceUsd: merged.tokenPriceUsd || merged.priceUsd || null,
-        mcapUsd: merged.marketCapUsd || null,
-        supply: merged.supply || null,
+        mcapUsd: merged.marketCapUsd || merged.mcapUsd || null,
+        supply: merged.supply || merged.total_supply || merged.totalSupply || null,
       };
     } catch (_) {
       return null;

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -602,6 +602,55 @@ test('a row-props quote fills at the tapped price without resolver or identity l
   assert.equal(harness.getState().journal[0].priceNative, 0.000032);
 });
 
+test('a USD-only GMGN row-props quote converts with the site rate', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  const buy = harness.doRowBuy(B, null, {
+    mint: B,
+    pair: PAIR,
+    priceUsd: 0.0032,
+    mcapUsd: 3200,
+    supply: 1_000_000,
+  });
+  await waitFor(() => race.isBIdentityRequested());
+  race.releaseB();
+  await buy;
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
+  assert.equal(harness.getState().journal[0].priceNative, 0.000032);
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
+    0,
+    'a reconciled GMGN quote skips the resolver cascade',
+  );
+});
+
+test('a USD-only row-props quote without a SOL/USD rate falls back', async () => {
+  const race = bootRace({ solUsdFails: true });
+  const { harness } = race;
+
+  const buy = harness.doRowBuy(B, null, {
+    mint: B,
+    pair: PAIR,
+    priceUsd: 0.0032,
+    mcapUsd: 3200,
+    supply: 1_000_000,
+  });
+  await waitFor(() => race.isBIdentityRequested());
+  race.releaseB();
+  await buy;
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
+  assert.equal(harness.getState().journal[0].priceNative, 1);
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
+    1,
+    'an unavailable conversion rate uses the resolver cascade',
+  );
+  assert.equal(harness.getRowArmed(), null, 'a quote with no conversion rate does not arm');
+});
+
 test('row-props validation has its own exact address check', () => {
   assert.match(CONTENT, /const ROW_ADDR_RE = \/\[1-9A-HJ-NP-Za-km-z\]\{32,44\}\//);
   assert.match(CONTENT, /const ROW_ADDR_EXACT_RE = \/\^\[1-9A-HJ-NP-Za-km-z\]\{32,44\}\$\//);

--- a/extension/test/rowprops.test.js
+++ b/extension/test/rowprops.test.js
@@ -150,6 +150,40 @@ test('a GMGN row proves its bare price is USD from supply and market cap', () =>
   });
 });
 
+test('an explicit mint wins over an unrelated generic address', () => {
+  const row = makeRow({
+    mint: A,
+    address: B,
+    pairAddress: PAIR,
+    priceSol: 0.000032,
+  });
+  assert.deepEqual(JSON.parse(JSON.stringify(quoteExtractor()(row, A))), {
+    mint: A,
+    pair: PAIR,
+    priceSol: 0.000032,
+    priceUsd: null,
+    mcapUsd: null,
+    supply: null,
+  });
+});
+
+test('an explicit token address wins over an unrelated generic address', () => {
+  const row = makeRow({
+    tokenAddress: A,
+    address: B,
+    pairAddress: PAIR,
+    priceSol: 0.000032,
+  });
+  assert.deepEqual(JSON.parse(JSON.stringify(quoteExtractor()(row, A))), {
+    mint: A,
+    pair: PAIR,
+    priceSol: 0.000032,
+    priceUsd: null,
+    mcapUsd: null,
+    supply: null,
+  });
+});
+
 test('a GMGN bare price without its USD cap is rejected', () => {
   assert.equal(quoteExtractor()(makeRow({
     address: A,

--- a/extension/test/rowprops.test.js
+++ b/extension/test/rowprops.test.js
@@ -130,6 +130,51 @@ test('unitless prices and percentage changes never become row quotes', () => {
   }), A), null);
 });
 
+test('a GMGN row proves its bare price is USD from supply and market cap', () => {
+  const row = makeRow({
+    data: {
+      address: A,
+      pool_address: PAIR,
+      price: 0.0000028749178,
+      usd_market_cap: 2874.92,
+      total_supply: 1_000_000_000,
+    },
+  });
+  assert.deepEqual(JSON.parse(JSON.stringify(quoteExtractor()(row, A))), {
+    mint: A,
+    pair: PAIR,
+    priceSol: null,
+    priceUsd: 0.0000028749178,
+    mcapUsd: 2874.92,
+    supply: 1_000_000_000,
+  });
+});
+
+test('a GMGN bare price without its USD cap is rejected', () => {
+  assert.equal(quoteExtractor()(makeRow({
+    address: A,
+    price: 0.0000028749178,
+    total_supply: 1_000_000_000,
+  }), A), null);
+});
+
+test('a GMGN bare price that disagrees with supply and cap is rejected', () => {
+  assert.equal(quoteExtractor()(makeRow({
+    address: A,
+    price: 0.00001,
+    usd_market_cap: 2874.92,
+    total_supply: 1_000_000_000,
+  }), A), null);
+});
+
+test('Padre dev funding amounts never become row prices', () => {
+  assert.equal(quoteExtractor()(makeRow({
+    tokenAddress: A,
+    marketAddress: PAIR,
+    devFundTxnSolAmount: 0.9,
+  }), A), null);
+});
+
 test('the row-buy bridge message carries the quote from the tapped row', () => {
   assert.match(
     BRIDGE,


### PR DESCRIPTION
## Summary

Stacked on #101, which made an Axiom chip tap price itself from the row it was painted on. GMGN's rows carry the same thing, so the same tap is now instant there too — no arming, no aggregator round trip.

I probed the logged-in boards over CDP first. GMGN row (chip `E2ei…pump`, row printing "MC $2.8K"):

```text
props.data.address        = "E2eiKD21Zfae4mcTrMioBLBjFVyfokt3J8oFxAfJpump"   // mint
props.data.pool_address   = "3W3xCQqY1Gb5jRjdUUWsPMhSTUPDRNiWsstf1AA5PXVp"
props.data.price          = 0.0000028749178
props.data.usd_market_cap = 2874.92
props.data.total_supply   = 1000000000
```

**The interesting part is the price key.** #101 refuses a bare `price`: a number with no denomination is exactly the kind of thing that becomes a 50,000x mispricing. GMGN's record proves its own denomination, so we don't have to assume it:

```js
const proven = bare * supply / mcapUsd  is within 2% of 1;   // 2.87e-6 * 1e9 = 2874.92 == the row's cap
if (proven) fields.priceUsd = bare;                          // USD — never priceSol
```

USD is the only denomination under which that number reconciles with the row's own USD cap and supply. Without a supply and a USD cap to reconcile against, the bare `price` is rejected exactly as before.

GMGN exposes no SOL price, so the fill converts with our own rate — and if the rate isn't there, there is no fill from this quote, it falls through to the existing cascade rather than guessing or letting a USD number through as SOL:

```js
if (priceUsd && !priceSol) {
  if (!reconciles(priceUsd, supply, mcapUsd)) return false;
  const rate = await boundedSolUsd();      // same 2s bound as #101
  if (!(rate > 0)) return false;           // cascade, not a fabricated rate
  return { ...quote, priceSol: priceUsd / rate };
}
```

**Padre is deliberately not in this PR.** Its rows carry identity (`tokenAddress` is the real mint, `marketAddress` the pool) but no price, cap or supply at all — the "MC $26K" it prints is formatted text. Every number reachable from a Padre row fiber was `devFundTxnSolAmount` (0.9, 0.01, 0.12): the dev's funding transfer, and precisely the sort of key that must never be read as a price because it ends in "SolAmount". There's a test asserting the recorded Padre shape yields no quote. Padre's price has to come from its own stream; that's the next one.

Two identity fixes fell out of teaching the extractor a second vocabulary:

- `address` and `pool_address` now *fill* `mint`/`pair` instead of overwriting them. `address` is generic — a dev/creator/wallet address on many records — so overwriting a real `tokenAddress` with it made the tapped-address guard reject a row that had everything we needed. It couldn't misprice, it just silently stopped working, which is the failure mode this whole line of work is about.
- The identity whitelist is now consulted before the percentage/delta name filter, because `badKey = /…|min|…/` matches `mint`.

## Testing

`cd extension && node --test` — 2,177 passed, 0 failed. New cases: the recorded GMGN row fills at `priceUsd / rate` keyed by the mint with no resolver price call; the same row with `usd_market_cap` removed, and one whose price/supply/cap disagree by more than 2%, both yield no quote; a USD-only quote with no SOL/USD rate falls through to the cascade instead of filling; the recorded Padre shape yields no quote; a record with a real mint plus an unrelated wallet `address` still keys by the real mint. Every #101 Axiom case is unchanged. Not yet exercised against a live GMGN tap — that's the next live pass.


Link to Devin session: https://app.devin.ai/sessions/b676704d774f4aa099ba7f31381b036f
Open in Devin Desktop: https://app.devin.ai/desktop/session/b676704d774f4aa099ba7f31381b036f?variant=devin
Requested by: @OnlyTerp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/papertrench/pull/102" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->