### PR TITLE
fix(quickbuy): reach the row's real cap and ticker, and never book a cap the price disagrees with

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -6573,7 +6573,7 @@
   // Newest USD price per mint from the site's OWN realtime feed (GMGN's
   // token_activity ticks carry a mint). A row buy prefers this over a
   // network quote because the screener is showing that very price.
-  const recentRowPrices = new Map(); // mint -> { usd, at }
+  const recentRowPrices = new Map(); // mint -> { usd, at, seq, symbol, name, mcap }
   const ROW_PRICE_TTL_MS = 10_000;
   let rowBuyScanAt = 0;
   let rowBuyInFlight = false;
@@ -6677,32 +6677,46 @@
 
   async function validRowPropsQuote(quote, address) {
     if (!quote || typeof quote !== 'object' || !ROW_ADDR_EXACT_RE.test(address || '')) return false;
-    const mint = quote.mint || null;
-    const pair = quote.pair || null;
+    const normalized = { ...quote };
+    const mint = normalized.mint || null;
+    const pair = normalized.pair || null;
     if ((mint && !ROW_ADDR_EXACT_RE.test(mint)) || (pair && !ROW_ADDR_EXACT_RE.test(pair))) return false;
     if ((!mint && !pair) || (mint !== address && pair !== address)) return false;
-    const hasPriceSol = quote.priceSol != null;
-    const hasPriceUsd = quote.priceUsd != null;
+    const hasPriceSol = normalized.priceSol != null;
+    const hasPriceUsd = normalized.priceUsd != null;
     if (!hasPriceSol && !hasPriceUsd) return false;
     for (const name of ['priceUsd', 'mcapUsd', 'supply']) {
-      if (quote[name] != null
-        && !(Number.isFinite(Number(quote[name])) && Number(quote[name]) > 0)) return false;
+      if (normalized[name] != null
+        && !(Number.isFinite(Number(normalized[name])) && Number(normalized[name]) > 0)) {
+        if (name !== 'mcapUsd') return false;
+        normalized.mcapUsd = null;
+      }
     }
     if (hasPriceSol
-        && !(Number.isFinite(Number(quote.priceSol)) && Number(quote.priceSol) > 0)) return false;
+        && !(Number.isFinite(Number(normalized.priceSol)) && Number(normalized.priceSol) > 0)) return false;
+    if (normalized.mcapUsd != null
+        && (!(Number(normalized.priceUsd) > 0 && Number(normalized.supply) > 0)
+          || Math.abs(Number(normalized.mcapUsd)
+            / (Number(normalized.priceUsd) * Number(normalized.supply)) - 1) > 0.02)) {
+      normalized.mcapUsd = null;
+    }
+    for (const [name, maxLength] of [['symbol', 24], ['name', 64]]) {
+      if (normalized[name] != null
+          && (typeof normalized[name] !== 'string'
+            || normalized[name].length > maxLength
+            || ROW_ADDR_EXACT_RE.test(normalized[name]))) normalized[name] = null;
+    }
     if (hasPriceUsd && !hasPriceSol) {
-      if (!(quote.supply > 0 && quote.mcapUsd > 0)
-          || Math.abs(Number(quote.priceUsd) * Number(quote.supply)
-            / Number(quote.mcapUsd) - 1) > 0.02) return false;
+      if (!(normalized.supply > 0 && normalized.mcapUsd > 0)) return false;
       const rate = await Promise.race([
         Promise.resolve().then(() => R.solUsd()).catch(() => 0),
         new Promise((resolve) => setTimeout(() => resolve(0), 2000)),
       ]);
       if (!(rate > 0)) return false;
-      return { ...quote, priceSol: Number(quote.priceUsd) / Number(rate) };
+      return { ...normalized, priceSol: Number(normalized.priceUsd) / Number(rate) };
     }
     if (hasPriceUsd) {
-      const implied = Number(quote.priceUsd) / Number(quote.priceSol);
+      const implied = Number(normalized.priceUsd) / Number(normalized.priceSol);
       const rate = await Promise.race([
         Promise.resolve().then(() => R.solUsd()).catch(() => 0),
         new Promise((resolve) => setTimeout(() => resolve(0), 2000)),
@@ -6710,7 +6724,7 @@
       if (rate > 0 && (!(implied > 0)
         || Math.max(implied / rate, rate / implied) > 1.25)) return false;
     }
-    return { ...quote, priceSol: Number(quote.priceSol) };
+    return { ...normalized, priceSol: Number(normalized.priceSol) };
   }
 
   /**
@@ -7056,8 +7070,8 @@
         data = {
           mint: validRowQuote.mint || address,
           pairAddress: validRowQuote.pair || null,
-          symbol: null,
-          name: null,
+          symbol: validRowQuote.symbol || null,
+          name: validRowQuote.name || null,
           priceNative: validRowQuote.priceSol,
           priceUsd: validRowQuote.priceUsd || null,
           mcap: validRowQuote.mcapUsd || null,

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -359,6 +359,7 @@
   // front reported ever older prices exactly as batches grew with volume
   // (DEFECT F-03). The budget only bites on pathological frames.
   const NODE_BUDGET = 20_000;
+  const padreSupplyByMint = new Map();
   // Identifier strength: on several sites `address`/`ca` carry the AMM/pool
   // address rather than the token mint, so an explicit mint-ish key must win
   // the record association when both appear on one object.
@@ -458,6 +459,47 @@
     return { records, top };
   }
 
+  function notePadreSupplies(obj) {
+    const seen = new WeakSet();
+    let budget = NODE_BUDGET;
+    (function walk(node, depth) {
+      if (!node || typeof node !== 'object' || depth > MAX_DEPTH || seen.has(node)) return;
+      if (budget-- <= 0) return;
+      seen.add(node);
+      if (typeof node.tokenAddress === 'string' && BASE58_RE.test(node.tokenAddress)) {
+        const totalSupply = numberValue(node.totalSupply);
+        const decimals = numberValue(node.decimals);
+        const supply = totalSupply > 0 && Number.isInteger(decimals) && decimals >= 0 && decimals <= 30
+          ? totalSupply / (10 ** decimals)
+          : null;
+        if (supply > 0 && Number.isFinite(supply)) {
+          padreSupplyByMint.set(node.tokenAddress, supply);
+          if (padreSupplyByMint.size > 300) {
+            padreSupplyByMint.delete(padreSupplyByMint.keys().next().value);
+          }
+        }
+      }
+      for (const value of Object.values(node)) walk(value, depth + 1);
+    })(obj, 0);
+  }
+
+  function normalizePadreCaps(records) {
+    for (const rec of records.values()) {
+      const supply = padreSupplyByMint.get(rec.mint);
+      const price = rec.candidates.find((candidate) => candidate.key === 'priceInUsd');
+      if (!(supply > 0) || !(price && price.value > 0) || !(rec.mcap > 0)) {
+        rec.mcap = null;
+        continue;
+      }
+      const derived = price.value * supply;
+      if (!(derived > 0) || !Number.isFinite(derived)) {
+        rec.mcap = null;
+      } else if (Math.abs(rec.mcap / derived - 1) > 0.02) {
+        rec.mcap = derived;
+      }
+    }
+  }
+
   // GMGN's realtime WebSocket publishes every venue trade on the
   // `token_activity` channel with terse keys: `a` = token mint, `pu` = trade
   // price in USD, `e` = buy/sell. The generic key scanner cannot see these
@@ -532,7 +574,7 @@
     return true;
   }
 
-  function forwardJson(raw, source, url, receivedAt, seq) {
+  function forwardJson(raw, source, url, receivedAt, seq, padreBinary = false) {
     // No consumer, no parse — the cheapest frame is the one never read.
     if (!feedActive()) return;
     let parsed = raw;
@@ -569,6 +611,7 @@
     if (!parsed || typeof parsed !== 'object') return;
 
     if (forwardTokenActivity(parsed)) return;
+    if (padreBinary) notePadreSupplies(parsed);
 
     // GMGN's embedded TradingView chart is explicitly a market-cap chart:
     // /api/v1/token_mcap_candles/... returns USD market-cap OHLC values in
@@ -599,6 +642,7 @@
     }
 
     const { records, top } = collect(parsed);
+    if (padreBinary) normalizePadreCaps(records);
     const hasContent = (rec) => rec.candidates.length || rec.mcap !== null;
     if (records.size) {
       // Watched token first — the GMGN fast-path contract, now generic — then
@@ -701,12 +745,12 @@
           forwardJson(event.data, 'ws', undefined, receivedAt, seq);
         } else if (hostIsPadre && feedActive() && event.data instanceof ArrayBuffer) {
           const decoded = decodeMsgpack(new Uint8Array(event.data));
-          if (decoded !== null) forwardJson(decoded, 'ws', undefined, receivedAt, seq);
+          if (decoded !== null) forwardJson(decoded, 'ws', undefined, receivedAt, seq, true);
         } else if (hostIsPadre && feedActive()
           && typeof Blob === 'function' && event.data instanceof Blob) {
           Promise.resolve(event.data.arrayBuffer()).then((buffer) => {
             const decoded = decodeMsgpack(new Uint8Array(buffer));
-            if (decoded !== null) forwardJson(decoded, 'ws', undefined, receivedAt, seq);
+            if (decoded !== null) forwardJson(decoded, 'ws', undefined, receivedAt, seq, true);
           }, () => {});
         }
       });
@@ -3725,7 +3769,7 @@
       const stack = [start];
       const candidates = [];
       const identityKeys = new Set([
-        'tokenAddress', 'mint', 'address', 'pairAddress', 'pool_address',
+        'tokenAddress', 'mint', 'address', 'pairAddress', 'pool_address', 'pair',
       ]);
       const priceKeys = new Set([
         'priceSol', 'priceNative', 'tokenPriceUsd', 'priceUsd',
@@ -3739,6 +3783,16 @@
         for (const [name, value] of Object.entries(obj)) {
           if (identityKeys.has(name)) {
             if (typeof value === 'string' && BASE58_RE.test(value)) fields[name] = value;
+            continue;
+          }
+          if ((name === 'tokenTicker' || name === 'symbol' || name === 'ticker')
+              && typeof value === 'string' && value.length <= 24 && !BASE58_RE.test(value)) {
+            fields.symbol = value;
+            continue;
+          }
+          if ((name === 'tokenName' || name === 'name')
+              && typeof value === 'string' && value.length <= 64 && !BASE58_RE.test(value)) {
+            fields.name = value;
             continue;
           }
           if (badKey.test(name)) continue;
@@ -3781,7 +3835,7 @@
         }
       };
       let steps = 0;
-      while (stack.length && steps++ < 80) {
+      while (stack.length && steps++ < 400) {
         const fiber = stack.pop();
         if (!fiber || seen.has(fiber)) continue;
         seen.add(fiber);
@@ -3789,6 +3843,12 @@
         walk(fiber.memoizedState, 0);
         if (fiber.child) stack.push(fiber.child);
         if (fiber.sibling) stack.push(fiber.sibling);
+      }
+      for (let fiber = start, ancestors = 0; fiber && ancestors < 12; fiber = fiber.return, ancestors++) {
+        if (seen.has(fiber)) continue;
+        seen.add(fiber);
+        walk(fiber.memoizedProps, 0);
+        walk(fiber.memoizedState, 0);
       }
       const matching = candidates.filter((fields) =>
         fields.tokenAddress === tappedAddress
@@ -3800,7 +3860,8 @@
       const selected = matching.reduce((best, fields) =>
         !best || Object.keys(fields).length > Object.keys(best).length ? fields : best, null);
       const usd = candidates.find((fields) =>
-        fields.tokenAddress
+        fields !== selected
+        && fields.tokenAddress
         && fields.tokenAddress === selected.tokenAddress
         && (fields.tokenPriceUsd !== undefined
           || fields.priceUsd !== undefined
@@ -3811,14 +3872,22 @@
           if (merged[name] === undefined && usd[name] !== undefined) merged[name] = usd[name];
         }
       }
-      return {
+      let mcapUsd = merged.marketCapUsd || merged.mcapUsd || null;
+      const priceUsd = merged.tokenPriceUsd || merged.priceUsd || null;
+      const supply = merged.supply || merged.total_supply || merged.totalSupply || null;
+      if (!(mcapUsd > 0 && priceUsd > 0 && supply > 0)
+          || Math.abs(mcapUsd / (priceUsd * supply) - 1) > 0.02) mcapUsd = null;
+      const quote = {
         mint: merged.tokenAddress || merged.mint || merged.address || null,
         pair: merged.pairAddress || merged.pair || merged.pool_address || null,
         priceSol: merged.priceSol || merged.priceNative || null,
-        priceUsd: merged.tokenPriceUsd || merged.priceUsd || null,
-        mcapUsd: merged.marketCapUsd || merged.mcapUsd || null,
-        supply: merged.supply || merged.total_supply || merged.totalSupply || null,
+        priceUsd,
+        mcapUsd,
+        supply,
       };
+      if (merged.symbol !== undefined) quote.symbol = merged.symbol;
+      if (merged.name !== undefined) quote.name = merged.name;
+      return quote;
     } catch (_) {
       return null;
     }

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3769,7 +3769,7 @@
       const stack = [start];
       const candidates = [];
       const identityKeys = new Set([
-        'tokenAddress', 'mint', 'address', 'pairAddress', 'pool_address', 'pair',
+        'tokenAddress', 'mint', 'address', 'pairAddress', 'pool_address',
       ]);
       const priceKeys = new Set([
         'priceSol', 'priceNative', 'tokenPriceUsd', 'priceUsd',

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3859,17 +3859,13 @@
       if (!matching.length) return null;
       const selected = matching.reduce((best, fields) =>
         !best || Object.keys(fields).length > Object.keys(best).length ? fields : best, null);
-      const usd = candidates.find((fields) =>
-        fields !== selected
-        && fields.tokenAddress
-        && fields.tokenAddress === selected.tokenAddress
-        && (fields.tokenPriceUsd !== undefined
-          || fields.priceUsd !== undefined
-          || fields.marketCapUsd !== undefined));
       const merged = { ...selected };
-      if (usd) {
+      for (const fields of candidates) {
+        if (fields === selected
+            || !fields.tokenAddress
+            || fields.tokenAddress !== selected.tokenAddress) continue;
         for (const name of ['tokenPriceUsd', 'priceUsd', 'marketCapUsd']) {
-          if (merged[name] === undefined && usd[name] !== undefined) merged[name] = usd[name];
+          if (merged[name] === undefined && fields[name] !== undefined) merged[name] = fields[name];
         }
       }
       let mcapUsd = merged.marketCapUsd || merged.mcapUsd || null;

--- a/extension/test/padrebridge.test.js
+++ b/extension/test/padrebridge.test.js
@@ -29,6 +29,14 @@ const PADRE_NATIVE_RATE_FRAME = Uint8Array.from(Buffer.from(
   'kwVVgqx0b2tlbkFkZHJlc3PZLEZRVGtncTZHa1l6a3JRRjNCMWNyaGZ2WUdrbjJ1THlNRTI4eFNIYnBwdW1wsm5hdGl2ZVByaWNlSW5Vc2RVactAWZfzf6mDcg==',
   'base64',
 ));
+const PADRE_DOUBLED_FDV_FRAME = Uint8Array.from(Buffer.from(
+  'kwVVgqR0eXBlpnVwZGF0ZaZ1cGRhdGWCpGFkZHORhax0b2tlbkFkZHJlc3PZLDI1YXBwb1hxTTV4cloxRnNKa3ozRDZUOW16MUpLWXF6OHhab0ZCVExwdW1wqnByaWNlSW5Vc2TLPnYzGcku/HuoZmR2SW5Vc2TLQGSuFHrhR66rdG90YWxTdXBwbHnPAAONfqTGgACoZGVjaW1hbHMGp3VwZGF0ZXOQ',
+  'base64',
+));
+const PADRE_COHERENT_FDV_FRAME = Uint8Array.from(Buffer.from(
+  'kwVVgqR0eXBlpnVwZGF0ZaZ1cGRhdGWCpGFkZHORhax0b2tlbkFkZHJlc3PZLENvelh5M1VlTkJ4NzNib0JqRnA0UjNrZ2VVVlRYckp4cWRoeXdXTVBwdW1wqnByaWNlSW5Vc2TLPtR/YFTL1qWoZmR2SW5Vc2TLQLMXAAAAAACrdG90YWxTdXBwbHnPAAONfqTGgACoZGVjaW1hbHMGp3VwZGF0ZXOQ',
+  'base64',
+));
 
 function runBridge(opts = {}) {
   let clock = Date.now();
@@ -257,7 +265,7 @@ test('Padre decoded TradingView bars emit an immediate PaperTrench tick', () => 
     'the unknown chart close is offered as mcap so quote validation can identify chart mode');
 });
 
-test('Padre MessagePack frames emit mint-tagged USD ticks with their FDV cap', () => {
+test('Padre MessagePack frames emit mint-tagged USD ticks without an unverified cap', () => {
   const env = runBridge();
   const socket = env.openSocket();
   socket.emit(PADRE_UPDATE_FRAME.buffer);
@@ -267,7 +275,28 @@ test('Padre MessagePack frames emit mint-tagged USD ticks with their FDV cap', (
   assert.equal(message.payload.mint, 'FQTkgq6GkYzkrQF3B1crhfvYGkn2uLyME28xSHbppump');
   assert.equal(message.payload.candidates[0].unit, 'usd');
   assert.equal(message.payload.candidates[0].value, 3.10644703526886e-06);
-  assert.equal(message.payload.mcap, 3106.4470352688604);
+  assert.equal(message.payload.mcap, null);
+});
+
+test('Padre replaces a doubled FDV with price times the derived supply', () => {
+  const env = runBridge();
+  env.openSocket().emit(PADRE_DOUBLED_FDV_FRAME.buffer);
+
+  const message = env.emitted.find((m) => m.type === 'tick' && m.payload?.source === 'ws');
+  assert.ok(message);
+  assert.equal(message.payload.mint, '25appoXqM5xrZ1FsJkz3D6T9mz1JKYqz8xZoFBTLpump');
+  assert.equal(message.payload.candidates[0].value, 8.27e-8);
+  assert.equal(message.payload.mcap, 82.7);
+});
+
+test('Padre keeps a coherent FDV when the derived supply proves it', () => {
+  const env = runBridge();
+  env.openSocket().emit(PADRE_COHERENT_FDV_FRAME.buffer);
+
+  const message = env.emitted.find((m) => m.type === 'tick' && m.payload?.source === 'ws');
+  assert.ok(message);
+  assert.equal(message.payload.mint, 'CozXy3UeNBx73boBjFp4R3kgeUVTXrJxqdhywWMPpump');
+  assert.equal(message.payload.mcap, 4887);
 });
 
 test('Padre Blob frames are decoded without blocking the WebSocket handler', async () => {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -323,6 +323,7 @@ function bootRace(options = {}) {
   window.__rowHarness = {
     doRowBuy,
     noteRowPrice,
+    validRowPropsQuote,
     flushRowArmed,
     enableOverlay,
     getState: () => state,
@@ -750,6 +751,8 @@ test('a row-props quote fills at the tapped price without resolver or identity l
     priceUsd: 0.0032,
     mcapUsd: 3200,
     supply: 100_000_000,
+    symbol: 'CRAP',
+    name: 'dinosaur crap',
   });
 
   assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
@@ -765,6 +768,8 @@ test('a row-props quote fills at the tapped price without resolver or identity l
     'an authoritative row-props mint skips identity probing',
   );
   assert.equal(harness.getState().journal[0].priceNative, 0.000032);
+  assert.equal(harness.getState().journal[0].symbol, 'CRAP');
+  assert.equal(harness.getState().positions[B].name, 'dinosaur crap');
 });
 
 test('a USD-only GMGN row-props quote converts with the site rate', async () => {
@@ -819,6 +824,34 @@ test('a USD-only row-props quote without a SOL/USD rate falls back', async () =>
 test('row-props validation has its own exact address check', () => {
   assert.match(CONTENT, /const ROW_ADDR_RE = \/\[1-9A-HJ-NP-Za-km-z\]\{32,44\}\//);
   assert.match(CONTENT, /const ROW_ADDR_EXACT_RE = \/\^\[1-9A-HJ-NP-Za-km-z\]\{32,44\}\$\//);
+});
+
+test('row-props validation drops an incoherent cap but keeps the price', async () => {
+  const race = bootRace();
+  const quote = await race.harness.validRowPropsQuote({
+    mint: B,
+    pair: PAIR,
+    priceSol: 0.000032,
+    priceUsd: 0.0032,
+    mcapUsd: 6400,
+    supply: 1_000_000,
+  }, B);
+  assert.equal(quote.priceSol, 0.000032);
+  assert.equal(quote.priceUsd, 0.0032);
+  assert.equal(quote.mcapUsd, null);
+});
+
+test('row-props validation rejects address-shaped metadata', async () => {
+  const race = bootRace();
+  const quote = await race.harness.validRowPropsQuote({
+    mint: B,
+    pair: PAIR,
+    priceSol: 0.000032,
+    symbol: A,
+    name: A,
+  }, B);
+  assert.equal(quote.symbol, null);
+  assert.equal(quote.name, null);
 });
 
 test('an invalid row-props identity falls back to the resolver', async () => {

--- a/extension/test/rowprops.test.js
+++ b/extension/test/rowprops.test.js
@@ -42,6 +42,18 @@ function makeRow(memoizedProps, memoizedState) {
   return row;
 }
 
+function makeFiberChain(length, targetIndex, targetProps) {
+  const start = { memoizedProps: {} };
+  let fiber = start;
+  for (let index = 1; index <= length; index += 1) {
+    fiber.sibling = { memoizedProps: index === targetIndex ? targetProps : {} };
+    fiber = fiber.sibling;
+  }
+  const row = {};
+  row.__reactFiber$test = start;
+  return row;
+}
+
 test('a tapped Axiom row yields its coherent mint, pair, SOL and USD quote', () => {
   const row = makeRow(
     {
@@ -199,6 +211,96 @@ test('a GMGN bare price that disagrees with supply and cap is rejected', () => {
     usd_market_cap: 2874.92,
     total_supply: 1_000_000_000,
   }), A), null);
+});
+
+test('an Axiom row can combine bounded ancestor records for the tapped token', () => {
+  const start = {
+    tokenAddress: A,
+    pairAddress: PAIR,
+    priceSol: 0.000032,
+    tokenPriceUsd: 0.000032,
+    supply: 1_000_000_000,
+    tokenTicker: 'crap',
+    tokenName: 'dinosaur crap',
+  };
+  const row = makeRow(start);
+  let fiber = row.__reactFiber$test;
+  for (let up = 1; up <= 7; up += 1) {
+    fiber.return = { memoizedProps: up === 7
+      ? { row: { tokenAddress: A, marketCapUsd: 32_000 } }
+      : { row: { tokenAddress: A } } };
+    fiber = fiber.return;
+  }
+  assert.deepEqual(JSON.parse(JSON.stringify(quoteExtractor()(row, A))), {
+    mint: A,
+    pair: PAIR,
+    priceSol: 0.000032,
+    priceUsd: 0.000032,
+    mcapUsd: 32_000,
+    supply: 1_000_000_000,
+    symbol: 'crap',
+    name: 'dinosaur crap',
+  });
+});
+
+test('an ancestor record for another token cannot leak into the tapped row quote', () => {
+  const row = makeRow({ tokenAddress: A, priceSol: 0.1 });
+  row.__reactFiber$test.return = {
+    memoizedProps: {
+      row: { tokenAddress: B, priceSol: 9, marketCapUsd: 900_000, supply: 100_000 },
+    },
+  };
+  const quote = quoteExtractor()(row, A);
+  assert.equal(quote.mint, A);
+  assert.equal(quote.priceSol, 0.1);
+  assert.equal(quote.mcapUsd, null);
+});
+
+test('a GMGN record beyond 80 fibers is found within the 400-step bound', () => {
+  const row = makeFiberChain(220, 211, {
+    address: A,
+    pool_address: PAIR,
+    price: 0.000002,
+    usd_market_cap: 2_000,
+    total_supply: 1_000_000_000,
+  });
+  const quote = quoteExtractor()(row, A);
+  assert.equal(quote.mint, A);
+  assert.equal(quote.priceUsd, 0.000002);
+});
+
+test('a GMGN record beyond 400 fibers remains out of bounds', () => {
+  const row = makeFiberChain(420, 411, {
+    address: A,
+    pool_address: PAIR,
+    price: 0.000002,
+    usd_market_cap: 2_000,
+    total_supply: 1_000_000_000,
+  });
+  assert.equal(quoteExtractor()(row, A), null);
+});
+
+test('an incoherent USD cap is dropped while the coherent price remains', () => {
+  const quote = quoteExtractor()(makeRow({
+    tokenAddress: A,
+    priceSol: 0.000032,
+    tokenPriceUsd: 0.0032,
+    marketCapUsd: 6_400,
+    supply: 1_000_000,
+  }), A);
+  assert.equal(quote.priceUsd, 0.0032);
+  assert.equal(quote.mcapUsd, null);
+});
+
+test('symbol and name values that look like addresses are rejected', () => {
+  const quote = quoteExtractor()(makeRow({
+    tokenAddress: A,
+    priceSol: 0.000032,
+    symbol: B,
+    name: B,
+  }), A);
+  assert.equal(quote.symbol, undefined);
+  assert.equal(quote.name, undefined);
 });
 
 test('Padre dev funding amounts never become row prices', () => {

--- a/extension/test/rowprops.test.js
+++ b/extension/test/rowprops.test.js
@@ -218,7 +218,6 @@ test('an Axiom row can combine bounded ancestor records for the tapped token', (
     tokenAddress: A,
     pairAddress: PAIR,
     priceSol: 0.000032,
-    tokenPriceUsd: 0.000032,
     supply: 1_000_000_000,
     tokenTicker: 'crap',
     tokenName: 'dinosaur crap',
@@ -227,10 +226,11 @@ test('an Axiom row can combine bounded ancestor records for the tapped token', (
   let fiber = row.__reactFiber$test;
   for (let up = 1; up <= 7; up += 1) {
     fiber.return = { memoizedProps: up === 7
-      ? { row: { tokenAddress: A, marketCapUsd: 32_000 } }
+      ? { action: { props: { tokenAddress: A, tokenPriceUsd: 0.000032 } } }
       : { row: { tokenAddress: A } } };
     fiber = fiber.return;
   }
+  fiber.return = { memoizedProps: { row: { tokenAddress: A, marketCapUsd: 32_000 } } };
   assert.deepEqual(JSON.parse(JSON.stringify(quoteExtractor()(row, A))), {
     mint: A,
     pair: PAIR,


### PR DESCRIPTION
## Summary

Live testing of the row-quote work (#101/#102/#103) on the logged-in terminals found three ways a chip fill could still be wrong or empty. All three are fixed here, and every rule below is backed by a measurement I took off the live boards over CDP, not an assumption.

**GMGN's direct quote never fired.** `rowQuoteFromFiber` walks at most 80 fibers. From the row element `findRowContainer` actually returns on gmgn.ai (331x88, `flex flex-1 gap-[8px]`), the row's record sits at fiber step **211–298** — so live extraction produced 0 candidates and every GMGN tap fell back to the aggregator cascade. Budget raised to 400; the record is found and the proven-USD path works as designed.

**Axiom booked no market cap and no symbol.** The walk only descended. Measured on axiom.trade/discover, the row's own record lives on *ancestor* fibers:

```
up=1  props.row              { tokenAddress, pairAddress, tokenTicker: "Agatha", tokenName: "The Sperm Guzzler",
                               supply: 1e9, priceSol: 8.17963301527259e-08, marketCapSol: 81.7963… }
up=7  props.row              { tokenAddress, marketCapUsd: 8326.866409547496 }
up=7  props.action.props     { tokenAddress, tokenPriceUsd: 8.326866409547496e-06 }
```

so the cap, the USD price and the ticker were all on screen and all unreachable — hence the null entry MC and the truncated-address "symbol" in the live run. The extractor now also climbs up to 12 ancestor fibers, under the *same* rules (identity and price from one object, only the narrow same-`tokenAddress` USD merge, final quote must match the tapped address — that filter is what keeps a virtualized list's other rows out). `tokenTicker`/`symbol` and `tokenName`/`name` ride along, rejected if they look like a base58 address.

**Padre's own FDV is sometimes exactly double the real cap**, so it must not be booked as-is. Captured from Padre's feed vs Dexscreener ground truth:

| mint | Padre `priceInUsd` / `fdvInUsd` | Dexscreener price / fdv |
|---|---|---|
| `25appo…pump` | 8.271838887295e-08 / 165.44 | 8.132e-08 / **81.32** |
| `CozXy…pump` | 4.90270942103877e-06 / 9805.42 | 4.887e-06 / **4887.01** |

The price agrees; the cap is 2x. Within one mint's stream the `fdv/price` ratio even flips 1e9 → 2e9 mid-session. On the Padre path only, the bridge now remembers each mint's supply from Padre's own `totalSupply`/`decimals` and:

```js
if (!supply)                              cap = null;               // unverifiable — book nothing
else if (|fdv / (price*supply) - 1| <= .02) cap = fdv;              // Padre's own number checks out
else                                        cap = price * supply;   // same feed, definitional
```

Same reconciliation guards the row-props path in both worlds: a `mcapUsd` that isn't within 2% of `priceUsd * supply` is dropped (the price still fills) — in the bridge, and again in `validRowPropsQuote`, since the bridge runs in the page's MAIN world.

Worth recording, since it looked like a bug and isn't: the caps the extension booked in the live run were **right** and the terminals' displayed caps were wrong or stale — booked SAVIOR $232.61 vs Dexscreener 232.61 (both boards printed ~$464), booked FUKYEAH ~$26.3K vs 26,303.96 (Padre printed $23.6K).

## Testing

`cd extension && node --test`: 2,202 passed. `scripts/preflight.sh`: 2,501 passed across extension/server/bot. New coverage: ancestor-only Axiom shape (cap + ticker + name), an ancestor record for a *different* token not leaking in, a GMGN record at fiber 211 found / at 411 still out of bounds, incoherent cap dropped while the price survives on both sides, address-shaped symbol/name rejected, and Padre doubled-FDV → `price*supply` / coherent FDV kept / unknown supply → no cap. Each behaviour was revert-proved (remove the guard, the matching test fails).

Still to verify live against this build.


Link to Devin session: https://app.devin.ai/sessions/b676704d774f4aa099ba7f31381b036f
Open in Devin Desktop: https://app.devin.ai/desktop/session/b676704d774f4aa099ba7f31381b036f?variant=devin
Requested by: @OnlyTerp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/papertrench/pull/104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->