### PR TITLE
feat(bridge): decode Padre's own price feed, so a Padre tap fills instantly too

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -6607,6 +6607,7 @@
       usd: Number(cand.value), at: Date.now(),
       symbol: typeof payload.symbol === 'string' ? payload.symbol : null,
       name: typeof payload.name === 'string' ? payload.name : null,
+      mcap: Number(payload.mcap) > 0 ? Number(payload.mcap) : null,
     });
     if (recentRowPrices.size > 300) recentRowPrices.delete(recentRowPrices.keys().next().value);
     // D-40: a board tick while a row snipe is armed is the fastest possible
@@ -6628,6 +6629,7 @@
       priceUsd: live.usd,
       symbol: live.symbol || null,
       name: live.name || null,
+      mcap: live.mcap || null,
     };
   }
 
@@ -7052,30 +7054,41 @@
           priceSource: 'row-props',
         };
       } else {
-        try {
-          data = await Promise.race([
-            (async () => {
-              let d = await R.resolve(address, { maxAgeMs: 3000 });
-              if (!d || !(d.priceNative > 0)) d = await R.resolve(address);
-              if (!d || !(d.priceNative > 0)) {
-                const row = await rowLivePrice(address);
-                if (row) {
-                  d = {
-                    mint: address, pairAddress: null,
-                    symbol: row.symbol, name: row.name,
-                    priceNative: row.priceNative, priceUsd: row.priceUsd, mcap: null,
-                    priceSource: 'row-feed',
-                  };
+        const fresh = await rowLivePrice(address);
+        if (fresh) {
+          data = {
+            mint: address, pairAddress: null,
+            symbol: fresh.symbol, name: fresh.name,
+            priceNative: fresh.priceNative, priceUsd: fresh.priceUsd,
+            mcap: fresh.mcap || null,
+            priceSource: 'row-feed',
+          };
+        } else {
+          try {
+            data = await Promise.race([
+              (async () => {
+                let d = await R.resolve(address, { maxAgeMs: 3000 });
+                if (!d || !(d.priceNative > 0)) d = await R.resolve(address);
+                if (!d || !(d.priceNative > 0)) {
+                  const row = await rowLivePrice(address);
+                  if (row) {
+                    d = {
+                      mint: address, pairAddress: null,
+                      symbol: row.symbol, name: row.name,
+                      priceNative: row.priceNative, priceUsd: row.priceUsd, mcap: row.mcap || null,
+                      priceSource: 'row-feed',
+                    };
+                  }
                 }
-              }
-              if (!d || !(d.priceNative > 0)) {
-                d = await rowChainQuote(address, site && site.rowBuy && site.rowBuy.kind);
-              }
-              return d;
-            })(),
-            new Promise((resolve) => setTimeout(() => resolve(null), ROW_CASCADE_TIMEOUT_MS)),
-          ]);
-        } catch (_) { data = null; }
+                if (!d || !(d.priceNative > 0)) {
+                  d = await rowChainQuote(address, site && site.rowBuy && site.rowBuy.kind);
+                }
+                return d;
+              })(),
+              new Promise((resolve) => setTimeout(() => resolve(null), ROW_CASCADE_TIMEOUT_MS)),
+            ]);
+          } catch (_) { data = null; }
+        }
       }
       if (!data || !(data.priceNative > 0)) {
         // D-40 (Terp roll-on, board path): the click already happened — the

--- a/extension/content.js
+++ b/extension/content.js
@@ -7054,7 +7054,10 @@
           priceSource: 'row-props',
         };
       } else {
-        const fresh = await rowLivePrice(address);
+        const fresh = await Promise.race([
+          rowLivePrice(address).catch(() => null),
+          new Promise((resolve) => setTimeout(() => resolve(null), 2000)),
+        ]);
         if (fresh) {
           data = {
             mint: address, pairAddress: null,

--- a/extension/content.js
+++ b/extension/content.js
@@ -6604,16 +6604,17 @@
       : null;
     if (!cand) return;
     const now = Date.now();
-    const candidateAt = Number(payload.at);
-    const frameAt = Number.isFinite(candidateAt)
-      && candidateAt > now - 30_000
-      && candidateAt <= now
-      ? candidateAt
-      : now;
+    const hasFrameAt = Number.isFinite(payload.at);
+    if (hasFrameAt && (payload.at <= now - 30_000 || payload.at > now)) return;
+    const frameAt = hasFrameAt ? payload.at : now;
+    const frameSeq = Number(payload.seq);
     const prev = recentRowPrices.get(payload.mint);
-    if (prev && frameAt < prev.at) return;
+    if (prev && (frameAt < prev.at
+      || (frameAt === prev.at && Number.isFinite(frameSeq)
+        && Number.isFinite(prev.seq) && frameSeq < prev.seq))) return;
     recentRowPrices.set(payload.mint, {
       usd: Number(cand.value), at: frameAt,
+      seq: Number.isFinite(frameSeq) ? frameSeq : null,
       symbol: typeof payload.symbol === 'string' ? payload.symbol : null,
       name: typeof payload.name === 'string' ? payload.name : null,
       mcap: Number(payload.mcap) > 0 ? Number(payload.mcap) : null,

--- a/extension/content.js
+++ b/extension/content.js
@@ -6603,8 +6603,17 @@
       ? payload.candidates.find((c) => c && c.unit === 'usd' && Number(c.value) > 0)
       : null;
     if (!cand) return;
+    const now = Date.now();
+    const candidateAt = Number(payload.at);
+    const frameAt = Number.isFinite(candidateAt)
+      && candidateAt > now - 30_000
+      && candidateAt <= now
+      ? candidateAt
+      : now;
+    const prev = recentRowPrices.get(payload.mint);
+    if (prev && frameAt < prev.at) return;
     recentRowPrices.set(payload.mint, {
-      usd: Number(cand.value), at: Date.now(),
+      usd: Number(cand.value), at: frameAt,
       symbol: typeof payload.symbol === 'string' ? payload.symbol : null,
       name: typeof payload.name === 'string' ? payload.name : null,
       mcap: Number(payload.mcap) > 0 ? Number(payload.mcap) : null,

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -35,6 +35,7 @@
   // bounded by NODE_BUDGET, so bigger frames cannot runaway the main thread.
   const FRAME_GUARD_BYTES = 2_000_000;
   const MAX_MARKS = 500;
+  let webSocketFrameSeq = 0;
 
   let paperMarks = [];
   // Per-mark fill levels (USD / SOL / market cap), kept for the execution-
@@ -473,11 +474,16 @@
   const ACTIVITY_TICK_MIN_MS = 100;
   const activityLastEmitByMint = new Map();
 
-  function withReceivedAt(payload, receivedAt) {
-    return Number.isFinite(receivedAt) ? { ...payload, at: receivedAt } : payload;
+  function withFrameEvidence(payload, receivedAt, seq) {
+    if (!Number.isFinite(receivedAt)) return payload;
+    return {
+      ...payload,
+      at: receivedAt,
+      ...(Number.isFinite(seq) ? { seq } : {}),
+    };
   }
 
-  function forwardTokenActivity(parsed, receivedAt) {
+  function forwardTokenActivity(parsed, receivedAt, seq) {
     if (!parsed || parsed.channel !== 'token_activity' || !Array.isArray(parsed.data)) return false;
     const now = Date.now();
     const latestByMint = new Map();
@@ -494,14 +500,14 @@
     const due = (mint) => now - (activityLastEmitByMint.get(mint) || 0) >= ACTIVITY_TICK_MIN_MS;
     const emitTick = (mint, priceUsd) => {
       activityLastEmitByMint.set(mint, now);
-      emit('tick', withReceivedAt({
+      emit('tick', withFrameEvidence({
         candidates: [{ value: priceUsd, unit: 'usd', key: 'tokenActivityPriceUsd' }],
         mcap: null,
         mint,
         symbol: currentSymbolInfo.mint === mint ? currentSymbolInfo.symbol : null,
         name: null,
         source: 'gmgn-ws-trade',
-      }, receivedAt));
+      }, receivedAt, seq));
     };
     const watchedMint = currentSymbolInfo.mint;
     if (watchedMint && latestByMint.has(watchedMint) && due(watchedMint)) {
@@ -526,7 +532,7 @@
     return true;
   }
 
-  function forwardJson(raw, source, url, receivedAt) {
+  function forwardJson(raw, source, url, receivedAt, seq) {
     // No consumer, no parse — the cheapest frame is the one never read.
     if (!feedActive()) return;
     let parsed = raw;
@@ -542,7 +548,7 @@
       // forwardTokenActivity still validates the parsed shape.
       if (trimmed.length > 15 && trimmed.slice(0, 120).indexOf('"token_activity"') !== -1) {
         try { parsed = JSON.parse(raw); } catch (_) { return; }
-        forwardTokenActivity(parsed, receivedAt);
+        forwardTokenActivity(parsed, receivedAt, seq);
         return;
       }
       if (url && /\/api\/v1\/token_mcap_candles\//.test(url)) {
@@ -581,13 +587,13 @@
         // C-08: this close IS the value on GMGN's Y axis — the scale anchor
         // for every GMGN line and fill shape (see gmgnCapScale).
         gmgnLastCandleClose = mcap;
-        emit('tick', withReceivedAt({
+        emit('tick', withFrameEvidence({
           candidates: [],
           mcap,
           mint: currentSymbolInfo.mint,
           symbol: currentSymbolInfo.symbol,
           source: 'gmgn-mcap-candle',
-        }, receivedAt));
+        }, receivedAt, seq));
         return;
       }
     }
@@ -602,20 +608,20 @@
         || null;
       let emitted = 0;
       if (watched && hasContent(watched)) {
-        emit('tick', withReceivedAt({ ...watched, source }, receivedAt));
+        emit('tick', withFrameEvidence({ ...watched, source }, receivedAt, seq));
         emitted++;
       }
       for (const rec of records.values()) {
         if (rec === watched || !hasContent(rec)) continue;
         if (emitted++ >= 5) break;
-        emit('tick', withReceivedAt({ ...rec, source }, receivedAt));
+        emit('tick', withFrameEvidence({ ...rec, source }, receivedAt, seq));
       }
       if (emitted) return;
       // Records existed but carried no prices; fall through to the
       // unattributed finds so a lone top-level price still ticks.
     }
     if (!top.candidates.length && top.mcap === null) return;
-    emit('tick', withReceivedAt({ ...top, source }, receivedAt));
+    emit('tick', withFrameEvidence({ ...top, source }, receivedAt, seq));
   }
 
   /* ---------------- SPA navigation signal ----------------
@@ -680,8 +686,8 @@
   }
 
   // Padre's binary socket frames are MessagePack, not protobuf. Capture the
-  // receive time before a Blob's asynchronous body conversion so consumers
-  // can reject an older frame that completes after a newer one.
+  // receive time and bridge-wide sequence before a Blob's asynchronous body
+  // conversion so consumers can order same-time frames safely.
   const OriginalWebSocket = window.WebSocket;
   if (typeof OriginalWebSocket === 'function') {
     const WrappedWebSocket = function (url, protocols) {
@@ -690,16 +696,17 @@
         : new OriginalWebSocket(url, protocols);
       socket.addEventListener('message', (event) => {
         const receivedAt = Date.now();
+        const seq = ++webSocketFrameSeq;
         if (typeof event.data === 'string') {
-          forwardJson(event.data, 'ws', undefined, receivedAt);
+          forwardJson(event.data, 'ws', undefined, receivedAt, seq);
         } else if (hostIsPadre && feedActive() && event.data instanceof ArrayBuffer) {
           const decoded = decodeMsgpack(new Uint8Array(event.data));
-          if (decoded !== null) forwardJson(decoded, 'ws', undefined, receivedAt);
+          if (decoded !== null) forwardJson(decoded, 'ws', undefined, receivedAt, seq);
         } else if (hostIsPadre && feedActive()
           && typeof Blob === 'function' && event.data instanceof Blob) {
           Promise.resolve(event.data.arrayBuffer()).then((buffer) => {
             const decoded = decodeMsgpack(new Uint8Array(buffer));
-            if (decoded !== null) forwardJson(decoded, 'ws', undefined, receivedAt);
+            if (decoded !== null) forwardJson(decoded, 'ws', undefined, receivedAt, seq);
           }, () => {});
         }
       });

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -26,6 +26,10 @@
   const PATCHED = Symbol('papertrench-patched');
   const MAX_DEPTH = 7;
   const MAX_CANDIDATES = 32;
+  const bridgeHostname = (() => {
+    try { return location.hostname || new URL(location.href).hostname; } catch (_) { return ''; }
+  })();
+  const hostIsPadre = /(^|\.)padre\.gg$/.test(bridgeHostname);
   // Upper bound on frames the generic path will JSON.parse. Parse cost at
   // this size is ~10-20 ms occasionally; the collector walk is separately
   // bounded by NODE_BUDGET, so bigger frames cannot runaway the main thread.
@@ -179,13 +183,128 @@
     return null;
   }
 
+  // Padre's multiplex socket uses MessagePack. Decode only the first value:
+  // the transport may append another value, but the first envelope is the
+  // complete page-owned message we need. The byte and node caps keep malformed
+  // or adversarial frames from turning the bridge into an unbounded parser.
+  function decodeMsgpack(input) {
+    try {
+      const bytes = input instanceof Uint8Array
+        ? input
+        : input instanceof ArrayBuffer ? new Uint8Array(input) : null;
+      if (!bytes || bytes.byteLength > 512 * 1024) return null;
+      const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+      let offset = 0;
+      let budget = NODE_BUDGET;
+      const fail = () => { throw new Error('invalid msgpack'); };
+      const need = (count) => {
+        if (count < 0 || offset + count > bytes.byteLength) fail();
+        const start = offset;
+        offset += count;
+        return start;
+      };
+      const text = (start, length) => {
+        const chunk = bytes.subarray(start, start + length);
+        if (typeof TextDecoder === 'function') return new TextDecoder().decode(chunk);
+        let out = '';
+        for (let i = 0; i < chunk.length; i++) out += String.fromCharCode(chunk[i]);
+        return out;
+      };
+      const parse = (depth) => {
+        if (depth > MAX_DEPTH * 4 || budget-- <= 0 || offset >= bytes.byteLength) fail();
+        const tag = bytes[offset++];
+        if (tag <= 0x7f) return tag;
+        if (tag >= 0xe0) return tag - 0x100;
+        if (tag >= 0xa0 && tag <= 0xbf) {
+          const length = tag & 0x1f;
+          return text(need(length), length);
+        }
+        if (tag >= 0x90 && tag <= 0x9f) {
+          const out = [];
+          for (let i = 0; i < (tag & 0x0f); i++) out.push(parse(depth + 1));
+          return out;
+        }
+        if (tag >= 0x80 && tag <= 0x8f) {
+          const out = {};
+          for (let i = 0; i < (tag & 0x0f); i++) {
+            const key = String(parse(depth + 1));
+            out[key] = parse(depth + 1);
+          }
+          return out;
+        }
+        switch (tag) {
+          case 0xc0: return null;
+          case 0xc2: return false;
+          case 0xc3: return true;
+          case 0xcc: { const at = need(1); return view.getUint8(at); }
+          case 0xcd: { const at = need(2); return view.getUint16(at); }
+          case 0xce: { const at = need(4); return view.getUint32(at); }
+          case 0xcf: {
+            const at = need(8);
+            return view.getUint32(at) * 4294967296 + view.getUint32(at + 4);
+          }
+          case 0xd0: { const at = need(1); return view.getInt8(at); }
+          case 0xd1: { const at = need(2); return view.getInt16(at); }
+          case 0xd2: { const at = need(4); return view.getInt32(at); }
+          case 0xd3: {
+            const at = need(8);
+            const high = view.getInt32(at);
+            return high * 4294967296 + view.getUint32(at + 4);
+          }
+          case 0xca: { const at = need(4); return view.getFloat32(at); }
+          case 0xcb: { const at = need(8); return view.getFloat64(at); }
+          case 0xd9: { const length = bytes[need(1)]; return text(need(length), length); }
+          case 0xda: { const at = need(2); const length = view.getUint16(at); return text(need(length), length); }
+          case 0xdb: { const at = need(4); const length = view.getUint32(at); return text(need(length), length); }
+          case 0xc4: { const length = bytes[need(1)]; return bytes.slice(need(length), offset); }
+          case 0xc5: { const at = need(2); const length = view.getUint16(at); return bytes.slice(need(length), offset); }
+          case 0xc6: { const at = need(4); const length = view.getUint32(at); return bytes.slice(need(length), offset); }
+          case 0xdc: {
+            const at = need(2);
+            const out = [];
+            for (let i = 0; i < view.getUint16(at); i++) out.push(parse(depth + 1));
+            return out;
+          }
+          case 0xdd: {
+            const at = need(4);
+            const out = [];
+            for (let i = 0; i < view.getUint32(at); i++) out.push(parse(depth + 1));
+            return out;
+          }
+          case 0xde: {
+            const at = need(2);
+            const out = {};
+            for (let i = 0; i < view.getUint16(at); i++) {
+              const key = String(parse(depth + 1));
+              out[key] = parse(depth + 1);
+            }
+            return out;
+          }
+          case 0xdf: {
+            const at = need(4);
+            const out = {};
+            for (let i = 0; i < view.getUint32(at); i++) {
+              const key = String(parse(depth + 1));
+              out[key] = parse(depth + 1);
+            }
+            return out;
+          }
+          default: fail();
+        }
+      };
+      return parse(0);
+    } catch (_) {
+      return null;
+    }
+  }
+
   const BASE58_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
   // avgPrice is deliberately ABSENT: it is a position-average field, not a
   // live price. When the user holds a REAL position, the site streams their
   // real entry average under that key, and treating it as a market tick let
   // the user's own entry price pollute the paper feed (DEFECT F-30 — the
   // average line "blended" a real buy with the paper buy).
-  const PRICE_KEY = /^(price|priceNative|priceUsd|priceInSol|priceSol|solPrice|usdPrice|tokenPrice|lastPrice|last|close|c|markPrice|currentPrice|quote)$/i;
+  const PRICE_KEY = /^(price|priceNative|priceUsd|priceInSol|priceSol|priceInUsd|solPrice|usdPrice|tokenPrice|lastPrice|last|close|c|markPrice|currentPrice|quote)$/i;
   // Subtrees that describe the USER'S OWN holdings, not the market. Prices
   // inside them are historical facts about the user (entry averages, cost
   // bases, unrealized P&L) and must never become market-price candidates.
@@ -193,7 +312,7 @@
   // positions-of-SOMEONE either way, and prices inside them are entries,
   // not the market.
   const POSITION_SUBTREE_KEY = /^(positions?|holdings?|portfolio|userPositions?|myPositions?|openOrders?|hodlers?|holders?|topHolders?|toptraders?|balances?)$/i;
-  const MCAP_KEY = /^(marketCap|marketCapInUsd|mcap|mcapInUsd|fdv|fullyDilutedValuation)$/i;
+  const MCAP_KEY = /^(marketCap|marketCapInUsd|mcap|mcapInUsd|fdv|fdvInUsd|fullyDilutedValuation)$/i;
   // A record that IS a trade event — an id-carrying or user-attributed
   // swap/trade object (fomo's social feed, tx-hash trade tapes). Its price
   // and cap fields describe the moment that trade happened, minutes to
@@ -560,9 +679,16 @@
         ? new OriginalWebSocket(url)
         : new OriginalWebSocket(url, protocols);
       socket.addEventListener('message', (event) => {
-        // Padre's multiplex messages are binary protobuf and are deliberately
-        // handled after Padre decodes them through its TradingView datafeed.
         if (typeof event.data === 'string') forwardJson(event.data, 'ws');
+        else if (hostIsPadre && event.data instanceof ArrayBuffer) {
+          const decoded = decodeMsgpack(new Uint8Array(event.data));
+          if (decoded !== null) forwardJson(decoded, 'ws');
+        } else if (hostIsPadre && typeof Blob === 'function' && event.data instanceof Blob) {
+          Promise.resolve(event.data.arrayBuffer()).then((buffer) => {
+            const decoded = decodeMsgpack(new Uint8Array(buffer));
+            if (decoded !== null) forwardJson(decoded, 'ws');
+          }, () => {});
+        }
       });
       return socket;
     };
@@ -584,9 +710,6 @@
   // port.start() — on an object the host site owns. Other sites keep their
   // native SharedWorker untouched.
   const OriginalSharedWorker = window.SharedWorker;
-  const bridgeHostname = (() => {
-    try { return location.hostname || new URL(location.href).hostname; } catch (_) { return ''; }
-  })();
   const hostUsesSharedWorkerFeed = /(^|\.)gmgn\.ai$/.test(bridgeHostname);
   if (typeof OriginalSharedWorker === 'function' && hostUsesSharedWorkerFeed) {
     const WrappedSharedWorker = function (url, options) {

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -678,15 +678,28 @@
       const socket = protocols === undefined
         ? new OriginalWebSocket(url)
         : new OriginalWebSocket(url, protocols);
+      let socketSeq = 0;
+      let lastForwardedSeq = 0;
       socket.addEventListener('message', (event) => {
-        if (typeof event.data === 'string') forwardJson(event.data, 'ws');
-        else if (hostIsPadre && event.data instanceof ArrayBuffer) {
+        const seq = ++socketSeq;
+        if (typeof event.data === 'string') {
+          if (seq >= lastForwardedSeq) {
+            lastForwardedSeq = seq;
+            forwardJson(event.data, 'ws');
+          }
+        } else if (hostIsPadre && feedActive() && event.data instanceof ArrayBuffer) {
           const decoded = decodeMsgpack(new Uint8Array(event.data));
-          if (decoded !== null) forwardJson(decoded, 'ws');
-        } else if (hostIsPadre && typeof Blob === 'function' && event.data instanceof Blob) {
+          if (decoded !== null && seq >= lastForwardedSeq) {
+            lastForwardedSeq = seq;
+            forwardJson(decoded, 'ws');
+          }
+        } else if (hostIsPadre && feedActive()
+          && typeof Blob === 'function' && event.data instanceof Blob) {
           Promise.resolve(event.data.arrayBuffer()).then((buffer) => {
             const decoded = decodeMsgpack(new Uint8Array(buffer));
-            if (decoded !== null) forwardJson(decoded, 'ws');
+            if (decoded === null || seq < lastForwardedSeq) return;
+            lastForwardedSeq = seq;
+            forwardJson(decoded, 'ws');
           }, () => {});
         }
       });

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -473,7 +473,11 @@
   const ACTIVITY_TICK_MIN_MS = 100;
   const activityLastEmitByMint = new Map();
 
-  function forwardTokenActivity(parsed) {
+  function withReceivedAt(payload, receivedAt) {
+    return Number.isFinite(receivedAt) ? { ...payload, at: receivedAt } : payload;
+  }
+
+  function forwardTokenActivity(parsed, receivedAt) {
     if (!parsed || parsed.channel !== 'token_activity' || !Array.isArray(parsed.data)) return false;
     const now = Date.now();
     const latestByMint = new Map();
@@ -490,14 +494,14 @@
     const due = (mint) => now - (activityLastEmitByMint.get(mint) || 0) >= ACTIVITY_TICK_MIN_MS;
     const emitTick = (mint, priceUsd) => {
       activityLastEmitByMint.set(mint, now);
-      emit('tick', {
+      emit('tick', withReceivedAt({
         candidates: [{ value: priceUsd, unit: 'usd', key: 'tokenActivityPriceUsd' }],
         mcap: null,
         mint,
         symbol: currentSymbolInfo.mint === mint ? currentSymbolInfo.symbol : null,
         name: null,
         source: 'gmgn-ws-trade',
-      });
+      }, receivedAt));
     };
     const watchedMint = currentSymbolInfo.mint;
     if (watchedMint && latestByMint.has(watchedMint) && due(watchedMint)) {
@@ -522,7 +526,7 @@
     return true;
   }
 
-  function forwardJson(raw, source, url) {
+  function forwardJson(raw, source, url, receivedAt) {
     // No consumer, no parse — the cheapest frame is the one never read.
     if (!feedActive()) return;
     let parsed = raw;
@@ -538,7 +542,7 @@
       // forwardTokenActivity still validates the parsed shape.
       if (trimmed.length > 15 && trimmed.slice(0, 120).indexOf('"token_activity"') !== -1) {
         try { parsed = JSON.parse(raw); } catch (_) { return; }
-        forwardTokenActivity(parsed);
+        forwardTokenActivity(parsed, receivedAt);
         return;
       }
       if (url && /\/api\/v1\/token_mcap_candles\//.test(url)) {
@@ -577,13 +581,13 @@
         // C-08: this close IS the value on GMGN's Y axis — the scale anchor
         // for every GMGN line and fill shape (see gmgnCapScale).
         gmgnLastCandleClose = mcap;
-        emit('tick', {
+        emit('tick', withReceivedAt({
           candidates: [],
           mcap,
           mint: currentSymbolInfo.mint,
           symbol: currentSymbolInfo.symbol,
           source: 'gmgn-mcap-candle',
-        });
+        }, receivedAt));
         return;
       }
     }
@@ -597,18 +601,21 @@
         || (currentSymbolInfo.pairAddress && records.get(currentSymbolInfo.pairAddress))
         || null;
       let emitted = 0;
-      if (watched && hasContent(watched)) { emit('tick', { ...watched, source }); emitted++; }
+      if (watched && hasContent(watched)) {
+        emit('tick', withReceivedAt({ ...watched, source }, receivedAt));
+        emitted++;
+      }
       for (const rec of records.values()) {
         if (rec === watched || !hasContent(rec)) continue;
         if (emitted++ >= 5) break;
-        emit('tick', { ...rec, source });
+        emit('tick', withReceivedAt({ ...rec, source }, receivedAt));
       }
       if (emitted) return;
       // Records existed but carried no prices; fall through to the
       // unattributed finds so a lone top-level price still ticks.
     }
     if (!top.candidates.length && top.mcap === null) return;
-    emit('tick', { ...top, source });
+    emit('tick', withReceivedAt({ ...top, source }, receivedAt));
   }
 
   /* ---------------- SPA navigation signal ----------------
@@ -672,34 +679,27 @@
     };
   }
 
+  // Padre's binary socket frames are MessagePack, not protobuf. Capture the
+  // receive time before a Blob's asynchronous body conversion so consumers
+  // can reject an older frame that completes after a newer one.
   const OriginalWebSocket = window.WebSocket;
   if (typeof OriginalWebSocket === 'function') {
     const WrappedWebSocket = function (url, protocols) {
       const socket = protocols === undefined
         ? new OriginalWebSocket(url)
         : new OriginalWebSocket(url, protocols);
-      let socketSeq = 0;
-      let lastForwardedSeq = 0;
       socket.addEventListener('message', (event) => {
-        const seq = ++socketSeq;
+        const receivedAt = Date.now();
         if (typeof event.data === 'string') {
-          if (seq >= lastForwardedSeq) {
-            lastForwardedSeq = seq;
-            forwardJson(event.data, 'ws');
-          }
+          forwardJson(event.data, 'ws', undefined, receivedAt);
         } else if (hostIsPadre && feedActive() && event.data instanceof ArrayBuffer) {
           const decoded = decodeMsgpack(new Uint8Array(event.data));
-          if (decoded !== null && seq >= lastForwardedSeq) {
-            lastForwardedSeq = seq;
-            forwardJson(decoded, 'ws');
-          }
+          if (decoded !== null) forwardJson(decoded, 'ws', undefined, receivedAt);
         } else if (hostIsPadre && feedActive()
           && typeof Blob === 'function' && event.data instanceof Blob) {
           Promise.resolve(event.data.arrayBuffer()).then((buffer) => {
             const decoded = decodeMsgpack(new Uint8Array(buffer));
-            if (decoded === null || seq < lastForwardedSeq) return;
-            lastForwardedSeq = seq;
-            forwardJson(decoded, 'ws');
+            if (decoded !== null) forwardJson(decoded, 'ws', undefined, receivedAt);
           }, () => {});
         }
       });

--- a/extension/test/padrebridge.test.js
+++ b/extension/test/padrebridge.test.js
@@ -285,7 +285,6 @@ test('Padre Blob frames carry their receive time when conversions complete backw
   const env = runBridge({ deferBlobs: true });
   const socket = env.openSocket();
   socket.emit(new env.Blob([PADRE_UPDATE_FRAME]));
-  env.advanceNow(10);
   socket.emit(new env.Blob([PADRE_NEWER_UPDATE_FRAME]));
   assert.equal(env.pendingBlobs.length, 2);
 
@@ -299,7 +298,9 @@ test('Padre Blob frames carry their receive time when conversions complete backw
   const ticks = env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws');
   assert.equal(ticks.length, 2);
   assert.equal(ticks[0].payload.candidates[0].value, 9.99);
-  assert.equal(ticks[0].payload.at, ticks[1].payload.at + 10);
+  assert.equal(ticks[0].payload.at, ticks[1].payload.at);
+  assert.equal(ticks[0].payload.seq, 2);
+  assert.equal(ticks[1].payload.seq, 1);
 });
 
 test('a later Padre frame without a quote does not suppress a valid tick', () => {

--- a/extension/test/padrebridge.test.js
+++ b/extension/test/padrebridge.test.js
@@ -21,12 +21,17 @@ const PADRE_NEWER_UPDATE_FRAME = Uint8Array.from(Buffer.from(
   'kwVVgqR0eXBlpnVwZGF0ZaZ1cGRhdGWCpGFkZHOQp3VwZGF0ZXORg6x0b2tlbkFkZHJlc3PZLEZRVGtncTZHa1l6a3JRRjNCMWNyaGZ2WUdrbjJ1THlNRTI4eFNIYnBwdW1wqnByaWNlSW5Vc2TLQCP64UeuFHuoZmR2SW5Vc2TNJwY=',
   'base64',
 ));
+const PADRE_OTHER_UPDATE_FRAME = Uint8Array.from(Buffer.from(
+  'kwVVgqR0eXBlpnVwZGF0ZaZ1cGRhdGWCpGFkZHOQp3VwZGF0ZXORg6x0b2tlbkFkZHJlc3PZIDExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExqnByaWNlSW5Vc2TLQB4AAAAAAACoZmR2SW5Vc2TPAAAAAb8I6wA=',
+  'base64',
+));
 const PADRE_NATIVE_RATE_FRAME = Uint8Array.from(Buffer.from(
   'kwVVgqx0b2tlbkFkZHJlc3PZLEZRVGtncTZHa1l6a3JRRjNCMWNyaGZ2WUdrbjJ1THlNRTI4eFNIYnBwdW1wsm5hdGl2ZVByaWNlSW5Vc2RVactAWZfzf6mDcg==',
   'base64',
 ));
 
 function runBridge(opts = {}) {
+  let clock = Date.now();
   const timers = [];
   const emitted = [];
   const listeners = {};
@@ -37,6 +42,11 @@ function runBridge(opts = {}) {
   let refreshMarksCount = 0;
   const orderLines = [];
   const NativeDataView = DataView;
+
+  class TestDate extends Date {
+    constructor(...args) { super(...(args.length ? args : [clock])); }
+    static now() { return clock; }
+  }
 
   class TestBlob {
     constructor(parts) {
@@ -172,7 +182,7 @@ function runBridge(opts = {}) {
       return { href, hostname: new URL(href).hostname };
     })(),
     console,
-    Date,
+    Date: TestDate,
     Math,
     Number,
     String,
@@ -217,6 +227,7 @@ function runBridge(opts = {}) {
     Blob: TestBlob,
     dataViewCalls: () => dataViewCalls,
     pendingBlobs,
+    advanceNow(ms) { clock += ms; },
     send(type, payload) {
       listeners.message({
         source: win,
@@ -270,39 +281,48 @@ test('Padre Blob frames are decoded without blocking the WebSocket handler', asy
     'a Padre Blob frame must reach the same generic tick pipeline');
 });
 
-test('Padre Blob frames preserve receive order when conversions complete backwards', async () => {
+test('Padre Blob frames carry their receive time when conversions complete backwards', async () => {
   const env = runBridge({ deferBlobs: true });
   const socket = env.openSocket();
   socket.emit(new env.Blob([PADRE_UPDATE_FRAME]));
+  env.advanceNow(10);
   socket.emit(new env.Blob([PADRE_NEWER_UPDATE_FRAME]));
   assert.equal(env.pendingBlobs.length, 2);
 
   env.resolveBlob(1);
   await Promise.resolve();
   assert.equal(env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws').length, 1);
-  assert.equal(
-    env.emitted.find((m) => m.type === 'tick' && m.payload?.source === 'ws').payload.candidates[0].value,
-    9.99,
-  );
   env.resolveBlob(0);
   await Promise.resolve();
   await Promise.resolve();
 
-  assert.equal(env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws').length, 1,
-    'an older Blob completion must be discarded after a newer frame publishes');
+  const ticks = env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws');
+  assert.equal(ticks.length, 2);
+  assert.equal(ticks[0].payload.candidates[0].value, 9.99);
+  assert.equal(ticks[0].payload.at, ticks[1].payload.at + 10);
 });
 
-test('Padre binary frame sequence state is independent per socket', async () => {
-  const env = runBridge({ deferBlobs: true });
-  const socketA = env.openSocket();
-  const socketB = env.openSocket();
-  socketA.emit(new env.Blob([PADRE_UPDATE_FRAME]));
-  socketB.emit(PADRE_UPDATE_FRAME.buffer);
-  env.resolveBlob(0);
-  await Promise.resolve();
+test('a later Padre frame without a quote does not suppress a valid tick', () => {
+  const env = runBridge();
+  const socket = env.openSocket();
+  socket.emit(PADRE_UPDATE_FRAME.buffer);
+  socket.emit(PADRE_NATIVE_RATE_FRAME.buffer);
 
-  assert.equal(env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws').length, 2,
-    'one socket must not suppress a frame from another socket');
+  const ticks = env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws');
+  assert.equal(ticks.length, 1);
+  assert.equal(ticks[0].payload.mint, 'FQTkgq6GkYzkrQF3B1crhfvYGkn2uLyME28xSHbppump');
+});
+
+test('a Padre frame for another mint does not suppress the first mint', () => {
+  const env = runBridge();
+  const socket = env.openSocket();
+  socket.emit(PADRE_UPDATE_FRAME.buffer);
+  socket.emit(PADRE_OTHER_UPDATE_FRAME.buffer);
+
+  const ticks = env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws');
+  assert.equal(ticks.length, 2);
+  assert.equal(ticks[0].payload.mint, 'FQTkgq6GkYzkrQF3B1crhfvYGkn2uLyME28xSHbppump');
+  assert.equal(ticks[1].payload.mint, '11111111111111111111111111111111');
 });
 
 test('Padre binary frames are gated before decoding when feed demand is off', () => {

--- a/extension/test/padrebridge.test.js
+++ b/extension/test/padrebridge.test.js
@@ -17,6 +17,10 @@ const PADRE_UPDATE_FRAME = Uint8Array.from(Buffer.from(
   'kwVVgqR0eXBlpnVwZGF0ZaZ1cGRhdGWCpGFkZHOQp3VwZGF0ZXORg6x0b2tlbkFkZHJlc3PZLEZRVGtncTZHa1l6a3JRRjNCMWNyaGZ2WUdrbjJ1THlNRTI4eFNIYnBwdW1wqGZkdkluVXNky0CoROThzofUqnByaWNlSW5Vc2TLPsoPC1Fz3To=',
   'base64',
 ));
+const PADRE_NEWER_UPDATE_FRAME = Uint8Array.from(Buffer.from(
+  'kwVVgqR0eXBlpnVwZGF0ZaZ1cGRhdGWCpGFkZHOQp3VwZGF0ZXORg6x0b2tlbkFkZHJlc3PZLEZRVGtncTZHa1l6a3JRRjNCMWNyaGZ2WUdrbjJ1THlNRTI4eFNIYnBwdW1wqnByaWNlSW5Vc2TLQCP64UeuFHuoZmR2SW5Vc2TNJwY=',
+  'base64',
+));
 const PADRE_NATIVE_RATE_FRAME = Uint8Array.from(Buffer.from(
   'kwVVgqx0b2tlbkFkZHJlc3PZLEZRVGtncTZHa1l6a3JRRjNCMWNyaGZ2WUdrbjJ1THlNRTI4eFNIYnBwdW1wsm5hdGl2ZVByaWNlSW5Vc2RVactAWZfzf6mDcg==',
   'base64',
@@ -26,10 +30,52 @@ function runBridge(opts = {}) {
   const timers = [];
   const emitted = [];
   const listeners = {};
+  let dataViewCalls = 0;
+  const pendingBlobs = [];
   let realtimeCallback = null;
   let clearMarksCount = 0;
   let refreshMarksCount = 0;
   const orderLines = [];
+  const NativeDataView = DataView;
+
+  class TestBlob {
+    constructor(parts) {
+      const bytes = Uint8Array.from(parts[0] || []);
+      this.bytes = bytes;
+      this.arrayBufferCalls = 0;
+      if (opts.deferBlobs) {
+        this.promise = new Promise((resolve) => {
+          this.resolve = resolve;
+        });
+        pendingBlobs.push(this);
+      }
+    }
+
+    arrayBuffer() {
+      this.arrayBufferCalls++;
+      if (this.promise) return this.promise;
+      return Promise.resolve(this.bytes.buffer.slice(
+        this.bytes.byteOffset,
+        this.bytes.byteOffset + this.bytes.byteLength,
+      ));
+    }
+
+    resolveFrame() {
+      if (this.resolve) {
+        this.resolve(this.bytes.buffer.slice(
+          this.bytes.byteOffset,
+          this.bytes.byteOffset + this.bytes.byteLength,
+        ));
+        this.resolve = null;
+      }
+    }
+  }
+
+  function TestDataView(...args) {
+    dataViewCalls++;
+    return new NativeDataView(...args);
+  }
+  TestDataView.prototype = NativeDataView.prototype;
 
   function makeOrderLine() {
     const line = { removed: false, values: {}, calls: [] };
@@ -141,9 +187,9 @@ function runBridge(opts = {}) {
     JSON,
     ArrayBuffer,
     Uint8Array,
-    DataView,
+    DataView: TestDataView,
     TextDecoder,
-    Blob,
+    Blob: TestBlob,
     Promise,
     isFinite,
     setInterval(fn, ms) { timers.push(fn); return timers.length; },
@@ -168,6 +214,16 @@ function runBridge(opts = {}) {
     refreshMarksCount: () => refreshMarksCount,
     orderLines,
     win,
+    Blob: TestBlob,
+    dataViewCalls: () => dataViewCalls,
+    pendingBlobs,
+    send(type, payload) {
+      listeners.message({
+        source: win,
+        data: { source: 'papertrench-content', type, payload },
+      });
+    },
+    resolveBlob(index) { pendingBlobs[index].resolveFrame(); },
     openSocket() { return new win.WebSocket('wss://backend.padre.gg/_multiplex?desc=/trenches'); },
   };
 }
@@ -206,12 +262,69 @@ test('Padre MessagePack frames emit mint-tagged USD ticks with their FDV cap', (
 test('Padre Blob frames are decoded without blocking the WebSocket handler', async () => {
   const env = runBridge();
   const socket = env.openSocket();
-  socket.emit(new Blob([PADRE_UPDATE_FRAME]));
+  socket.emit(new env.Blob([PADRE_UPDATE_FRAME]));
   await Promise.resolve();
   await Promise.resolve();
 
   assert.ok(env.emitted.some((m) => m.type === 'tick' && m.payload?.source === 'ws'),
     'a Padre Blob frame must reach the same generic tick pipeline');
+});
+
+test('Padre Blob frames preserve receive order when conversions complete backwards', async () => {
+  const env = runBridge({ deferBlobs: true });
+  const socket = env.openSocket();
+  socket.emit(new env.Blob([PADRE_UPDATE_FRAME]));
+  socket.emit(new env.Blob([PADRE_NEWER_UPDATE_FRAME]));
+  assert.equal(env.pendingBlobs.length, 2);
+
+  env.resolveBlob(1);
+  await Promise.resolve();
+  assert.equal(env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws').length, 1);
+  assert.equal(
+    env.emitted.find((m) => m.type === 'tick' && m.payload?.source === 'ws').payload.candidates[0].value,
+    9.99,
+  );
+  env.resolveBlob(0);
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.equal(env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws').length, 1,
+    'an older Blob completion must be discarded after a newer frame publishes');
+});
+
+test('Padre binary frame sequence state is independent per socket', async () => {
+  const env = runBridge({ deferBlobs: true });
+  const socketA = env.openSocket();
+  const socketB = env.openSocket();
+  socketA.emit(new env.Blob([PADRE_UPDATE_FRAME]));
+  socketB.emit(PADRE_UPDATE_FRAME.buffer);
+  env.resolveBlob(0);
+  await Promise.resolve();
+
+  assert.equal(env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws').length, 2,
+    'one socket must not suppress a frame from another socket');
+});
+
+test('Padre binary frames are gated before decoding when feed demand is off', () => {
+  const env = runBridge();
+  env.send('page-state', { wantsTicks: false });
+  const socket = env.openSocket();
+  const blob = new env.Blob([PADRE_UPDATE_FRAME]);
+  socket.emit(PADRE_UPDATE_FRAME.buffer);
+  socket.emit(blob);
+
+  assert.equal(env.dataViewCalls(), 0, 'inactive feeds must not decode binary frames');
+  assert.equal(blob.arrayBufferCalls, 0, 'inactive feeds must not copy Blob bodies');
+  assert.equal(env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws').length, 0);
+});
+
+test('Padre binary frames decode when feed demand is on', () => {
+  const env = runBridge();
+  const socket = env.openSocket();
+  socket.emit(PADRE_UPDATE_FRAME.buffer);
+
+  assert.ok(env.dataViewCalls() > 0, 'active feeds decode the captured binary envelope');
+  assert.ok(env.emitted.some((m) => m.type === 'tick' && m.payload?.source === 'ws'));
 });
 
 test('Padre nativePriceInUsdUi is never treated as a token price', () => {

--- a/extension/test/padrebridge.test.js
+++ b/extension/test/padrebridge.test.js
@@ -13,6 +13,14 @@ const path = require('node:path');
 const vm = require('node:vm');
 
 const ROOT = path.join(__dirname, '..');
+const PADRE_UPDATE_FRAME = Uint8Array.from(Buffer.from(
+  'kwVVgqR0eXBlpnVwZGF0ZaZ1cGRhdGWCpGFkZHOQp3VwZGF0ZXORg6x0b2tlbkFkZHJlc3PZLEZRVGtncTZHa1l6a3JRRjNCMWNyaGZ2WUdrbjJ1THlNRTI4eFNIYnBwdW1wqGZkdkluVXNky0CoROThzofUqnByaWNlSW5Vc2TLPsoPC1Fz3To=',
+  'base64',
+));
+const PADRE_NATIVE_RATE_FRAME = Uint8Array.from(Buffer.from(
+  'kwVVgqx0b2tlbkFkZHJlc3PZLEZRVGtncTZHa1l6a3JRRjNCMWNyaGZ2WUdrbjJ1THlNRTI4eFNIYnBwdW1wsm5hdGl2ZVByaWNlSW5Vc2RVactAWZfzf6mDcg==',
+  'base64',
+));
 
 function runBridge(opts = {}) {
   const timers = [];
@@ -56,8 +64,16 @@ function runBridge(opts = {}) {
     createOrderLine: makeOrderLine,
   };
 
-  function FakeWebSocket() {}
-  FakeWebSocket.prototype.addEventListener = () => {};
+  function FakeWebSocket() {
+    this.listeners = {};
+    FakeWebSocket.last = this;
+  }
+  FakeWebSocket.prototype.addEventListener = function (type, listener) {
+    this.listeners[type] = listener;
+  };
+  FakeWebSocket.prototype.emit = function (data) {
+    if (this.listeners.message) this.listeners.message({ data });
+  };
   FakeWebSocket.CONNECTING = 0;
   FakeWebSocket.OPEN = 1;
   FakeWebSocket.CLOSING = 2;
@@ -123,6 +139,11 @@ function runBridge(opts = {}) {
     WeakSet,
     Symbol,
     JSON,
+    ArrayBuffer,
+    Uint8Array,
+    DataView,
+    TextDecoder,
+    Blob,
     Promise,
     isFinite,
     setInterval(fn, ms) { timers.push(fn); return timers.length; },
@@ -147,6 +168,7 @@ function runBridge(opts = {}) {
     refreshMarksCount: () => refreshMarksCount,
     orderLines,
     win,
+    openSocket() { return new win.WebSocket('wss://backend.padre.gg/_multiplex?desc=/trenches'); },
   };
 }
 
@@ -166,6 +188,56 @@ test('Padre decoded TradingView bars emit an immediate PaperTrench tick', () => 
   assert.equal(message.payload.candidates[0].value, bar.close);
   assert.equal(message.payload.mcap, bar.close,
     'the unknown chart close is offered as mcap so quote validation can identify chart mode');
+});
+
+test('Padre MessagePack frames emit mint-tagged USD ticks with their FDV cap', () => {
+  const env = runBridge();
+  const socket = env.openSocket();
+  socket.emit(PADRE_UPDATE_FRAME.buffer);
+
+  const message = env.emitted.find((m) => m.type === 'tick' && m.payload?.source === 'ws');
+  assert.ok(message, 'a decoded Padre update must feed the generic tick pipeline');
+  assert.equal(message.payload.mint, 'FQTkgq6GkYzkrQF3B1crhfvYGkn2uLyME28xSHbppump');
+  assert.equal(message.payload.candidates[0].unit, 'usd');
+  assert.equal(message.payload.candidates[0].value, 3.10644703526886e-06);
+  assert.equal(message.payload.mcap, 3106.4470352688604);
+});
+
+test('Padre Blob frames are decoded without blocking the WebSocket handler', async () => {
+  const env = runBridge();
+  const socket = env.openSocket();
+  socket.emit(new Blob([PADRE_UPDATE_FRAME]));
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.ok(env.emitted.some((m) => m.type === 'tick' && m.payload?.source === 'ws'),
+    'a Padre Blob frame must reach the same generic tick pipeline');
+});
+
+test('Padre nativePriceInUsdUi is never treated as a token price', () => {
+  const env = runBridge();
+  env.openSocket().emit(PADRE_NATIVE_RATE_FRAME.buffer);
+
+  assert.ok(!env.emitted.some((m) => m.type === 'tick' && m.payload?.source === 'ws'),
+    'the chain SOL/USD rate must not become an unattributed token tick');
+});
+
+test('malformed and oversized Padre frames are rejected without throwing', () => {
+  const env = runBridge();
+  const socket = env.openSocket();
+  assert.doesNotThrow(() => {
+    socket.emit(PADRE_UPDATE_FRAME.slice(0, 12).buffer);
+    socket.emit(new Uint8Array(512 * 1024 + 1).buffer);
+  });
+  assert.ok(!env.emitted.some((m) => m.type === 'tick' && m.payload?.source === 'ws'),
+    'invalid frames must not produce partial ticks');
+});
+
+test('non-Padre hosts ignore binary WebSocket frames', () => {
+  const env = runBridge({ href: 'https://axiom.trade/pulse' });
+  env.openSocket().emit(PADRE_UPDATE_FRAME.buffer);
+  assert.ok(!env.emitted.some((m) => m.type === 'tick' && m.payload?.source === 'ws'),
+    'binary Padre decoding must remain host-scoped');
 });
 
 test('paper buys are merged into Padre native getMarks with hover details', () => {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -574,6 +574,80 @@ test('a priced row click still commits without an armed intent', async () => {
   assert.equal(harness.getRowArmed(), null, 'a priced click does not create an armed intent');
 });
 
+test('a fresh Padre row tick wins before the resolver and carries its cap', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  harness.noteRowPrice({
+    mint: B,
+    candidates: [{ unit: 'usd', value: 0.0032 }],
+    mcap: 3200,
+    symbol: 'B',
+    name: 'Token B',
+  });
+  const buy = harness.doRowBuy(B);
+  await waitFor(() => race.isBIdentityRequested());
+  race.releaseB();
+  await buy;
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
+  assert.equal(harness.getState().journal[0].priceNative, 0.000032);
+  assert.equal(harness.getState().journal[0].priceUsd, 0.0032);
+  assert.equal(harness.getState().journal[0].mcap, 3200);
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
+    0,
+    'a fresh row tick skips resolver pricing',
+  );
+});
+
+test('a stale Padre row tick falls through to the resolver cascade', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  harness.noteRowPrice({
+    mint: B,
+    candidates: [{ unit: 'usd', value: 0.0032 }],
+    mcap: 3200,
+  });
+  race.setNow(Date.now() + 120_001);
+  const buy = harness.doRowBuy(B);
+  await waitFor(() => race.isBIdentityRequested());
+  race.releaseB();
+  await buy;
+
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
+    1,
+    'an expired row tick must use the existing resolver cascade',
+  );
+  assert.equal(harness.getState().journal[0].priceNative, 1);
+  assert.equal(harness.getState().journal[0].mcap, 100_000);
+});
+
+test('a fresh row tick without SOL/USD falls through rather than guessing', async () => {
+  const race = bootRace({ solUsdFails: true });
+  const { harness } = race;
+
+  harness.noteRowPrice({
+    mint: B,
+    candidates: [{ unit: 'usd', value: 0.0032 }],
+    mcap: 3200,
+  });
+  const buy = harness.doRowBuy(B);
+  await waitFor(() => race.isBIdentityRequested());
+  race.releaseB();
+  await buy;
+
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
+    1,
+    'without a conversion rate the row tick must fall through',
+  );
+  assert.equal(harness.getState().journal[0].priceNative, 0.000032);
+  assert.ok(Math.abs(harness.getState().journal[0].mcap - 3.2) < 1e-9);
+});
+
 test('a row-props quote fills at the tapped price without resolver or identity lookup', async () => {
   const race = bootRace();
   const { harness } = race;

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -333,6 +333,7 @@ function bootRace(options = {}) {
     getRowBuyInFlightAt: () => rowBuyInFlightAt,
     getRowBuyOwner: () => rowBuyOwner,
     getRowArmedFlushTimer: () => rowArmedFlushTimer,
+    getRecentRowPrice: (mint) => recentRowPrices.get(mint) || null,
   };
 `
     + CONTENT.slice(end);
@@ -377,6 +378,7 @@ function bootRace(options = {}) {
       releaseSolUsd(100);
     },
     messages,
+    now: () => clock,
     setNow(next) { clock = next; },
     advance,
   };
@@ -572,6 +574,44 @@ test('a priced row click still commits without an armed intent', async () => {
 
   assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
   assert.equal(harness.getRowArmed(), null, 'a priced click does not create an armed intent');
+});
+
+test('row ticks use bounded frame times and reject older same-mint ticks', () => {
+  const race = bootRace();
+  const { harness } = race;
+  const now = race.now();
+
+  harness.noteRowPrice({
+    mint: A,
+    at: now - 1_000,
+    candidates: [{ unit: 'usd', value: 100 }],
+    mcap: 100_000,
+  });
+  harness.noteRowPrice({
+    mint: A,
+    at: now - 2_000,
+    candidates: [{ unit: 'usd', value: 90 }],
+    mcap: 90_000,
+  });
+  const retained = harness.getRecentRowPrice(A);
+  assert.equal(retained.usd, 100);
+  assert.equal(retained.at, now - 1_000);
+  assert.equal(retained.symbol, null);
+  assert.equal(retained.name, null);
+  assert.equal(retained.mcap, 100_000);
+
+  harness.noteRowPrice({
+    mint: B,
+    at: now + 60_000,
+    candidates: [{ unit: 'usd', value: 200 }],
+  });
+  harness.noteRowPrice({
+    mint: C,
+    at: now - 60_000,
+    candidates: [{ unit: 'usd', value: 300 }],
+  });
+  assert.equal(harness.getRecentRowPrice(B).at, now);
+  assert.equal(harness.getRecentRowPrice(C).at, now);
 });
 
 test('a fresh Padre row tick wins before the resolver and carries its cap', async () => {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -584,34 +584,60 @@ test('row ticks use bounded frame times and reject older same-mint ticks', () =>
   harness.noteRowPrice({
     mint: A,
     at: now - 1_000,
+    seq: 10,
     candidates: [{ unit: 'usd', value: 100 }],
     mcap: 100_000,
   });
   harness.noteRowPrice({
     mint: A,
     at: now - 2_000,
+    seq: 9,
     candidates: [{ unit: 'usd', value: 90 }],
     mcap: 90_000,
   });
   const retained = harness.getRecentRowPrice(A);
   assert.equal(retained.usd, 100);
   assert.equal(retained.at, now - 1_000);
+  assert.equal(retained.seq, 10);
   assert.equal(retained.symbol, null);
   assert.equal(retained.name, null);
   assert.equal(retained.mcap, 100_000);
 
   harness.noteRowPrice({
     mint: B,
-    at: now + 60_000,
+    at: now - 45_000,
+    source: 'ws',
     candidates: [{ unit: 'usd', value: 200 }],
   });
   harness.noteRowPrice({
     mint: C,
-    at: now - 60_000,
+    at: now + 60_000,
     candidates: [{ unit: 'usd', value: 300 }],
   });
+  assert.equal(harness.getRecentRowPrice(B), null);
+  assert.equal(harness.getRecentRowPrice(C), null);
+
+  harness.noteRowPrice({
+    mint: B,
+    candidates: [{ unit: 'usd', value: 250 }],
+  });
   assert.equal(harness.getRecentRowPrice(B).at, now);
-  assert.equal(harness.getRecentRowPrice(C).at, now);
+  assert.equal(harness.getRecentRowPrice(B).seq, null);
+
+  harness.noteRowPrice({
+    mint: C,
+    at: now,
+    seq: 20,
+    candidates: [{ unit: 'usd', value: 400 }],
+  });
+  harness.noteRowPrice({
+    mint: C,
+    at: now,
+    seq: 19,
+    candidates: [{ unit: 'usd', value: 390 }],
+  });
+  assert.equal(harness.getRecentRowPrice(C).usd, 400);
+  assert.equal(harness.getRecentRowPrice(C).seq, 20);
 });
 
 test('a fresh Padre row tick wins before the resolver and carries its cap', async () => {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -648,6 +648,31 @@ test('a fresh row tick without SOL/USD falls through rather than guessing', asyn
   assert.ok(Math.abs(harness.getState().journal[0].mcap - 3.2) < 1e-9);
 });
 
+test('a fresh row tick with a hung SOL/USD lookup falls through to the resolver', async () => {
+  const race = bootRace({ holdSolUsd: true });
+  const { harness } = race;
+
+  harness.noteRowPrice({
+    mint: B,
+    candidates: [{ unit: 'usd', value: 0.0032 }],
+    mcap: 3200,
+  });
+  const buy = harness.doRowBuy(B);
+  await waitFor(() => race.isSolUsdRequested());
+  await race.advance(2_001);
+  await waitFor(() => race.isBIdentityRequested());
+  race.releaseB();
+  await buy;
+
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
+    1,
+    'a hung row-feed conversion must fall through to resolver pricing',
+  );
+  assert.equal(harness.getState().journal.length, 1, 'the timed-out tap still fills');
+  assert.equal(harness.getRowBuyInFlight(), false, 'the row-buy latch is released');
+});
+
 test('a row-props quote fills at the tapped price without resolver or identity lookup', async () => {
   const race = bootRace();
   const { harness } = race;


### PR DESCRIPTION
## Summary

Stacked on #102. Padre's trenches board had no price source at all — every tap there went to the resolver, and the ones it couldn't answer armed invisibly. It turns out Padre streams its own prices and we were throwing the frames away over a wrong comment:

```js
// price-bridge.js, before this PR
// Padre's multiplex messages are binary protobuf and are deliberately
// handled after Padre decodes them through its TradingView datafeed.
if (typeof event.data === 'string') forwardJson(event.data, 'ws');   // binary: dropped
```

They aren't protobuf. I captured 30 s off your logged-in board (1032 frames from `backend.padre.gg/_multiplex` and `_heavy_multiplex`) and they're MessagePack, envelope `[kind, channelId, payload]`, carrying **553** objects like these in that window:

```text
{tokenAddress: "FQTkgq…pump", priceInUsd: 3.10644703526886e-06,  fdvInUsd: 3106.4470352688604}
{tokenAddress: "CW6MAQ…nSPG", priceInUsd: 1.380879865435091e-05, fdvInUsd: 13808.79865435091}
```

`fdvInUsd / priceInUsd` = 1.0000e9 on every sample — the pump.fun supply — so the pair is coherent, and both keys name their denomination in the key itself. Decoding those into the tick pipeline we already have (`collect` → `noteRowPrice` → `recentRowPrices`) is all Padre needed; `priceInUsd` and `fdvInUsd` join the existing key patterns and everything downstream is unchanged.

**One key in that stream is a trap and is deliberately excluded:** `nativePriceInUsdUi` (102.374 in the capture) is the *chain's* native-asset price, not a token's. Reading it as one would price every coin at ~$102. There's a test asserting it never becomes a candidate for any mint.

The decoder is written to be safe on a hot path fed by a remote server: first value only, 512 KB byte cap, node budget, no ext types, and `null` — never a throw, never a partial object — on anything malformed or truncated.

**Second half: a fresh tick now beats the resolver.** The cascade consulted the board's own price only *after* two resolver round trips, so a tap waited on the network while the number it wanted was already in hand:

```js
// before:  resolve(maxAge 3s) -> resolve() -> rowLivePrice -> chain
// after:
const fresh = await Promise.race([rowLivePrice(address).catch(() => null), timeout(2000)]);
if (fresh) data = { …fresh, mint: address, priceSource: 'row-feed' };
else       …existing cascade, unchanged…
```

`row-feed` with `mint: address` is exactly what the in-cascade branch already produced, so identity repair and the witness rules (including large-jump-needs-a-resolver-witness) behave as before. No SOL/USD rate, or a rate lookup that stalls, means no fill from this path — it falls through to the cascade rather than guessing a conversion, and the 2 s bound keeps a hung rate lookup off the tap. The tick's cap rides along with its price now (`noteRowPrice` keeps `mcap`), so an entry cap is never a price times a guessed supply.

Padre's rows themselves stay a dead end, and that's not a gap in this PR: re-probing four live rows for any key matching `price|usd|fdv|mcap|supply|liquid|decimals|reserve|quote` at depth 5 returned nothing — the "MC $26K" they print is formatted text. The feed is the only honest instant price there.

## Testing

`cd extension && node --test` — 2,186 passed, 0 failed. New cases: the recorded Padre envelope decodes to a mint-tagged USD tick carrying `fdvInUsd` as the cap; `nativePriceInUsdUi` never becomes a price candidate; malformed, truncated and oversized frames yield `null` with no tick and no throw; a Padre tap with a fresh tick fills at the tick's price with no resolver price call and books the tick's cap; a stale tick still runs the cascade; a fresh tick with no rate, and one whose rate lookup never settles, both fall through to the cascade and still fill from the resolver with the latch released; binary frames stay ignored on non-Padre hosts. Not yet exercised against a live Padre tap — that's the next live pass.


Link to Devin session: https://app.devin.ai/sessions/b676704d774f4aa099ba7f31381b036f
Open in Devin Desktop: https://app.devin.ai/desktop/session/b676704d774f4aa099ba7f31381b036f?variant=devin
Requested by: @OnlyTerp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/papertrench/pull/103" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->