### PR TITLE
fix(quickbuy): queue a second row tap instead of throwing it away, and never call a no-op a fill

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -1179,17 +1179,42 @@ function clearWarmTabState() {
  * with the browser, like the intent always should) and the coin's own chart
  * page adopts it into its own D-39 armedBuy machinery, TTL and all. */
 const ARMED_ROW_KEY = 'pt_armed_row_intent';
-function writeArmedRowIntent(intent) {
-  return new Promise((resolve) => chrome.storage.session.set({ [ARMED_ROW_KEY]: intent }, () => resolve()));
+const ARMED_ROW_MAX = 3;
+function normalizeArmedRowIntents(value) {
+  const list = Array.isArray(value) ? value : (value && value.address ? [value] : []);
+  return list.filter((intent) => intent && typeof intent.address === 'string'
+    && Number(intent.amount) > 0 && Number.isFinite(Number(intent.at)));
 }
 function readArmedRowIntent() {
   return new Promise((resolve) => chrome.storage.session.get([ARMED_ROW_KEY], (value) => {
     if (chrome.runtime && chrome.runtime.lastError) { resolve(null); return; }
-    resolve(value[ARMED_ROW_KEY] || null);
+    resolve(normalizeArmedRowIntents(value[ARMED_ROW_KEY]));
   }));
 }
-function clearArmedRowIntent() {
-  return new Promise((resolve) => chrome.storage.session.remove(ARMED_ROW_KEY, () => resolve()));
+async function writeArmedRowIntent(intent) {
+  const list = await readArmedRowIntent();
+  const index = list.findIndex((item) => item.address === intent.address);
+  if (index !== -1) {
+    list[index] = { address: intent.address, amount: intent.amount, at: intent.at };
+  } else {
+    list.push({ address: intent.address, amount: intent.amount, at: intent.at });
+  }
+  while (list.length > ARMED_ROW_MAX) list.shift();
+  return new Promise((resolve) => chrome.storage.session.set({ [ARMED_ROW_KEY]: list }, () => resolve()));
+}
+function clearArmedRowIntent(address) {
+  if (!address) {
+    return new Promise((resolve) => chrome.storage.session.remove(ARMED_ROW_KEY, () => resolve()));
+  }
+  return readArmedRowIntent().then((list) => {
+    const remaining = list.filter((intent) => intent.address !== address);
+    if (!remaining.length) {
+      return new Promise((resolve) => chrome.storage.session.remove(ARMED_ROW_KEY, () => resolve()));
+    }
+    return new Promise((resolve) => chrome.storage.session.set(
+      { [ARMED_ROW_KEY]: remaining }, () => resolve(),
+    ));
+  });
 }
 
 /** The registered viewer tab, revalidated against reality: it must still exist
@@ -2583,7 +2608,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         break;
       }
       case 'pt_armed_row_clear': {
-        await clearArmedRowIntent();
+        await clearArmedRowIntent(message.address);
         sendResponse({ ok: true });
         break;
       }

--- a/extension/background.js
+++ b/extension/background.js
@@ -1180,34 +1180,57 @@ function clearWarmTabState() {
  * page adopts it into its own D-39 armedBuy machinery, TTL and all. */
 const ARMED_ROW_KEY = 'pt_armed_row_intent';
 const ARMED_ROW_MAX = 3;
+let armedRowChain = Promise.resolve();
 function normalizeArmedRowIntents(value) {
   const list = Array.isArray(value) ? value : (value && value.address ? [value] : []);
   return list.filter((intent) => intent && typeof intent.address === 'string'
     && Number(intent.amount) > 0 && Number.isFinite(Number(intent.at)));
 }
-function readArmedRowIntent() {
+function readArmedRowList() {
   return new Promise((resolve) => chrome.storage.session.get([ARMED_ROW_KEY], (value) => {
-    if (chrome.runtime && chrome.runtime.lastError) { resolve(null); return; }
-    resolve(normalizeArmedRowIntents(value[ARMED_ROW_KEY]));
+    if (chrome.runtime && chrome.runtime.lastError) {
+      resolve({ ok: false, list: [] });
+      return;
+    }
+    resolve({ ok: true, list: normalizeArmedRowIntents(value[ARMED_ROW_KEY]) });
   }));
 }
-async function writeArmedRowIntent(intent) {
-  const list = await readArmedRowIntent();
-  const index = list.findIndex((item) => item.address === intent.address);
-  if (index !== -1) {
-    list[index] = { address: intent.address, amount: intent.amount, at: intent.at };
-  } else {
-    list.push({ address: intent.address, amount: intent.amount, at: intent.at });
-  }
-  while (list.length > ARMED_ROW_MAX) list.shift();
-  return new Promise((resolve) => chrome.storage.session.set({ [ARMED_ROW_KEY]: list }, () => resolve()));
+function readArmedRowIntent() {
+  return readArmedRowList().then((read) => read.list);
+}
+function armedRowSerial(fn) {
+  const next = armedRowChain.then(fn, fn);
+  armedRowChain = next.then(() => {}, () => {});
+  return next;
+}
+function writeArmedRowIntent(intent) {
+  return armedRowSerial(async () => {
+    const read = await readArmedRowList();
+    if (!read.ok) return false;
+    const list = read.list;
+    const index = list.findIndex((item) => item.address === intent.address);
+    if (index !== -1) {
+      list[index] = { address: intent.address, amount: intent.amount, at: intent.at };
+    } else {
+      list.push({ address: intent.address, amount: intent.amount, at: intent.at });
+    }
+    while (list.length > ARMED_ROW_MAX) list.shift();
+    await new Promise((resolve) => chrome.storage.session.set(
+      { [ARMED_ROW_KEY]: list }, () => resolve(),
+    ));
+    return true;
+  });
 }
 function clearArmedRowIntent(address) {
-  if (!address) {
-    return new Promise((resolve) => chrome.storage.session.remove(ARMED_ROW_KEY, () => resolve()));
-  }
-  return readArmedRowIntent().then((list) => {
-    const remaining = list.filter((intent) => intent.address !== address);
+  return armedRowSerial(async () => {
+    if (!address) {
+      return new Promise((resolve) => chrome.storage.session.remove(ARMED_ROW_KEY, () => resolve()));
+    }
+    const read = await readArmedRowList();
+    if (!read.ok) {
+      return new Promise((resolve) => chrome.storage.session.remove(ARMED_ROW_KEY, () => resolve()));
+    }
+    const remaining = read.list.filter((intent) => intent.address !== address);
     if (!remaining.length) {
       return new Promise((resolve) => chrome.storage.session.remove(ARMED_ROW_KEY, () => resolve()));
     }

--- a/extension/content.js
+++ b/extension/content.js
@@ -6607,6 +6607,7 @@
       usd: Number(cand.value), at: Date.now(),
       symbol: typeof payload.symbol === 'string' ? payload.symbol : null,
       name: typeof payload.name === 'string' ? payload.name : null,
+      mcap: Number(payload.mcap) > 0 ? Number(payload.mcap) : null,
     });
     if (recentRowPrices.size > 300) recentRowPrices.delete(recentRowPrices.keys().next().value);
     // D-40: a board tick while a row snipe is armed is the fastest possible
@@ -6628,6 +6629,7 @@
       priceUsd: live.usd,
       symbol: live.symbol || null,
       name: live.name || null,
+      mcap: live.mcap || null,
     };
   }
 
@@ -7052,30 +7054,41 @@
           priceSource: 'row-props',
         };
       } else {
-        try {
-          data = await Promise.race([
-            (async () => {
-              let d = await R.resolve(address, { maxAgeMs: 3000 });
-              if (!d || !(d.priceNative > 0)) d = await R.resolve(address);
-              if (!d || !(d.priceNative > 0)) {
-                const row = await rowLivePrice(address);
-                if (row) {
-                  d = {
-                    mint: address, pairAddress: null,
-                    symbol: row.symbol, name: row.name,
-                    priceNative: row.priceNative, priceUsd: row.priceUsd, mcap: null,
-                    priceSource: 'row-feed',
-                  };
+        const fresh = await rowLivePrice(address);
+        if (fresh) {
+          data = {
+            mint: address, pairAddress: null,
+            symbol: fresh.symbol, name: fresh.name,
+            priceNative: fresh.priceNative, priceUsd: fresh.priceUsd,
+            mcap: fresh.mcap || null,
+            priceSource: 'row-feed',
+          };
+        } else {
+          try {
+            data = await Promise.race([
+              (async () => {
+                let d = await R.resolve(address, { maxAgeMs: 3000 });
+                if (!d || !(d.priceNative > 0)) d = await R.resolve(address);
+                if (!d || !(d.priceNative > 0)) {
+                  const row = await rowLivePrice(address);
+                  if (row) {
+                    d = {
+                      mint: address, pairAddress: null,
+                      symbol: row.symbol, name: row.name,
+                      priceNative: row.priceNative, priceUsd: row.priceUsd, mcap: row.mcap || null,
+                      priceSource: 'row-feed',
+                    };
+                  }
                 }
-              }
-              if (!d || !(d.priceNative > 0)) {
-                d = await rowChainQuote(address, site && site.rowBuy && site.rowBuy.kind);
-              }
-              return d;
-            })(),
-            new Promise((resolve) => setTimeout(() => resolve(null), ROW_CASCADE_TIMEOUT_MS)),
-          ]);
-        } catch (_) { data = null; }
+                if (!d || !(d.priceNative > 0)) {
+                  d = await rowChainQuote(address, site && site.rowBuy && site.rowBuy.kind);
+                }
+                return d;
+              })(),
+              new Promise((resolve) => setTimeout(() => resolve(null), ROW_CASCADE_TIMEOUT_MS)),
+            ]);
+          } catch (_) { data = null; }
+        }
       }
       if (!data || !(data.priceNative > 0)) {
         // D-40 (Terp roll-on, board path): the click already happened — the

--- a/extension/content.js
+++ b/extension/content.js
@@ -7096,7 +7096,7 @@
     const t0 = fromQueue ? queuedAt : Date.now();
     const amount = fromQueue ? queueOptions.amount : (settings.presetsBuy || [0.1])[0];
     if (rowBuyInFlight || (!fromQueue && rowBuyQueue.length)) {
-      if (rowBuyQueue.length >= ROW_BUY_QUEUE_MAX) {
+      if (!fromQueue && rowBuyQueue.length >= ROW_BUY_QUEUE_MAX) {
         toast('Row buy queue full — tap again after current buys finish');
         rowBuyTiming(t0, 'queue', {}, 'refused');
         return;

--- a/extension/content.js
+++ b/extension/content.js
@@ -6676,7 +6676,10 @@
     }
     if (quote.priceUsd != null) {
       const implied = Number(quote.priceUsd) / Number(quote.priceSol);
-      const rate = await R.solUsd().catch(() => 0);
+      const rate = await Promise.race([
+        Promise.resolve().then(() => R.solUsd()).catch(() => 0),
+        new Promise((resolve) => setTimeout(() => resolve(0), 2000)),
+      ]);
       if (rate > 0 && (!(implied > 0)
         || Math.max(implied / rate, rate / implied) > 1.25)) return false;
     }
@@ -6864,8 +6867,7 @@
     // The chain classifies the click address the same way prewatch does —
     // one bounded read, never blocking the fill: a miss keeps the row's own
     // address as the key, exactly the honest legacy behavior.
-    if (address && data.priceSource !== 'row-props'
-      && (!data.mint || data.mint === address)) {
+    if (address && (!data.mint || data.mint === address)) {
       try {
         const found = await R.onchainPrewatch({ mint: address, pool: address }).catch(() => null);
         if (found && found.mint && found.mint !== data.mint) {
@@ -6940,6 +6942,7 @@
     }
     rowArmedFlushing = true;
     const armed = rowArmed;
+    const rowBuyToken = rowBuyInFlight ? rowBuyOwner : null;
     try {
       // Same source order the click itself runs: freshest resolver read,
       // then the row's own feed, then the chain. The flush may only fire
@@ -6969,13 +6972,13 @@
         }
         // Serialize only the commit. The armed resolver cascade must stay free
         // to retry while a direct click is pricing or filling.
-        if (rowBuyInFlight) return;
-        const rowBuyToken = acquireRowBuyLatch();
+        if (rowBuyInFlight || (rowBuyToken !== null && rowBuyOwner !== rowBuyToken)) return;
+        const commitToken = acquireRowBuyLatch();
         let result;
         try {
           result = await fillRowBuy(armed.address, data, armed.amount);
         } finally {
-          releaseRowBuyLatch(rowBuyToken);
+          releaseRowBuyLatch(commitToken);
         }
         if (result) {
           // D-42: the SW mirror dies with the intent it belongs to — a filled
@@ -7125,6 +7128,7 @@
 
       // D-40: the commit core is shared with the armed flush — one extractor,
       // identical guard/engine/attestation/rail behaviour on both paths.
+      if (rowBuyOwner !== rowBuyToken) return;
       await fillRowBuy(address, data, amount);
     } catch (err) {
       toast(err.message || 'Row buy failed');

--- a/extension/content.js
+++ b/extension/content.js
@@ -6954,11 +6954,11 @@
           releaseRowBuyLatch(rowBuyToken);
         }
         if (result) {
-          rowArmed = null;
+          if (rowArmed === armed) {
+            rowArmed = null;
+            sendMessage({ type: 'pt_armed_row_clear' }).catch(() => {});
+          }
           sendPadreMarker('row-buy-done', null);
-          // D-42: the SW mirror dies with the local intent — a filled snipe
-          // must never be adopted by the chart page and filled twice.
-          sendMessage({ type: 'pt_armed_row_clear' }).catch(() => {});
         }
       }
     } catch (_) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -478,14 +478,11 @@
       // gets nothing: without a genuine recent gesture the fill is refused.
       if (Date.now() - lastGestureAt > TRADE_GESTURE_WINDOW_MS) {
         toast('Paper buy needs a real tap — websites cannot trigger fills');
-        // The chip's busy state is cleared ONLY by row-buy-done; a refusal
-        // that skipped it left the chip stuck forever (DEFECT F-08).
-        sendPadreMarker('row-buy-done', null);
+        sendRowBuyDoneIfIdle();
         return;
       }
       if (ev.payload && ev.payload.address) {
-        doRowBuy(ev.payload.address, null, ev.payload.quote)
-          .finally(() => sendPadreMarker('row-buy-done', null));
+        doRowBuy(ev.payload.address, null, ev.payload.quote);
       }
     }
     else if (ev.type === 'nav') {
@@ -1175,12 +1172,17 @@
       // wait (the click already happened; nothing here narrates). TTL from
       // the ORIGINAL tap bounds it; a mismatched mint is not this intent.
       try {
-        const intent = await sendMessage({ type: 'pt_armed_row_get' });
-        if (intent && intent.address && intent.amount > 0) {
-          const matches = intent.address === data.mint
-            || intent.address === data.pairAddress
-            || intent.address === data.srcAddress;
-          if (matches && Date.now() - intent.at <= ARMED_ROW_TTL_MS) {
+        const mirrored = await sendMessage({ type: 'pt_armed_row_get' });
+        const intents = Array.isArray(mirrored)
+          ? mirrored
+          : (mirrored && mirrored.address ? [mirrored] : []);
+        const intent = intents.find((candidate) => candidate && candidate.address
+          && candidate.amount > 0
+          && (candidate.address === data.mint
+            || candidate.address === data.pairAddress
+            || candidate.address === data.srcAddress));
+        if (intent) {
+          if (Date.now() - intent.at <= ARMED_ROW_TTL_MS) {
             if (!armedBuy) {
               armedBuy = {
                 amount: intent.amount, usd: null, at: intent.at,
@@ -1192,7 +1194,10 @@
             }
             // Consumed either way: an intent the chart adopts is never
             // re-fillable by the (likely dead) board context.
-            sendMessage({ type: 'pt_armed_row_clear' }).catch(() => {});
+            sendMessage({
+              type: 'pt_armed_row_clear',
+              address: intent.address,
+            }).catch(() => {});
           }
         }
       } catch (_) { /* adoption is an enhancement, never a landing risk */ }
@@ -6592,6 +6597,13 @@
   let rowBuyInFlightAt = 0;
   let rowBuyOwner = 0;
   let rowBuyTimingState = null;
+  function rowBuyWorkOutstanding() {
+    return rowBuyInFlight || rowBuyQueue.length > 0 || rowArmed.length > 0;
+  }
+
+  function sendRowBuyDoneIfIdle() {
+    if (!rowBuyWorkOutstanding()) sendPadreMarker('row-buy-done', null);
+  }
 
   function acquireRowBuyLatch() {
     rowBuyInFlight = true;
@@ -6648,6 +6660,7 @@
     if (Date.now() - entry.at >= ROW_BUY_QUEUE_TTL_MS) {
       toast('Queued row buy expired — no fill at the tapped price');
       rowBuyTiming(entry.at, 'queue', {}, 'expired');
+      sendRowBuyDoneIfIdle();
       scheduleRowBuyDrain();
       return;
     }
@@ -6692,7 +6705,7 @@
     if (recentRowPrices.size > 300) recentRowPrices.delete(recentRowPrices.keys().next().value);
     // D-40: a board tick while a row snipe is armed is the fastest possible
     // wake — the row the trader tapped just printed a price of its own.
-    if (rowArmed) flushRowArmed();
+    if (rowArmed.length) flushRowArmed();
   }
 
   /** The row's own live price when the resolver cannot answer — GMGN's
@@ -6861,7 +6874,8 @@
    * Shape: { address, amount, at } — address is the row identity (mint or
    * pool) as the page printed it; the flush re-derives the canonical mint.
    */
-  let rowArmed = null;
+  const ARMED_ROW_MAX = ROW_BUY_QUEUE_MAX;
+  let rowArmed = [];
   let rowArmedFlushing = false;
   // D-42 (Bug 4): repeating armed-row probe — see doRowBuy's arm block.
   let rowArmedFlushTimer = null;
@@ -6869,7 +6883,13 @@
   // lifetime: when this page context dies, the intent dies with it — never
   // a zombie fill from a detached page. (D-42: the SW mirror carries a copy
   // across navigations; ARMED_ROW_TTL_MS lives with the armed state above.)
-  onTeardown(() => { rowArmed = null; });
+  onTeardown(() => {
+    rowArmed.length = 0;
+    if (rowArmedFlushTimer) {
+      clearInterval(rowArmedFlushTimer);
+      rowArmedFlushTimer = null;
+    }
+  });
 
   /** The row buy's commit core — shared by the direct fill and the armed
    * flush so both paths commit identically (same guard, same engine call,
@@ -7052,18 +7072,29 @@
    * miss keeps the intent armed (the board feed, the resolver, and the chain
    * probe each get more chances until the TTL). */
   async function flushRowArmed() {
-    if (!rowArmed || rowArmedFlushing) return;
-    if (Date.now() - rowArmed.at > ARMED_ROW_TTL_MS) {
-      rowArmed = null;
-      sendPadreMarker('row-buy-done', null);
-      toast('Armed row buy expired — no fillable price arrived in time');
-      // D-42: expiry clears the SW mirror too, or the chart page would
-      // adopt an intent the board already expired.
-      sendMessage({ type: 'pt_armed_row_clear' }).catch(() => {});
-      return;
+    if (!rowArmed.length || rowArmedFlushing) return;
+    const now = Date.now();
+    for (let i = rowArmed.length - 1; i >= 0; i--) {
+      const intent = rowArmed[i];
+      if (now - intent.at > ARMED_ROW_TTL_MS) {
+        rowArmed.splice(i, 1);
+        toast('Armed row buy expired — no fillable price arrived in time');
+        // D-42: expiry clears the SW mirror too, or the chart page would
+        // adopt an intent the board already expired.
+        sendMessage({
+          type: 'pt_armed_row_clear',
+          address: intent.address,
+        }).catch(() => {});
+        rowBuyTiming(intent.at, 'armed', {}, 'expired');
+      }
     }
+    sendRowBuyDoneIfIdle();
+    if (!rowArmed.length) return;
     rowArmedFlushing = true;
-    const armed = rowArmed;
+    const armed = rowArmed[0];
+    const timing = { priceSource: 'armed' };
+    let terminal = false;
+    rowBuyTimingState = timing;
     try {
       // Same source order the click itself runs: freshest resolver read,
       // then the row's own feed, then the chain. The flush may only fire
@@ -7096,29 +7127,44 @@
         if (rowBuyInFlight) return;
         const rowBuyToken = acquireRowBuyLatch();
         let result;
-        const timing = { priceSource: data.priceSource };
+        terminal = true;
+        timing.priceSource = data.priceSource;
         rowBuyTimingState = timing;
         try {
           result = await fillRowBuy(armed.address, data, armed.amount, rowBuyToken);
+          if (!result && !timing.outcome) timing.outcome = 'refused';
         } finally {
           rowBuyTimingState = null;
           releaseRowBuyLatch(rowBuyToken);
           scheduleRowBuyDrain();
         }
-        if (result) {
+        if (result || timing.outcome !== 'superseded') {
           // D-42: the SW mirror dies with the intent it belongs to — a filled
-          // snipe must never be adopted by the chart page and filled twice,
-          // and a newer intent must keep both its slot and its mirror.
-          if (rowArmed === armed) {
-            rowArmed = null;
-            sendMessage({ type: 'pt_armed_row_clear' }).catch(() => {});
+          // snipe must never be adopted by the chart page and filled twice.
+          // A refusal is terminal too; only an ownership supersession keeps
+          // the intent for a later retry.
+          const index = rowArmed.indexOf(armed);
+          if (index !== -1) {
+            rowArmed.splice(index, 1);
+            sendMessage({
+              type: 'pt_armed_row_clear',
+              address: armed.address,
+            }).catch(() => {});
           }
-          sendPadreMarker('row-buy-done', null);
         }
       }
     } catch (_) {
       // A transient failure keeps the intent armed — the next wake retries.
-    } finally { rowArmedFlushing = false; }
+      if (terminal) timing.outcome = 'error';
+    } finally {
+      rowBuyTimingState = null;
+      rowArmedFlushing = false;
+      if (terminal) {
+        if (!timing.outcome) timing.outcome = 'done';
+        rowBuyTiming(armed.at, timing.priceSource, timing, timing.outcome);
+      }
+      sendRowBuyDoneIfIdle();
+    }
   }
 
   /** Paper-buy the first preset amount of a screener row's token. */
@@ -7132,6 +7178,7 @@
       if (!fromQueue && rowBuyQueue.length >= ROW_BUY_QUEUE_MAX) {
         toast('Row buy queue full — tap again after current buys finish');
         rowBuyTiming(t0, 'queue', {}, 'refused');
+        sendRowBuyDoneIfIdle();
         return;
       }
       const entry = { address, button, quote: rowQuote, amount, at: fromQueue ? queuedAt : Date.now() };
@@ -7226,7 +7273,18 @@
         // source: the row's own mint-tagged board tick (fastest wake), the
         // resolver's next pass, or a delayed chain re-probe. The same 60 s
         // TTL honesty bounds the wait; expiry says so instead of guessing.
-        rowArmed = { address, amount, at: Date.now() };
+        const armedAt = Date.now();
+        const existingArmed = rowArmed.find((intent) => intent.address === address);
+        if (existingArmed) {
+          existingArmed.amount = amount;
+          existingArmed.at = armedAt;
+        } else if (rowArmed.length >= ARMED_ROW_MAX) {
+          toast('Armed row queue full — tap again after current buys finish');
+          outcome = 'refused';
+          return;
+        } else {
+          rowArmed.push({ address, amount, at: armedAt });
+        }
         // D-42 (Bug 3): the trader's next move is to click the coin and open
         // its chart — which destroys THIS context and, before this line, the
         // armed intent with it (no fill, no position, no line: the live
@@ -7235,7 +7293,7 @@
         // armedBuy flush. Both sides clear the SW copy on fill/expiry.
         sendMessage({
           type: 'pt_armed_row_arm',
-          intent: { address, amount, at: rowArmed.at },
+          intent: { address, amount, at: armedAt },
         }).catch(() => {});
         setTimeout(() => flushRowArmed(), 1200);
         setTimeout(() => flushRowArmed(), 4000);
@@ -7248,7 +7306,7 @@
         // self-clears; managedInterval already dies with the context.
         if (!rowArmedFlushTimer) {
           rowArmedFlushTimer = managedInterval(() => {
-            if (!rowArmed) {
+            if (!rowArmed.length) {
               clearInterval(rowArmedFlushTimer);
               rowArmedFlushTimer = null;
               return;
@@ -7304,6 +7362,7 @@
       if (button) button.classList.remove('busy');
       if (timing.outcome) outcome = timing.outcome;
       rowBuyTiming(t0, timing.priceSource, timing, outcome);
+      sendRowBuyDoneIfIdle();
       scheduleRowBuyDrain();
     }
   }
@@ -9263,7 +9322,7 @@
       // D-40 armed-row watchdog: the board's 1 s heartbeat keeps the armed
       // snipe honest — re-probing the sources while it waits and expiring it
       // visibly when the TTL passes (the panel's armed-buy watchdog, ported).
-      if (rowArmed) flushRowArmed();
+      if (rowArmed.length) flushRowArmed();
       // D-41 latch hygiene: an in-flight buy/sell whose await never settled
       // (hung resolver, dying SW) must not wedge every later trade behind
       // "already in progress". A live cascade never takes 20 s; if the
@@ -9275,6 +9334,7 @@
         rowBuyInFlight = false;
         rowBuyInFlightAt = 0;
         toast('A stuck row buy was released — try again');
+        sendRowBuyDoneIfIdle();
         scheduleRowBuyDrain();
       }
       if (buyInFlight && buyInFlightAt && Date.now() - buyInFlightAt > LATCH_MAX_AGE_MS) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -6581,6 +6581,20 @@
   // once left "Row buy already in progress…" on every coin until reload —
   // live report). A settled finally clears the latch long before this ages.
   let rowBuyInFlightAt = 0;
+  let rowBuyOwner = 0;
+
+  function acquireRowBuyLatch() {
+    rowBuyInFlight = true;
+    rowBuyInFlightAt = Date.now();
+    rowBuyOwner += 1;
+    return rowBuyOwner;
+  }
+
+  function releaseRowBuyLatch(token) {
+    if (rowBuyOwner !== token) return;
+    rowBuyInFlight = false;
+    rowBuyInFlightAt = 0;
+  }
 
   function noteRowPrice(payload) {
     if (!payload || typeof payload.mint !== 'string' || !ROW_ADDR_RE.test(payload.mint)) return;
@@ -6932,14 +6946,12 @@
         // Serialize only the commit. The armed resolver cascade must stay free
         // to retry while a direct click is pricing or filling.
         if (rowBuyInFlight) return;
-        rowBuyInFlight = true;
-        rowBuyInFlightAt = Date.now();
+        const rowBuyToken = acquireRowBuyLatch();
         let result;
         try {
           result = await fillRowBuy(armed.address, data, armed.amount);
         } finally {
-          rowBuyInFlight = false;
-          rowBuyInFlightAt = 0;
+          releaseRowBuyLatch(rowBuyToken);
         }
         if (result) {
           rowArmed = null;
@@ -6957,8 +6969,7 @@
   /** Paper-buy the first preset amount of a screener row's token. */
   async function doRowBuy(address, button) {
     if (rowBuyInFlight) return toast('Row buy already in progress…');
-    rowBuyInFlight = true;
-    rowBuyInFlightAt = Date.now();
+    const rowBuyToken = acquireRowBuyLatch();
     if (button) button.classList.add('busy');
     primeAudio();
     try {
@@ -7077,7 +7088,7 @@
     } catch (err) {
       toast(err.message || 'Row buy failed');
     } finally {
-      rowBuyInFlight = false;
+      releaseRowBuyLatch(rowBuyToken);
       if (button) button.classList.remove('busy');
     }
   }
@@ -9041,10 +9052,11 @@
       // D-41 latch hygiene: an in-flight buy/sell whose await never settled
       // (hung resolver, dying SW) must not wedge every later trade behind
       // "already in progress". A live cascade never takes 20 s; if the
-      // latch is that old the operation is dead, so free it. The eventual
-      // finally is idempotent — it only clears, never re-arms.
+      // latch is that old the operation is dead, so free it. The generation
+      // token keeps its eventual finally from releasing a newer operation.
       const LATCH_MAX_AGE_MS = 20_000;
       if (rowBuyInFlight && rowBuyInFlightAt && Date.now() - rowBuyInFlightAt > LATCH_MAX_AGE_MS) {
+        rowBuyOwner += 1;
         rowBuyInFlight = false;
         rowBuyInFlightAt = 0;
         toast('A stuck row buy was released — try again');

--- a/extension/content.js
+++ b/extension/content.js
@@ -7054,7 +7054,10 @@
           priceSource: 'row-props',
         };
       } else {
-        const fresh = await rowLivePrice(address);
+        const fresh = await Promise.race([
+          rowLivePrice(address).catch(() => null),
+          new Promise((resolve) => setTimeout(() => resolve(null), 2000)),
+        ]);
         if (fresh) {
           data = {
             mint: address, pairAddress: null,

--- a/extension/content.js
+++ b/extension/content.js
@@ -7213,7 +7213,7 @@
           }, 1500);
         }
         timing.priceSource = 'armed';
-        rowBuyTiming(t0, timing.priceSource, timing, 'armed');
+        outcome = 'armed';
         return;
       }
       timing.quote = Date.now();

--- a/extension/content.js
+++ b/extension/content.js
@@ -6568,7 +6568,8 @@
    * exactly like the site's own quick buy moves you to the position.
    */
 
-  const ROW_ADDR_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
+  const ROW_ADDR_RE = /[1-9A-HJ-NP-Za-km-z]{32,44}/;
+  const ROW_ADDR_EXACT_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
   // Newest USD price per mint from the site's OWN realtime feed (GMGN's
   // token_activity ticks carry a mint). A row buy prefers this over a
   // network quote because the screener is showing that very price.
@@ -6662,16 +6663,22 @@
     };
   }
 
-  function validRowPropsQuote(quote, address) {
-    if (!quote || typeof quote !== 'object' || !ROW_ADDR_RE.test(address || '')) return false;
+  async function validRowPropsQuote(quote, address) {
+    if (!quote || typeof quote !== 'object' || !ROW_ADDR_EXACT_RE.test(address || '')) return false;
     const mint = quote.mint || null;
     const pair = quote.pair || null;
-    if ((mint && !ROW_ADDR_RE.test(mint)) || (pair && !ROW_ADDR_RE.test(pair))) return false;
+    if ((mint && !ROW_ADDR_EXACT_RE.test(mint)) || (pair && !ROW_ADDR_EXACT_RE.test(pair))) return false;
     if ((!mint && !pair) || (mint !== address && pair !== address)) return false;
     if (!(Number.isFinite(Number(quote.priceSol)) && Number(quote.priceSol) > 0)) return false;
     for (const name of ['priceUsd', 'mcapUsd', 'supply']) {
       if (quote[name] != null
         && !(Number.isFinite(Number(quote[name])) && Number(quote[name]) > 0)) return false;
+    }
+    if (quote.priceUsd != null) {
+      const implied = Number(quote.priceUsd) / Number(quote.priceSol);
+      const rate = await R.solUsd().catch(() => 0);
+      if (rate > 0 && (!(implied > 0)
+        || Math.max(implied / rate, rate / implied) > 1.25)) return false;
     }
     return true;
   }
@@ -7014,11 +7021,7 @@
       // nothing below may block this function's finally forever.
       const ROW_CASCADE_TIMEOUT_MS = 10_000;
       let data = null;
-      if (rowQuote) {
-        if (!validRowPropsQuote(rowQuote, address)) {
-          toast('Row price identity could not be confirmed — paper buy refused');
-          return;
-        }
+      if (rowQuote && await validRowPropsQuote(rowQuote, address)) {
         data = {
           mint: rowQuote.mint || address,
           pairAddress: rowQuote.pair || null,

--- a/extension/content.js
+++ b/extension/content.js
@@ -2225,8 +2225,11 @@
    * (a fill, an order change). The heartbeat passes none: its marks are
    * re-applied here and there is nothing else it owns.
    */
+  let lastPersistAttempts = 0;
   async function persistStateNow(remutate) {
+    lastPersistAttempts = 0;
     for (let attempt = 0; attempt < 4; attempt++) {
+      lastPersistAttempts = attempt + 1;
       state.seq = (Number(state.seq) || 0) + 1;
       state.updatedAt = Date.now();
       lastWrittenState = state;
@@ -2271,6 +2274,7 @@
     // tries again next beat, which is what keeps the LYAR silent-eat class
     // dead: heartbeats never force.
     if (remutate) {
+      lastPersistAttempts += 1;
       state.seq = (Number(state.seq) || 0) + 1;
       state.updatedAt = Date.now();
       lastWrittenState = state;
@@ -6604,11 +6608,30 @@
 
   function rowBuyTiming(t0, priceSource, marks, outcome) {
     const elapsed = (mark) => Number.isFinite(mark) ? Math.max(0, mark - t0) : '-';
+    const fromFill = Number.isFinite(marks.fillStart) && Number.isFinite(marks.withStateStart)
+      ? Math.max(0, marks.withStateStart - marks.fillStart)
+      : '-';
+    const guardState = Number.isFinite(marks.guardStateDuration)
+      ? Math.max(0, marks.guardStateDuration) : elapsed(marks.guardState);
+    const persist = Number.isFinite(marks.persistMs) ? marks.persistMs : '-';
+    const attempts = Number.isFinite(marks.persistAttempts) ? marks.persistAttempts : '-';
     const total = Math.max(0, Date.now() - t0);
     console.debug(`PaperTrench: row-buy source=${priceSource || 'unknown'}`
       + ` outcome=${outcome || 'done'} quote=${elapsed(marks.quote)}ms`
-      + ` guard+state=${elapsed(marks.guardState)}ms commit=${elapsed(marks.commit)}ms`
-      + ` total=${total}ms`);
+      + ` guard+state=${guardState}ms commit=${elapsed(marks.commit)}ms`
+      + ` total=${total}ms withState=${fromFill}ms persist=${persist}ms attempts=${attempts}`);
+  }
+
+  function finishRowPersist(timing, startedAt) {
+    if (!timing) return;
+    timing.persistMs = Date.now() - startedAt;
+    timing.persistAttempts = lastPersistAttempts;
+    timing.guardStateDuration = Math.max(
+      0,
+      Date.now() - timing.quote
+        - (timing.withStateStart - timing.fillStart)
+        - timing.persistMs,
+    );
   }
 
   function scheduleRowBuyDrain() {
@@ -6898,6 +6921,7 @@
 
   async function fillRowBuy(address, data, amount, ownerToken) {
     const timing = rowBuyTimingState;
+    if (timing) timing.fillStart = Date.now();
     // F-56: a chip fill runs through the SAME honesty gates as a panel fill.
     // The row's own price used to price the trade blind — no witness, no
     // contradiction check — so a stale/wrong row print booked entries far
@@ -6969,7 +6993,12 @@
     const guard = E.guardCheck(state, settings, { solAmount: amount });
     if (!guard.ok) { toast(guard.message); return null; }
     const result = await withState(async () => {
-      if (rowBuyOwner !== ownerToken) return null;
+      if (timing) timing.withStateStart = Date.now();
+      if (rowBuyOwner !== ownerToken) {
+        toast('That tap was released after taking too long — nothing was filled');
+        if (timing) timing.outcome = 'superseded';
+        return null;
+      }
       // Re-runnable mutation — see doBuy: a lost CAS race re-applies this
       // row buy on the adopted base; only the landing attempt is chained.
       let filled = null;
@@ -6985,8 +7014,9 @@
         filled.opened = opened;
       };
       mutate();
+      const persistStartedAt = Date.now();
       await persistStateNow(mutate);
-      if (timing) timing.guardState = Date.now();
+      finishRowPersist(timing, persistStartedAt);
       // Chain append after the wallet commit — see doBuy for the ordering.
       await commitFill(filled.trade);
       if (timing) timing.commit = Date.now();
@@ -7066,9 +7096,12 @@
         if (rowBuyInFlight) return;
         const rowBuyToken = acquireRowBuyLatch();
         let result;
+        const timing = { priceSource: data.priceSource };
+        rowBuyTimingState = timing;
         try {
           result = await fillRowBuy(armed.address, data, armed.amount, rowBuyToken);
         } finally {
+          rowBuyTimingState = null;
           releaseRowBuyLatch(rowBuyToken);
           scheduleRowBuyDrain();
         }
@@ -7269,6 +7302,7 @@
     } finally {
       releaseRowBuyLatch(rowBuyToken);
       if (button) button.classList.remove('busy');
+      if (timing.outcome) outcome = timing.outcome;
       rowBuyTiming(t0, timing.priceSource, timing, outcome);
       scheduleRowBuyDrain();
     }

--- a/extension/content.js
+++ b/extension/content.js
@@ -6589,6 +6589,7 @@
   const ROW_BUY_QUEUE_MAX = 3;
   const ROW_BUY_QUEUE_TTL_MS = 5000;
   let rowBuyDrainTimer = null;
+  let rowBuyExpiryTimer = null;
   // D-41: when the in-flight latch was SET, so the 1 s heartbeat can free a
   // latch whose await never settled (a hung resolver/SW RPC on a weird pair
   // once left "Row buy already in progress…" on every coin until reload —
@@ -6653,9 +6654,39 @@
     }, 0);
   }
 
+  function scheduleRowBuyExpiry() {
+    if (rowBuyExpiryTimer) {
+      clearTimeout(rowBuyExpiryTimer);
+      rowBuyExpiryTimer = null;
+    }
+    if (contextDead || !rowBuyQueue.length) return;
+    const earliest = Math.min(...rowBuyQueue.map((entry) => entry.at));
+    rowBuyExpiryTimer = setTimeout(
+      expireRowBuyQueue,
+      Math.max(0, earliest + ROW_BUY_QUEUE_TTL_MS - Date.now()),
+    );
+  }
+
+  function expireRowBuyQueue() {
+    rowBuyExpiryTimer = null;
+    const now = Date.now();
+    for (let i = 0; i < rowBuyQueue.length;) {
+      if (now - rowBuyQueue[i].at < ROW_BUY_QUEUE_TTL_MS) {
+        i += 1;
+        continue;
+      }
+      const [entry] = rowBuyQueue.splice(i, 1);
+      toast('Queued row buy expired — no fill at the tapped price');
+      rowBuyTiming(entry.at, 'queue', {}, 'expired');
+    }
+    sendRowBuyDoneIfIdle();
+    scheduleRowBuyExpiry();
+  }
+
   function drainRowBuyQueue() {
     if (contextDead || rowBuyInFlight || !rowBuyQueue.length) return;
     const entry = rowBuyQueue.shift();
+    scheduleRowBuyExpiry();
     if (Date.now() - entry.at >= ROW_BUY_QUEUE_TTL_MS) {
       toast('Queued row buy expired — no fill at the tapped price');
       rowBuyTiming(entry.at, 'queue', {}, 'expired');
@@ -6674,6 +6705,10 @@
     if (rowBuyDrainTimer) {
       clearTimeout(rowBuyDrainTimer);
       rowBuyDrainTimer = null;
+    }
+    if (rowBuyExpiryTimer) {
+      clearTimeout(rowBuyExpiryTimer);
+      rowBuyExpiryTimer = null;
     }
   }
 
@@ -7191,6 +7226,7 @@
       if (fromQueue) rowBuyQueue.unshift(entry);
       else rowBuyQueue.push(entry);
       toast('Queued — filling after the current buy');
+      scheduleRowBuyExpiry();
       scheduleRowBuyDrain();
       return;
     }

--- a/extension/content.js
+++ b/extension/content.js
@@ -6604,16 +6604,17 @@
       : null;
     if (!cand) return;
     const now = Date.now();
-    const candidateAt = Number(payload.at);
-    const frameAt = Number.isFinite(candidateAt)
-      && candidateAt > now - 30_000
-      && candidateAt <= now
-      ? candidateAt
-      : now;
+    const hasFrameAt = Number.isFinite(payload.at);
+    if (hasFrameAt && (payload.at <= now - 30_000 || payload.at > now)) return;
+    const frameAt = hasFrameAt ? payload.at : now;
+    const frameSeq = Number(payload.seq);
     const prev = recentRowPrices.get(payload.mint);
-    if (prev && frameAt < prev.at) return;
+    if (prev && (frameAt < prev.at
+      || (frameAt === prev.at && Number.isFinite(frameSeq)
+        && Number.isFinite(prev.seq) && frameSeq < prev.seq))) return;
     recentRowPrices.set(payload.mint, {
       usd: Number(cand.value), at: frameAt,
+      seq: Number.isFinite(frameSeq) ? frameSeq : null,
       symbol: typeof payload.symbol === 'string' ? payload.symbol : null,
       name: typeof payload.name === 'string' ? payload.name : null,
       mcap: Number(payload.mcap) > 0 ? Number(payload.mcap) : null,

--- a/extension/content.js
+++ b/extension/content.js
@@ -484,7 +484,7 @@
         return;
       }
       if (ev.payload && ev.payload.address) {
-        doRowBuy(ev.payload.address, null)
+        doRowBuy(ev.payload.address, null, ev.payload.quote)
           .finally(() => sendPadreMarker('row-buy-done', null));
       }
     }
@@ -6568,7 +6568,7 @@
    * exactly like the site's own quick buy moves you to the position.
    */
 
-  const ROW_ADDR_RE = /[1-9A-HJ-NP-Za-km-z]{32,44}/;
+  const ROW_ADDR_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
   // Newest USD price per mint from the site's OWN realtime feed (GMGN's
   // token_activity ticks carry a mint). A row buy prefers this over a
   // network quote because the screener is showing that very price.
@@ -6660,6 +6660,20 @@
       mcap: null,
       priceSource: 'row-onchain',
     };
+  }
+
+  function validRowPropsQuote(quote, address) {
+    if (!quote || typeof quote !== 'object' || !ROW_ADDR_RE.test(address || '')) return false;
+    const mint = quote.mint || null;
+    const pair = quote.pair || null;
+    if ((mint && !ROW_ADDR_RE.test(mint)) || (pair && !ROW_ADDR_RE.test(pair))) return false;
+    if ((!mint && !pair) || (mint !== address && pair !== address)) return false;
+    if (!(Number.isFinite(Number(quote.priceSol)) && Number(quote.priceSol) > 0)) return false;
+    for (const name of ['priceUsd', 'mcapUsd', 'supply']) {
+      if (quote[name] != null
+        && !(Number.isFinite(Number(quote[name])) && Number(quote[name]) > 0)) return false;
+    }
+    return true;
   }
 
   /**
@@ -6756,7 +6770,8 @@
   async function rowPrintVouchesFirstBuy(address, data, posAnchor) {
     if (posAnchor) return true; // an existing position anchors (F-56 above)
     if (!(Number(data.priceNative) > 0) || !(Number(data.priceUsd) > 0)) return true;
-    if (data.priceSource === 'row-feed' || data.priceSource === 'row-onchain') return true;
+    if (data.priceSource === 'row-feed' || data.priceSource === 'row-props'
+      || data.priceSource === 'row-onchain') return true;
     const rowPrint = (data.mint && recentRowPrices.get(data.mint))
       || (data.pairAddress && recentRowPrices.get(data.pairAddress))
       || (address && recentRowPrices.get(address));
@@ -6805,7 +6820,7 @@
       if (ratio > 2) {
         let witnessNative = null;
         try {
-          if (data.priceSource === 'row-feed' || !data.priceSource) {
+          if (data.priceSource === 'row-feed' || data.priceSource === 'row-props' || !data.priceSource) {
             const obs = await R.resolve(address, { maxAgeMs: 3000 }).catch(() => null);
             if (obs && Number(obs.priceNative) > 0) witnessNative = Number(obs.priceNative);
           } else {
@@ -6842,7 +6857,8 @@
     // The chain classifies the click address the same way prewatch does —
     // one bounded read, never blocking the fill: a miss keeps the row's own
     // address as the key, exactly the honest legacy behavior.
-    if (address && (!data.mint || data.mint === address)) {
+    if (address && data.priceSource !== 'row-props'
+      && (!data.mint || data.mint === address)) {
       try {
         const found = await R.onchainPrewatch({ mint: address, pool: address }).catch(() => null);
         if (found && found.mint && found.mint !== data.mint) {
@@ -6936,7 +6952,8 @@
         const live = (data.mint && recentRowPrices.get(data.mint))
           || (data.pairAddress && recentRowPrices.get(data.pairAddress))
           || recentRowPrices.get(armed.address);
-        if (live && Date.now() - live.at < ROW_PRICE_TTL_MS && Number(data.priceUsd) > 0) {
+        if (data.priceSource !== 'row-props'
+            && live && Date.now() - live.at < ROW_PRICE_TTL_MS && Number(data.priceUsd) > 0) {
           const scale = live.usd / Number(data.priceUsd);
           data.priceUsd = live.usd;
           data.priceNative = Number(data.priceNative) * scale;
@@ -6970,7 +6987,7 @@
   }
 
   /** Paper-buy the first preset amount of a screener row's token. */
-  async function doRowBuy(address, button) {
+  async function doRowBuy(address, button, rowQuote) {
     if (rowBuyInFlight) return toast('Row buy already in progress…');
     const rowBuyToken = acquireRowBuyLatch();
     if (button) button.classList.add('busy');
@@ -6997,30 +7014,47 @@
       // nothing below may block this function's finally forever.
       const ROW_CASCADE_TIMEOUT_MS = 10_000;
       let data = null;
-      try {
-        data = await Promise.race([
-          (async () => {
-            let d = await R.resolve(address, { maxAgeMs: 3000 });
-            if (!d || !(d.priceNative > 0)) d = await R.resolve(address);
-            if (!d || !(d.priceNative > 0)) {
-              const row = await rowLivePrice(address);
-              if (row) {
-                d = {
-                  mint: address, pairAddress: null,
-                  symbol: row.symbol, name: row.name,
-                  priceNative: row.priceNative, priceUsd: row.priceUsd, mcap: null,
-                  priceSource: 'row-feed',
-                };
+      if (rowQuote) {
+        if (!validRowPropsQuote(rowQuote, address)) {
+          toast('Row price identity could not be confirmed — paper buy refused');
+          return;
+        }
+        data = {
+          mint: rowQuote.mint || address,
+          pairAddress: rowQuote.pair || null,
+          symbol: null,
+          name: null,
+          priceNative: rowQuote.priceSol,
+          priceUsd: rowQuote.priceUsd || null,
+          mcap: rowQuote.mcapUsd || null,
+          priceSource: 'row-props',
+        };
+      } else {
+        try {
+          data = await Promise.race([
+            (async () => {
+              let d = await R.resolve(address, { maxAgeMs: 3000 });
+              if (!d || !(d.priceNative > 0)) d = await R.resolve(address);
+              if (!d || !(d.priceNative > 0)) {
+                const row = await rowLivePrice(address);
+                if (row) {
+                  d = {
+                    mint: address, pairAddress: null,
+                    symbol: row.symbol, name: row.name,
+                    priceNative: row.priceNative, priceUsd: row.priceUsd, mcap: null,
+                    priceSource: 'row-feed',
+                  };
+                }
               }
-            }
-            if (!d || !(d.priceNative > 0)) {
-              d = await rowChainQuote(address, site && site.rowBuy && site.rowBuy.kind);
-            }
-            return d;
-          })(),
-          new Promise((resolve) => setTimeout(() => resolve(null), ROW_CASCADE_TIMEOUT_MS)),
-        ]);
-      } catch (_) { data = null; }
+              if (!d || !(d.priceNative > 0)) {
+                d = await rowChainQuote(address, site && site.rowBuy && site.rowBuy.kind);
+              }
+              return d;
+            })(),
+            new Promise((resolve) => setTimeout(() => resolve(null), ROW_CASCADE_TIMEOUT_MS)),
+          ]);
+        } catch (_) { data = null; }
+      }
       if (!data || !(data.priceNative > 0)) {
         // D-40 (Terp roll-on, board path): the click already happened — the
         // intent is NEVER refused. It arms exactly like the panel's D-39
@@ -7072,7 +7106,8 @@
       const live = (data.mint && recentRowPrices.get(data.mint))
         || (data.pairAddress && recentRowPrices.get(data.pairAddress))
         || (address && recentRowPrices.get(address));
-      if (live && Date.now() - live.at < ROW_PRICE_TTL_MS && Number(data.priceUsd) > 0) {
+      if (data.priceSource !== 'row-props'
+          && live && Date.now() - live.at < ROW_PRICE_TTL_MS && Number(data.priceUsd) > 0) {
         // F-59: the cap rides the price. The old override rewrote
         // priceUsd/priceNative and left `mcap` at the resolver's stale
         // value — the toast and the position then reported an entry MC the

--- a/extension/content.js
+++ b/extension/content.js
@@ -6942,7 +6942,6 @@
     }
     rowArmedFlushing = true;
     const armed = rowArmed;
-    const rowBuyToken = rowBuyInFlight ? rowBuyOwner : null;
     try {
       // Same source order the click itself runs: freshest resolver read,
       // then the row's own feed, then the chain. The flush may only fire
@@ -6972,13 +6971,13 @@
         }
         // Serialize only the commit. The armed resolver cascade must stay free
         // to retry while a direct click is pricing or filling.
-        if (rowBuyInFlight || (rowBuyToken !== null && rowBuyOwner !== rowBuyToken)) return;
-        const commitToken = acquireRowBuyLatch();
+        if (rowBuyInFlight) return;
+        const rowBuyToken = acquireRowBuyLatch();
         let result;
         try {
           result = await fillRowBuy(armed.address, data, armed.amount);
         } finally {
-          releaseRowBuyLatch(commitToken);
+          releaseRowBuyLatch(rowBuyToken);
         }
         if (result) {
           // D-42: the SW mirror dies with the intent it belongs to — a filled

--- a/extension/content.js
+++ b/extension/content.js
@@ -6628,16 +6628,21 @@
       scheduleRowBuyDrain();
       return;
     }
-    doRowBuy(entry.address, entry.button, entry.quote, entry.at);
+    doRowBuy(entry.address, entry.button, entry.quote, {
+      queuedAt: entry.at,
+      amount: entry.amount,
+    });
   }
 
-  onTeardown(() => {
+  function clearRowBuyQueue() {
     rowBuyQueue.length = 0;
     if (rowBuyDrainTimer) {
       clearTimeout(rowBuyDrainTimer);
       rowBuyDrainTimer = null;
     }
-  });
+  }
+
+  onTeardown(clearRowBuyQueue);
 
   function noteRowPrice(payload) {
     if (!payload || typeof payload.mint !== 'string' || !ROW_ADDR_RE.test(payload.mint)) return;
@@ -7084,16 +7089,23 @@
   }
 
   /** Paper-buy the first preset amount of a screener row's token. */
-  async function doRowBuy(address, button, rowQuote, queuedAt) {
-    const t0 = Number.isFinite(queuedAt) ? queuedAt : Date.now();
-    if (rowBuyInFlight) {
+  async function doRowBuy(address, button, rowQuote, options) {
+    const queueOptions = options && typeof options === 'object' ? options : {};
+    const queuedAt = queueOptions.queuedAt;
+    const fromQueue = Number.isFinite(queuedAt);
+    const t0 = fromQueue ? queuedAt : Date.now();
+    const amount = fromQueue ? queueOptions.amount : (settings.presetsBuy || [0.1])[0];
+    if (rowBuyInFlight || (!fromQueue && rowBuyQueue.length)) {
       if (rowBuyQueue.length >= ROW_BUY_QUEUE_MAX) {
         toast('Row buy queue full — tap again after current buys finish');
         rowBuyTiming(t0, 'queue', {}, 'refused');
         return;
       }
-      rowBuyQueue.push({ address, button, quote: rowQuote, at: Date.now() });
+      const entry = { address, button, quote: rowQuote, amount, at: fromQueue ? queuedAt : Date.now() };
+      if (fromQueue) rowBuyQueue.unshift(entry);
+      else rowBuyQueue.push(entry);
       toast('Queued — filling after the current buy');
+      scheduleRowBuyDrain();
       return;
     }
     const rowBuyToken = acquireRowBuyLatch();
@@ -7102,7 +7114,6 @@
     if (button) button.classList.add('busy');
     primeAudio();
     try {
-      const amount = (settings.presetsBuy || [0.1])[0];
       // Guardrails apply to chip buys exactly like panel buys.
       const guard = E.guardCheck(state, settings, { solAmount: amount });
       if (!guard.ok) { outcome = 'guard-refused'; toast(guard.message); return; }
@@ -9250,6 +9261,7 @@
   }
 
   function disableOverlay() {
+    clearRowBuyQueue();
     if (!host) return;
     stopOverlays();
     // O-26: listeners registered per mount (drag wiring, resize re-clamp,

--- a/extension/content.js
+++ b/extension/content.js
@@ -1178,27 +1178,26 @@
           : (mirrored && mirrored.address ? [mirrored] : []);
         const intent = intents.find((candidate) => candidate && candidate.address
           && candidate.amount > 0
+          && Date.now() - candidate.at <= ARMED_ROW_TTL_MS
           && (candidate.address === data.mint
             || candidate.address === data.pairAddress
             || candidate.address === data.srcAddress));
         if (intent) {
-          if (Date.now() - intent.at <= ARMED_ROW_TTL_MS) {
-            if (!armedBuy) {
-              armedBuy = {
-                amount: intent.amount, usd: null, at: intent.at,
-                mint: data.mint, fromClick: true,
-                adoptedFromRow: true,
-              };
-              renderBuyButton();
-              flushArmedBuy();
-            }
-            // Consumed either way: an intent the chart adopts is never
-            // re-fillable by the (likely dead) board context.
-            sendMessage({
-              type: 'pt_armed_row_clear',
-              address: intent.address,
-            }).catch(() => {});
+          if (!armedBuy) {
+            armedBuy = {
+              amount: intent.amount, usd: null, at: intent.at,
+              mint: data.mint, fromClick: true,
+              adoptedFromRow: true,
+            };
+            renderBuyButton();
+            flushArmedBuy();
           }
+          // Consumed either way: an intent the chart adopts is never
+          // re-fillable by the (likely dead) board context.
+          sendMessage({
+            type: 'pt_armed_row_clear',
+            address: intent.address,
+          }).catch(() => {});
         }
       } catch (_) { /* adoption is an enhancement, never a landing risk */ }
       // The site publishes its live market cap in document.title, which changes
@@ -7350,7 +7349,8 @@
       // identical guard/engine/attestation/rail behaviour on both paths.
       rowBuyTimingState = timing;
       try {
-        await fillRowBuy(address, data, amount, rowBuyToken);
+        const result = await fillRowBuy(address, data, amount, rowBuyToken);
+        if (!result && !timing.outcome) outcome = 'refused';
       } finally {
         rowBuyTimingState = null;
       }

--- a/extension/content.js
+++ b/extension/content.js
@@ -6929,7 +6929,18 @@
           if (Number(data.mcap) > 0) data.mcap = Number(data.mcap) * scale;
           data.priceSource = 'row-feed';
         }
-        const result = await fillRowBuy(armed.address, data, armed.amount);
+        // Serialize only the commit. The armed resolver cascade must stay free
+        // to retry while a direct click is pricing or filling.
+        if (rowBuyInFlight) return;
+        rowBuyInFlight = true;
+        rowBuyInFlightAt = Date.now();
+        let result;
+        try {
+          result = await fillRowBuy(armed.address, data, armed.amount);
+        } finally {
+          rowBuyInFlight = false;
+          rowBuyInFlightAt = 0;
+        }
         if (result) {
           rowArmed = null;
           sendPadreMarker('row-buy-done', null);

--- a/extension/content.js
+++ b/extension/content.js
@@ -6954,6 +6954,9 @@
           releaseRowBuyLatch(rowBuyToken);
         }
         if (result) {
+          // D-42: the SW mirror dies with the intent it belongs to — a filled
+          // snipe must never be adopted by the chart page and filled twice,
+          // and a newer intent must keep both its slot and its mirror.
           if (rowArmed === armed) {
             rowArmed = null;
             sendMessage({ type: 'pt_armed_row_clear' }).catch(() => {});

--- a/extension/content.js
+++ b/extension/content.js
@@ -6573,7 +6573,7 @@
   // Newest USD price per mint from the site's OWN realtime feed (GMGN's
   // token_activity ticks carry a mint). A row buy prefers this over a
   // network quote because the screener is showing that very price.
-  const recentRowPrices = new Map(); // mint -> { usd, at }
+  const recentRowPrices = new Map(); // mint -> { usd, at, seq, symbol, name, mcap }
   const ROW_PRICE_TTL_MS = 10_000;
   let rowBuyScanAt = 0;
   let rowBuyInFlight = false;
@@ -6677,32 +6677,46 @@
 
   async function validRowPropsQuote(quote, address) {
     if (!quote || typeof quote !== 'object' || !ROW_ADDR_EXACT_RE.test(address || '')) return false;
-    const mint = quote.mint || null;
-    const pair = quote.pair || null;
+    const normalized = { ...quote };
+    const mint = normalized.mint || null;
+    const pair = normalized.pair || null;
     if ((mint && !ROW_ADDR_EXACT_RE.test(mint)) || (pair && !ROW_ADDR_EXACT_RE.test(pair))) return false;
     if ((!mint && !pair) || (mint !== address && pair !== address)) return false;
-    const hasPriceSol = quote.priceSol != null;
-    const hasPriceUsd = quote.priceUsd != null;
+    const hasPriceSol = normalized.priceSol != null;
+    const hasPriceUsd = normalized.priceUsd != null;
     if (!hasPriceSol && !hasPriceUsd) return false;
     for (const name of ['priceUsd', 'mcapUsd', 'supply']) {
-      if (quote[name] != null
-        && !(Number.isFinite(Number(quote[name])) && Number(quote[name]) > 0)) return false;
+      if (normalized[name] != null
+        && !(Number.isFinite(Number(normalized[name])) && Number(normalized[name]) > 0)) {
+        if (name !== 'mcapUsd') return false;
+        normalized.mcapUsd = null;
+      }
     }
     if (hasPriceSol
-        && !(Number.isFinite(Number(quote.priceSol)) && Number(quote.priceSol) > 0)) return false;
+        && !(Number.isFinite(Number(normalized.priceSol)) && Number(normalized.priceSol) > 0)) return false;
+    if (normalized.mcapUsd != null
+        && (!(Number(normalized.priceUsd) > 0 && Number(normalized.supply) > 0)
+          || Math.abs(Number(normalized.mcapUsd)
+            / (Number(normalized.priceUsd) * Number(normalized.supply)) - 1) > 0.02)) {
+      normalized.mcapUsd = null;
+    }
+    for (const [name, maxLength] of [['symbol', 24], ['name', 64]]) {
+      if (normalized[name] != null
+          && (typeof normalized[name] !== 'string'
+            || normalized[name].length > maxLength
+            || ROW_ADDR_EXACT_RE.test(normalized[name]))) normalized[name] = null;
+    }
     if (hasPriceUsd && !hasPriceSol) {
-      if (!(quote.supply > 0 && quote.mcapUsd > 0)
-          || Math.abs(Number(quote.priceUsd) * Number(quote.supply)
-            / Number(quote.mcapUsd) - 1) > 0.02) return false;
+      if (!(normalized.supply > 0 && normalized.mcapUsd > 0)) return false;
       const rate = await Promise.race([
         Promise.resolve().then(() => R.solUsd()).catch(() => 0),
         new Promise((resolve) => setTimeout(() => resolve(0), 2000)),
       ]);
       if (!(rate > 0)) return false;
-      return { ...quote, priceSol: Number(quote.priceUsd) / Number(rate) };
+      return { ...normalized, priceSol: Number(normalized.priceUsd) / Number(rate) };
     }
     if (hasPriceUsd) {
-      const implied = Number(quote.priceUsd) / Number(quote.priceSol);
+      const implied = Number(normalized.priceUsd) / Number(normalized.priceSol);
       const rate = await Promise.race([
         Promise.resolve().then(() => R.solUsd()).catch(() => 0),
         new Promise((resolve) => setTimeout(() => resolve(0), 2000)),
@@ -6710,7 +6724,7 @@
       if (rate > 0 && (!(implied > 0)
         || Math.max(implied / rate, rate / implied) > 1.25)) return false;
     }
-    return { ...quote, priceSol: Number(quote.priceSol) };
+    return { ...normalized, priceSol: Number(normalized.priceSol) };
   }
 
   /**
@@ -7056,8 +7070,8 @@
         data = {
           mint: validRowQuote.mint || address,
           pairAddress: validRowQuote.pair || null,
-          symbol: null,
-          name: null,
+          symbol: validRowQuote.symbol || null,
+          name: validRowQuote.name || null,
           priceNative: validRowQuote.priceSol,
           priceUsd: validRowQuote.priceUsd || null,
           mcap: validRowQuote.mcapUsd || null,

--- a/extension/content.js
+++ b/extension/content.js
@@ -6619,7 +6619,7 @@
     console.debug(`PaperTrench: row-buy source=${priceSource || 'unknown'}`
       + ` outcome=${outcome || 'done'} quote=${elapsed(marks.quote)}ms`
       + ` guard+state=${guardState}ms commit=${elapsed(marks.commit)}ms`
-      + ` total=${total}ms withState=${fromFill}ms persist=${persist}ms attempts=${attempts}`);
+      + ` total=${total}ms fill->state=${fromFill}ms persist=${persist}ms attempts=${attempts}`);
   }
 
   function finishRowPersist(timing, startedAt) {

--- a/extension/content.js
+++ b/extension/content.js
@@ -6669,12 +6669,27 @@
     const pair = quote.pair || null;
     if ((mint && !ROW_ADDR_EXACT_RE.test(mint)) || (pair && !ROW_ADDR_EXACT_RE.test(pair))) return false;
     if ((!mint && !pair) || (mint !== address && pair !== address)) return false;
-    if (!(Number.isFinite(Number(quote.priceSol)) && Number(quote.priceSol) > 0)) return false;
+    const hasPriceSol = quote.priceSol != null;
+    const hasPriceUsd = quote.priceUsd != null;
+    if (!hasPriceSol && !hasPriceUsd) return false;
     for (const name of ['priceUsd', 'mcapUsd', 'supply']) {
       if (quote[name] != null
         && !(Number.isFinite(Number(quote[name])) && Number(quote[name]) > 0)) return false;
     }
-    if (quote.priceUsd != null) {
+    if (hasPriceSol
+        && !(Number.isFinite(Number(quote.priceSol)) && Number(quote.priceSol) > 0)) return false;
+    if (hasPriceUsd && !hasPriceSol) {
+      if (!(quote.supply > 0 && quote.mcapUsd > 0)
+          || Math.abs(Number(quote.priceUsd) * Number(quote.supply)
+            / Number(quote.mcapUsd) - 1) > 0.02) return false;
+      const rate = await Promise.race([
+        Promise.resolve().then(() => R.solUsd()).catch(() => 0),
+        new Promise((resolve) => setTimeout(() => resolve(0), 2000)),
+      ]);
+      if (!(rate > 0)) return false;
+      return { ...quote, priceSol: Number(quote.priceUsd) / Number(rate) };
+    }
+    if (hasPriceUsd) {
       const implied = Number(quote.priceUsd) / Number(quote.priceSol);
       const rate = await Promise.race([
         Promise.resolve().then(() => R.solUsd()).catch(() => 0),
@@ -6683,7 +6698,7 @@
       if (rate > 0 && (!(implied > 0)
         || Math.max(implied / rate, rate / implied) > 1.25)) return false;
     }
-    return true;
+    return { ...quote, priceSol: Number(quote.priceSol) };
   }
 
   /**
@@ -7024,15 +7039,16 @@
       // nothing below may block this function's finally forever.
       const ROW_CASCADE_TIMEOUT_MS = 10_000;
       let data = null;
-      if (rowQuote && await validRowPropsQuote(rowQuote, address)) {
+      const validRowQuote = rowQuote && await validRowPropsQuote(rowQuote, address);
+      if (validRowQuote) {
         data = {
-          mint: rowQuote.mint || address,
-          pairAddress: rowQuote.pair || null,
+          mint: validRowQuote.mint || address,
+          pairAddress: validRowQuote.pair || null,
           symbol: null,
           name: null,
-          priceNative: rowQuote.priceSol,
-          priceUsd: rowQuote.priceUsd || null,
-          mcap: rowQuote.mcapUsd || null,
+          priceNative: validRowQuote.priceSol,
+          priceUsd: validRowQuote.priceUsd || null,
+          mcap: validRowQuote.mcapUsd || null,
           priceSource: 'row-props',
         };
       } else {

--- a/extension/content.js
+++ b/extension/content.js
@@ -6704,7 +6704,7 @@
     if (recentRowPrices.size > 300) recentRowPrices.delete(recentRowPrices.keys().next().value);
     // D-40: a board tick while a row snipe is armed is the fastest possible
     // wake — the row the trader tapped just printed a price of its own.
-    if (rowArmed.length) flushRowArmed();
+    if (rowArmed.length) flushRowArmed(payload.mint);
   }
 
   /** The row's own live price when the resolver cannot answer — GMGN's
@@ -7070,7 +7070,7 @@
   /** The D-40 armed-row flush: attempt a fill by every source in order; a
    * miss keeps the intent armed (the board feed, the resolver, and the chain
    * probe each get more chances until the TTL). */
-  async function flushRowArmed() {
+  async function flushRowArmed(preferAddress) {
     if (!rowArmed.length || rowArmedFlushing) return;
     const now = Date.now();
     for (let i = rowArmed.length - 1; i >= 0; i--) {
@@ -7090,7 +7090,8 @@
     sendRowBuyDoneIfIdle();
     if (!rowArmed.length) return;
     rowArmedFlushing = true;
-    const armed = rowArmed[0];
+    const armed = (preferAddress && rowArmed.find((intent) => intent.address === preferAddress))
+      || rowArmed[0];
     const timing = { priceSource: 'armed' };
     let terminal = false;
     rowBuyTimingState = timing;
@@ -7150,6 +7151,12 @@
               address: armed.address,
             }).catch(() => {});
           }
+        }
+      } else {
+        const index = rowArmed.indexOf(armed);
+        if (index !== -1) {
+          rowArmed.splice(index, 1);
+          rowArmed.push(armed);
         }
       }
     } catch (_) {
@@ -9356,6 +9363,7 @@
 
   function disableOverlay() {
     clearRowBuyQueue();
+    sendRowBuyDoneIfIdle();
     if (!host) return;
     stopOverlays();
     // O-26: listeners registered per mount (drag wiring, resize re-clamp,

--- a/extension/content.js
+++ b/extension/content.js
@@ -6808,7 +6808,7 @@
     return true;
   }
 
-  async function fillRowBuy(address, data, amount) {
+  async function fillRowBuy(address, data, amount, ownerToken) {
     // F-56: a chip fill runs through the SAME honesty gates as a panel fill.
     // The row's own price used to price the trade blind — no witness, no
     // contradiction check — so a stale/wrong row print booked entries far
@@ -6879,6 +6879,7 @@
     // Guardrails apply to chip buys exactly like panel buys.
     const guard = E.guardCheck(state, settings, { solAmount: amount });
     if (!guard.ok) { toast(guard.message); return null; }
+    if (rowBuyOwner !== ownerToken) return null;
     const result = await withState(async () => {
       // Re-runnable mutation — see doBuy: a lost CAS race re-applies this
       // row buy on the adopted base; only the landing attempt is chained.
@@ -6975,7 +6976,7 @@
         const rowBuyToken = acquireRowBuyLatch();
         let result;
         try {
-          result = await fillRowBuy(armed.address, data, armed.amount);
+          result = await fillRowBuy(armed.address, data, armed.amount, rowBuyToken);
         } finally {
           releaseRowBuyLatch(rowBuyToken);
         }
@@ -7127,8 +7128,7 @@
 
       // D-40: the commit core is shared with the armed flush — one extractor,
       // identical guard/engine/attestation/rail behaviour on both paths.
-      if (rowBuyOwner !== rowBuyToken) return;
-      await fillRowBuy(address, data, amount);
+      await fillRowBuy(address, data, amount, rowBuyToken);
     } catch (err) {
       toast(err.message || 'Row buy failed');
     } finally {

--- a/extension/content.js
+++ b/extension/content.js
@@ -6603,8 +6603,17 @@
       ? payload.candidates.find((c) => c && c.unit === 'usd' && Number(c.value) > 0)
       : null;
     if (!cand) return;
+    const now = Date.now();
+    const candidateAt = Number(payload.at);
+    const frameAt = Number.isFinite(candidateAt)
+      && candidateAt > now - 30_000
+      && candidateAt <= now
+      ? candidateAt
+      : now;
+    const prev = recentRowPrices.get(payload.mint);
+    if (prev && frameAt < prev.at) return;
     recentRowPrices.set(payload.mint, {
-      usd: Number(cand.value), at: Date.now(),
+      usd: Number(cand.value), at: frameAt,
       symbol: typeof payload.symbol === 'string' ? payload.symbol : null,
       name: typeof payload.name === 'string' ? payload.name : null,
       mcap: Number(payload.mcap) > 0 ? Number(payload.mcap) : null,

--- a/extension/content.js
+++ b/extension/content.js
@@ -6577,12 +6577,17 @@
   const ROW_PRICE_TTL_MS = 10_000;
   let rowBuyScanAt = 0;
   let rowBuyInFlight = false;
+  const rowBuyQueue = [];
+  const ROW_BUY_QUEUE_MAX = 3;
+  const ROW_BUY_QUEUE_TTL_MS = 5000;
+  let rowBuyDrainTimer = null;
   // D-41: when the in-flight latch was SET, so the 1 s heartbeat can free a
   // latch whose await never settled (a hung resolver/SW RPC on a weird pair
   // once left "Row buy already in progress…" on every coin until reload —
   // live report). A settled finally clears the latch long before this ages.
   let rowBuyInFlightAt = 0;
   let rowBuyOwner = 0;
+  let rowBuyTimingState = null;
 
   function acquireRowBuyLatch() {
     rowBuyInFlight = true;
@@ -6596,6 +6601,43 @@
     rowBuyInFlight = false;
     rowBuyInFlightAt = 0;
   }
+
+  function rowBuyTiming(t0, priceSource, marks, outcome) {
+    const elapsed = (mark) => Number.isFinite(mark) ? Math.max(0, mark - t0) : '-';
+    const total = Math.max(0, Date.now() - t0);
+    console.debug(`PaperTrench: row-buy source=${priceSource || 'unknown'}`
+      + ` outcome=${outcome || 'done'} quote=${elapsed(marks.quote)}ms`
+      + ` guard+state=${elapsed(marks.guardState)}ms commit=${elapsed(marks.commit)}ms`
+      + ` total=${total}ms`);
+  }
+
+  function scheduleRowBuyDrain() {
+    if (contextDead || rowBuyDrainTimer || rowBuyInFlight || !rowBuyQueue.length) return;
+    rowBuyDrainTimer = setTimeout(() => {
+      rowBuyDrainTimer = null;
+      drainRowBuyQueue();
+    }, 0);
+  }
+
+  function drainRowBuyQueue() {
+    if (contextDead || rowBuyInFlight || !rowBuyQueue.length) return;
+    const entry = rowBuyQueue.shift();
+    if (Date.now() - entry.at >= ROW_BUY_QUEUE_TTL_MS) {
+      toast('Queued row buy expired — no fill at the tapped price');
+      rowBuyTiming(entry.at, 'queue', {}, 'expired');
+      scheduleRowBuyDrain();
+      return;
+    }
+    doRowBuy(entry.address, entry.button, entry.quote, entry.at);
+  }
+
+  onTeardown(() => {
+    rowBuyQueue.length = 0;
+    if (rowBuyDrainTimer) {
+      clearTimeout(rowBuyDrainTimer);
+      rowBuyDrainTimer = null;
+    }
+  });
 
   function noteRowPrice(payload) {
     if (!payload || typeof payload.mint !== 'string' || !ROW_ADDR_RE.test(payload.mint)) return;
@@ -6850,6 +6892,7 @@
   }
 
   async function fillRowBuy(address, data, amount, ownerToken) {
+    const timing = rowBuyTimingState;
     // F-56: a chip fill runs through the SAME honesty gates as a panel fill.
     // The row's own price used to price the trade blind — no witness, no
     // contradiction check — so a stale/wrong row print booked entries far
@@ -6938,8 +6981,10 @@
       };
       mutate();
       await persistStateNow(mutate);
+      if (timing) timing.guardState = Date.now();
       // Chain append after the wallet commit — see doBuy for the ordering.
       await commitFill(filled.trade);
+      if (timing) timing.commit = Date.now();
       return { trade: filled.trade, position: filled.position, opened: filled.opened };
     });
     if (!result) return null;
@@ -7020,6 +7065,7 @@
           result = await fillRowBuy(armed.address, data, armed.amount, rowBuyToken);
         } finally {
           releaseRowBuyLatch(rowBuyToken);
+          scheduleRowBuyDrain();
         }
         if (result) {
           // D-42: the SW mirror dies with the intent it belongs to — a filled
@@ -7038,16 +7084,28 @@
   }
 
   /** Paper-buy the first preset amount of a screener row's token. */
-  async function doRowBuy(address, button, rowQuote) {
-    if (rowBuyInFlight) return toast('Row buy already in progress…');
+  async function doRowBuy(address, button, rowQuote, queuedAt) {
+    const t0 = Number.isFinite(queuedAt) ? queuedAt : Date.now();
+    if (rowBuyInFlight) {
+      if (rowBuyQueue.length >= ROW_BUY_QUEUE_MAX) {
+        toast('Row buy queue full — tap again after current buys finish');
+        rowBuyTiming(t0, 'queue', {}, 'refused');
+        return;
+      }
+      rowBuyQueue.push({ address, button, quote: rowQuote, at: Date.now() });
+      toast('Queued — filling after the current buy');
+      return;
+    }
     const rowBuyToken = acquireRowBuyLatch();
+    const timing = { quote: null, guardState: null, commit: null };
+    let outcome = 'done';
     if (button) button.classList.add('busy');
     primeAudio();
     try {
       const amount = (settings.presetsBuy || [0.1])[0];
       // Guardrails apply to chip buys exactly like panel buys.
       const guard = E.guardCheck(state, settings, { solAmount: amount });
-      if (!guard.ok) { toast(guard.message); return; }
+      if (!guard.ok) { outcome = 'guard-refused'; toast(guard.message); return; }
       // A screener chip fill must not price from a minute-old display cache
       // (the resolver keeps entries 60 s for display use). Demand a quote no
       // older than the live-feed staleness bound; the resolver refetches when
@@ -7154,8 +7212,11 @@
             flushRowArmed();
           }, 1500);
         }
+        timing.priceSource = 'armed';
+        rowBuyTiming(t0, timing.priceSource, timing, 'armed');
         return;
       }
+      timing.quote = Date.now();
       // The screener's own realtime price wins when it is fresh: that is the
       // number the user just looked at before tapping.
       // F-59: the lookup tries EVERY identity the token answers to. Pulse
@@ -7181,15 +7242,24 @@
         if (Number(data.mcap) > 0) data.mcap = Number(data.mcap) * scale;
         data.priceSource = 'row-feed';
       }
+      timing.priceSource = data.priceSource;
 
       // D-40: the commit core is shared with the armed flush — one extractor,
       // identical guard/engine/attestation/rail behaviour on both paths.
-      await fillRowBuy(address, data, amount, rowBuyToken);
+      rowBuyTimingState = timing;
+      try {
+        await fillRowBuy(address, data, amount, rowBuyToken);
+      } finally {
+        rowBuyTimingState = null;
+      }
     } catch (err) {
+      outcome = 'error';
       toast(err.message || 'Row buy failed');
     } finally {
       releaseRowBuyLatch(rowBuyToken);
       if (button) button.classList.remove('busy');
+      rowBuyTiming(t0, timing.priceSource, timing, outcome);
+      scheduleRowBuyDrain();
     }
   }
 
@@ -9160,6 +9230,7 @@
         rowBuyInFlight = false;
         rowBuyInFlightAt = 0;
         toast('A stuck row buy was released — try again');
+        scheduleRowBuyDrain();
       }
       if (buyInFlight && buyInFlightAt && Date.now() - buyInFlightAt > LATCH_MAX_AGE_MS) {
         buyInFlight = false;

--- a/extension/content.js
+++ b/extension/content.js
@@ -6879,8 +6879,8 @@
     // Guardrails apply to chip buys exactly like panel buys.
     const guard = E.guardCheck(state, settings, { solAmount: amount });
     if (!guard.ok) { toast(guard.message); return null; }
-    if (rowBuyOwner !== ownerToken) return null;
     const result = await withState(async () => {
+      if (rowBuyOwner !== ownerToken) return null;
       // Re-runnable mutation — see doBuy: a lost CAS race re-applies this
       // row buy on the adopted base; only the landing attempt is chained.
       let filled = null;

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3609,18 +3609,6 @@
         const hasIdentity = own.tokenAddress || own.mint || own.pairAddress;
         const hasPrice = [...priceKeys].some((name) => own[name] !== undefined);
         if (hasIdentity && hasPrice) candidates.push(own);
-        const hasUsdPrice = own.tokenPriceUsd !== undefined
-          || own.priceUsd !== undefined
-          || own.marketCapUsd !== undefined;
-        if (!hasIdentity && hasUsdPrice) {
-          for (const value of Object.values(obj)) {
-            const nested = fieldsFor(value);
-            if (nested && nested.tokenAddress) {
-              candidates.push({ tokenAddress: nested.tokenAddress, ...own });
-              break;
-            }
-          }
-        }
         for (const value of Object.values(obj)) {
           if (value && typeof value === 'object') walk(value, depth + 1);
         }

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -400,6 +400,10 @@
       if (rec.candidates.length >= MAX_CANDIDATES) rec.candidates.shift();
       rec.candidates.push(cand);
     };
+    const validPadreSymbol = (value) => typeof value === 'string'
+      && value.length <= 24 && !BASE58_RE.test(value) ? value : null;
+    const validPadreName = (value) => typeof value === 'string'
+      && value.length <= 64 && !BASE58_RE.test(value) ? value : null;
 
     (function walk(node, depth, ctx, tainted) {
       if (!node || typeof node !== 'object' || depth > MAX_DEPTH || seen.has(node)) return;
@@ -427,6 +431,16 @@
       const entries = Array.isArray(node)
         ? node.map((v, i) => [String(i), v])
         : Object.entries(node);
+      const sameObjectSymbol = !Array.isArray(node)
+        ? entries.reduce((found, [key, value]) => found || (
+          /^(tokenTicker|symbol|ticker)$/.test(key) ? validPadreSymbol(value) : null
+        ), null)
+        : null;
+      const sameObjectName = !Array.isArray(node)
+        ? entries.reduce((found, [key, value]) => found || (
+          /^(tokenName|name)$/.test(key) ? validPadreName(value) : null
+        ), null)
+        : null;
 
       for (const [key, value] of entries) {
         if (budget <= 0) return;
@@ -443,7 +457,11 @@
           const n = numberValue(value);
           if (n > 0) {
             const unit = USD_HINT.test(key) ? 'usd' : NATIVE_HINT.test(key) ? 'native' : 'unknown';
-            pushCandidate(rec, { value: n, unit, key });
+            pushCandidate(rec, {
+              value: n, unit, key,
+              ...(sameObjectSymbol ? { symbol: sameObjectSymbol } : {}),
+              ...(sameObjectName ? { name: sameObjectName } : {}),
+            });
           }
         } else if (!tainted && MCAP_KEY.test(key)) {
           const n = numberValue(value);
@@ -457,6 +475,16 @@
     })(obj, 0, null, false);
 
     return { records, top };
+  }
+
+  function padreMetadata(rec) {
+    const candidate = rec && rec.candidates
+      ? rec.candidates.find((item) => item.value > 0)
+      : null;
+    return {
+      symbol: candidate && candidate.symbol ? candidate.symbol : null,
+      name: candidate && candidate.name ? candidate.name : null,
+    };
   }
 
   function notePadreSupplies(obj) {
@@ -652,20 +680,35 @@
         || null;
       let emitted = 0;
       if (watched && hasContent(watched)) {
-        emit('tick', withFrameEvidence({ ...watched, source }, receivedAt, seq));
+        const metadata = padreBinary ? padreMetadata(watched) : null;
+        emit('tick', withFrameEvidence({
+          ...watched,
+          ...(metadata ? metadata : {}),
+          source,
+        }, receivedAt, seq));
         emitted++;
       }
       for (const rec of records.values()) {
         if (rec === watched || !hasContent(rec)) continue;
         if (emitted++ >= 5) break;
-        emit('tick', withFrameEvidence({ ...rec, source }, receivedAt, seq));
+        const metadata = padreBinary ? padreMetadata(rec) : null;
+        emit('tick', withFrameEvidence({
+          ...rec,
+          ...(metadata ? metadata : {}),
+          source,
+        }, receivedAt, seq));
       }
       if (emitted) return;
       // Records existed but carried no prices; fall through to the
       // unattributed finds so a lone top-level price still ticks.
     }
     if (!top.candidates.length && top.mcap === null) return;
-    emit('tick', withFrameEvidence({ ...top, source }, receivedAt, seq));
+    const metadata = padreBinary ? padreMetadata(top) : null;
+    emit('tick', withFrameEvidence({
+      ...top,
+      ...(metadata ? metadata : {}),
+      source,
+    }, receivedAt, seq));
   }
 
   /* ---------------- SPA navigation signal ----------------

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -35,6 +35,7 @@
   // bounded by NODE_BUDGET, so bigger frames cannot runaway the main thread.
   const FRAME_GUARD_BYTES = 2_000_000;
   const MAX_MARKS = 500;
+  let webSocketFrameSeq = 0;
 
   let paperMarks = [];
   // Per-mark fill levels (USD / SOL / market cap), kept for the execution-
@@ -473,11 +474,16 @@
   const ACTIVITY_TICK_MIN_MS = 100;
   const activityLastEmitByMint = new Map();
 
-  function withReceivedAt(payload, receivedAt) {
-    return Number.isFinite(receivedAt) ? { ...payload, at: receivedAt } : payload;
+  function withFrameEvidence(payload, receivedAt, seq) {
+    if (!Number.isFinite(receivedAt)) return payload;
+    return {
+      ...payload,
+      at: receivedAt,
+      ...(Number.isFinite(seq) ? { seq } : {}),
+    };
   }
 
-  function forwardTokenActivity(parsed, receivedAt) {
+  function forwardTokenActivity(parsed, receivedAt, seq) {
     if (!parsed || parsed.channel !== 'token_activity' || !Array.isArray(parsed.data)) return false;
     const now = Date.now();
     const latestByMint = new Map();
@@ -494,14 +500,14 @@
     const due = (mint) => now - (activityLastEmitByMint.get(mint) || 0) >= ACTIVITY_TICK_MIN_MS;
     const emitTick = (mint, priceUsd) => {
       activityLastEmitByMint.set(mint, now);
-      emit('tick', withReceivedAt({
+      emit('tick', withFrameEvidence({
         candidates: [{ value: priceUsd, unit: 'usd', key: 'tokenActivityPriceUsd' }],
         mcap: null,
         mint,
         symbol: currentSymbolInfo.mint === mint ? currentSymbolInfo.symbol : null,
         name: null,
         source: 'gmgn-ws-trade',
-      }, receivedAt));
+      }, receivedAt, seq));
     };
     const watchedMint = currentSymbolInfo.mint;
     if (watchedMint && latestByMint.has(watchedMint) && due(watchedMint)) {
@@ -526,7 +532,7 @@
     return true;
   }
 
-  function forwardJson(raw, source, url, receivedAt) {
+  function forwardJson(raw, source, url, receivedAt, seq) {
     // No consumer, no parse — the cheapest frame is the one never read.
     if (!feedActive()) return;
     let parsed = raw;
@@ -542,7 +548,7 @@
       // forwardTokenActivity still validates the parsed shape.
       if (trimmed.length > 15 && trimmed.slice(0, 120).indexOf('"token_activity"') !== -1) {
         try { parsed = JSON.parse(raw); } catch (_) { return; }
-        forwardTokenActivity(parsed, receivedAt);
+        forwardTokenActivity(parsed, receivedAt, seq);
         return;
       }
       if (url && /\/api\/v1\/token_mcap_candles\//.test(url)) {
@@ -581,13 +587,13 @@
         // C-08: this close IS the value on GMGN's Y axis — the scale anchor
         // for every GMGN line and fill shape (see gmgnCapScale).
         gmgnLastCandleClose = mcap;
-        emit('tick', withReceivedAt({
+        emit('tick', withFrameEvidence({
           candidates: [],
           mcap,
           mint: currentSymbolInfo.mint,
           symbol: currentSymbolInfo.symbol,
           source: 'gmgn-mcap-candle',
-        }, receivedAt));
+        }, receivedAt, seq));
         return;
       }
     }
@@ -602,20 +608,20 @@
         || null;
       let emitted = 0;
       if (watched && hasContent(watched)) {
-        emit('tick', withReceivedAt({ ...watched, source }, receivedAt));
+        emit('tick', withFrameEvidence({ ...watched, source }, receivedAt, seq));
         emitted++;
       }
       for (const rec of records.values()) {
         if (rec === watched || !hasContent(rec)) continue;
         if (emitted++ >= 5) break;
-        emit('tick', withReceivedAt({ ...rec, source }, receivedAt));
+        emit('tick', withFrameEvidence({ ...rec, source }, receivedAt, seq));
       }
       if (emitted) return;
       // Records existed but carried no prices; fall through to the
       // unattributed finds so a lone top-level price still ticks.
     }
     if (!top.candidates.length && top.mcap === null) return;
-    emit('tick', withReceivedAt({ ...top, source }, receivedAt));
+    emit('tick', withFrameEvidence({ ...top, source }, receivedAt, seq));
   }
 
   /* ---------------- SPA navigation signal ----------------
@@ -680,8 +686,8 @@
   }
 
   // Padre's binary socket frames are MessagePack, not protobuf. Capture the
-  // receive time before a Blob's asynchronous body conversion so consumers
-  // can reject an older frame that completes after a newer one.
+  // receive time and bridge-wide sequence before a Blob's asynchronous body
+  // conversion so consumers can order same-time frames safely.
   const OriginalWebSocket = window.WebSocket;
   if (typeof OriginalWebSocket === 'function') {
     const WrappedWebSocket = function (url, protocols) {
@@ -690,16 +696,17 @@
         : new OriginalWebSocket(url, protocols);
       socket.addEventListener('message', (event) => {
         const receivedAt = Date.now();
+        const seq = ++webSocketFrameSeq;
         if (typeof event.data === 'string') {
-          forwardJson(event.data, 'ws', undefined, receivedAt);
+          forwardJson(event.data, 'ws', undefined, receivedAt, seq);
         } else if (hostIsPadre && feedActive() && event.data instanceof ArrayBuffer) {
           const decoded = decodeMsgpack(new Uint8Array(event.data));
-          if (decoded !== null) forwardJson(decoded, 'ws', undefined, receivedAt);
+          if (decoded !== null) forwardJson(decoded, 'ws', undefined, receivedAt, seq);
         } else if (hostIsPadre && feedActive()
           && typeof Blob === 'function' && event.data instanceof Blob) {
           Promise.resolve(event.data.arrayBuffer()).then((buffer) => {
             const decoded = decodeMsgpack(new Uint8Array(buffer));
-            if (decoded !== null) forwardJson(decoded, 'ws', undefined, receivedAt);
+            if (decoded !== null) forwardJson(decoded, 'ws', undefined, receivedAt, seq);
           }, () => {});
         }
       });

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -359,6 +359,7 @@
   // front reported ever older prices exactly as batches grew with volume
   // (DEFECT F-03). The budget only bites on pathological frames.
   const NODE_BUDGET = 20_000;
+  const padreSupplyByMint = new Map();
   // Identifier strength: on several sites `address`/`ca` carry the AMM/pool
   // address rather than the token mint, so an explicit mint-ish key must win
   // the record association when both appear on one object.
@@ -458,6 +459,47 @@
     return { records, top };
   }
 
+  function notePadreSupplies(obj) {
+    const seen = new WeakSet();
+    let budget = NODE_BUDGET;
+    (function walk(node, depth) {
+      if (!node || typeof node !== 'object' || depth > MAX_DEPTH || seen.has(node)) return;
+      if (budget-- <= 0) return;
+      seen.add(node);
+      if (typeof node.tokenAddress === 'string' && BASE58_RE.test(node.tokenAddress)) {
+        const totalSupply = numberValue(node.totalSupply);
+        const decimals = numberValue(node.decimals);
+        const supply = totalSupply > 0 && Number.isInteger(decimals) && decimals >= 0 && decimals <= 30
+          ? totalSupply / (10 ** decimals)
+          : null;
+        if (supply > 0 && Number.isFinite(supply)) {
+          padreSupplyByMint.set(node.tokenAddress, supply);
+          if (padreSupplyByMint.size > 300) {
+            padreSupplyByMint.delete(padreSupplyByMint.keys().next().value);
+          }
+        }
+      }
+      for (const value of Object.values(node)) walk(value, depth + 1);
+    })(obj, 0);
+  }
+
+  function normalizePadreCaps(records) {
+    for (const rec of records.values()) {
+      const supply = padreSupplyByMint.get(rec.mint);
+      const price = rec.candidates.find((candidate) => candidate.key === 'priceInUsd');
+      if (!(supply > 0) || !(price && price.value > 0) || !(rec.mcap > 0)) {
+        rec.mcap = null;
+        continue;
+      }
+      const derived = price.value * supply;
+      if (!(derived > 0) || !Number.isFinite(derived)) {
+        rec.mcap = null;
+      } else if (Math.abs(rec.mcap / derived - 1) > 0.02) {
+        rec.mcap = derived;
+      }
+    }
+  }
+
   // GMGN's realtime WebSocket publishes every venue trade on the
   // `token_activity` channel with terse keys: `a` = token mint, `pu` = trade
   // price in USD, `e` = buy/sell. The generic key scanner cannot see these
@@ -532,7 +574,7 @@
     return true;
   }
 
-  function forwardJson(raw, source, url, receivedAt, seq) {
+  function forwardJson(raw, source, url, receivedAt, seq, padreBinary = false) {
     // No consumer, no parse — the cheapest frame is the one never read.
     if (!feedActive()) return;
     let parsed = raw;
@@ -569,6 +611,7 @@
     if (!parsed || typeof parsed !== 'object') return;
 
     if (forwardTokenActivity(parsed)) return;
+    if (padreBinary) notePadreSupplies(parsed);
 
     // GMGN's embedded TradingView chart is explicitly a market-cap chart:
     // /api/v1/token_mcap_candles/... returns USD market-cap OHLC values in
@@ -599,6 +642,7 @@
     }
 
     const { records, top } = collect(parsed);
+    if (padreBinary) normalizePadreCaps(records);
     const hasContent = (rec) => rec.candidates.length || rec.mcap !== null;
     if (records.size) {
       // Watched token first — the GMGN fast-path contract, now generic — then
@@ -701,12 +745,12 @@
           forwardJson(event.data, 'ws', undefined, receivedAt, seq);
         } else if (hostIsPadre && feedActive() && event.data instanceof ArrayBuffer) {
           const decoded = decodeMsgpack(new Uint8Array(event.data));
-          if (decoded !== null) forwardJson(decoded, 'ws', undefined, receivedAt, seq);
+          if (decoded !== null) forwardJson(decoded, 'ws', undefined, receivedAt, seq, true);
         } else if (hostIsPadre && feedActive()
           && typeof Blob === 'function' && event.data instanceof Blob) {
           Promise.resolve(event.data.arrayBuffer()).then((buffer) => {
             const decoded = decodeMsgpack(new Uint8Array(buffer));
-            if (decoded !== null) forwardJson(decoded, 'ws', undefined, receivedAt, seq);
+            if (decoded !== null) forwardJson(decoded, 'ws', undefined, receivedAt, seq, true);
           }, () => {});
         }
       });
@@ -3725,7 +3769,7 @@
       const stack = [start];
       const candidates = [];
       const identityKeys = new Set([
-        'tokenAddress', 'mint', 'address', 'pairAddress', 'pool_address',
+        'tokenAddress', 'mint', 'address', 'pairAddress', 'pool_address', 'pair',
       ]);
       const priceKeys = new Set([
         'priceSol', 'priceNative', 'tokenPriceUsd', 'priceUsd',
@@ -3739,6 +3783,16 @@
         for (const [name, value] of Object.entries(obj)) {
           if (identityKeys.has(name)) {
             if (typeof value === 'string' && BASE58_RE.test(value)) fields[name] = value;
+            continue;
+          }
+          if ((name === 'tokenTicker' || name === 'symbol' || name === 'ticker')
+              && typeof value === 'string' && value.length <= 24 && !BASE58_RE.test(value)) {
+            fields.symbol = value;
+            continue;
+          }
+          if ((name === 'tokenName' || name === 'name')
+              && typeof value === 'string' && value.length <= 64 && !BASE58_RE.test(value)) {
+            fields.name = value;
             continue;
           }
           if (badKey.test(name)) continue;
@@ -3781,7 +3835,7 @@
         }
       };
       let steps = 0;
-      while (stack.length && steps++ < 80) {
+      while (stack.length && steps++ < 400) {
         const fiber = stack.pop();
         if (!fiber || seen.has(fiber)) continue;
         seen.add(fiber);
@@ -3789,6 +3843,12 @@
         walk(fiber.memoizedState, 0);
         if (fiber.child) stack.push(fiber.child);
         if (fiber.sibling) stack.push(fiber.sibling);
+      }
+      for (let fiber = start, ancestors = 0; fiber && ancestors < 12; fiber = fiber.return, ancestors++) {
+        if (seen.has(fiber)) continue;
+        seen.add(fiber);
+        walk(fiber.memoizedProps, 0);
+        walk(fiber.memoizedState, 0);
       }
       const matching = candidates.filter((fields) =>
         fields.tokenAddress === tappedAddress
@@ -3800,7 +3860,8 @@
       const selected = matching.reduce((best, fields) =>
         !best || Object.keys(fields).length > Object.keys(best).length ? fields : best, null);
       const usd = candidates.find((fields) =>
-        fields.tokenAddress
+        fields !== selected
+        && fields.tokenAddress
         && fields.tokenAddress === selected.tokenAddress
         && (fields.tokenPriceUsd !== undefined
           || fields.priceUsd !== undefined
@@ -3811,14 +3872,22 @@
           if (merged[name] === undefined && usd[name] !== undefined) merged[name] = usd[name];
         }
       }
-      return {
+      let mcapUsd = merged.marketCapUsd || merged.mcapUsd || null;
+      const priceUsd = merged.tokenPriceUsd || merged.priceUsd || null;
+      const supply = merged.supply || merged.total_supply || merged.totalSupply || null;
+      if (!(mcapUsd > 0 && priceUsd > 0 && supply > 0)
+          || Math.abs(mcapUsd / (priceUsd * supply) - 1) > 0.02) mcapUsd = null;
+      const quote = {
         mint: merged.tokenAddress || merged.mint || merged.address || null,
         pair: merged.pairAddress || merged.pair || merged.pool_address || null,
         priceSol: merged.priceSol || merged.priceNative || null,
-        priceUsd: merged.tokenPriceUsd || merged.priceUsd || null,
-        mcapUsd: merged.marketCapUsd || merged.mcapUsd || null,
-        supply: merged.supply || merged.total_supply || merged.totalSupply || null,
+        priceUsd,
+        mcapUsd,
+        supply,
       };
+      if (merged.symbol !== undefined) quote.symbol = merged.symbol;
+      if (merged.name !== undefined) quote.name = merged.name;
+      return quote;
     } catch (_) {
       return null;
     }

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3769,7 +3769,7 @@
       const stack = [start];
       const candidates = [];
       const identityKeys = new Set([
-        'tokenAddress', 'mint', 'address', 'pairAddress', 'pool_address', 'pair',
+        'tokenAddress', 'mint', 'address', 'pairAddress', 'pool_address',
       ]);
       const priceKeys = new Set([
         'priceSol', 'priceNative', 'tokenPriceUsd', 'priceUsd',

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3859,17 +3859,13 @@
       if (!matching.length) return null;
       const selected = matching.reduce((best, fields) =>
         !best || Object.keys(fields).length > Object.keys(best).length ? fields : best, null);
-      const usd = candidates.find((fields) =>
-        fields !== selected
-        && fields.tokenAddress
-        && fields.tokenAddress === selected.tokenAddress
-        && (fields.tokenPriceUsd !== undefined
-          || fields.priceUsd !== undefined
-          || fields.marketCapUsd !== undefined));
       const merged = { ...selected };
-      if (usd) {
+      for (const fields of candidates) {
+        if (fields === selected
+            || !fields.tokenAddress
+            || fields.tokenAddress !== selected.tokenAddress) continue;
         for (const name of ['tokenPriceUsd', 'priceUsd', 'marketCapUsd']) {
-          if (merged[name] === undefined && usd[name] !== undefined) merged[name] = usd[name];
+          if (merged[name] === undefined && fields[name] !== undefined) merged[name] = fields[name];
         }
       }
       let mcapUsd = merged.marketCapUsd || merged.mcapUsd || null;

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3603,19 +3603,26 @@
         }
         return fields;
       };
-      const walk = (obj, depth, inheritedPrices) => {
+      const walk = (obj, depth) => {
         if (!obj || typeof obj !== 'object' || depth > 3) return;
         const own = fieldsFor(obj) || {};
         const hasIdentity = own.tokenAddress || own.mint || own.pairAddress;
-        const fields = hasIdentity ? { ...inheritedPrices, ...own } : own;
-        const hasPrice = [...priceKeys].some((name) => fields[name] !== undefined);
-        if (hasIdentity && hasPrice) candidates.push(fields);
-        const childPrices = hasIdentity ? {} : { ...inheritedPrices };
-        for (const name of [...priceKeys, 'supply']) {
-          if (own[name] !== undefined) childPrices[name] = own[name];
+        const hasPrice = [...priceKeys].some((name) => own[name] !== undefined);
+        if (hasIdentity && hasPrice) candidates.push(own);
+        const hasUsdPrice = own.tokenPriceUsd !== undefined
+          || own.priceUsd !== undefined
+          || own.marketCapUsd !== undefined;
+        if (!hasIdentity && hasUsdPrice) {
+          for (const value of Object.values(obj)) {
+            const nested = fieldsFor(value);
+            if (nested && nested.tokenAddress) {
+              candidates.push({ tokenAddress: nested.tokenAddress, ...own });
+              break;
+            }
+          }
         }
         for (const value of Object.values(obj)) {
-          if (value && typeof value === 'object') walk(value, depth + 1, childPrices);
+          if (value && typeof value === 'object') walk(value, depth + 1);
         }
       };
       let steps = 0;
@@ -3623,8 +3630,8 @@
         const fiber = stack.pop();
         if (!fiber || seen.has(fiber)) continue;
         seen.add(fiber);
-        walk(fiber.memoizedProps, 0, {});
-        walk(fiber.memoizedState, 0, {});
+        walk(fiber.memoizedProps, 0);
+        walk(fiber.memoizedState, 0);
         if (fiber.child) stack.push(fiber.child);
         if (fiber.sibling) stack.push(fiber.sibling);
       }

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -26,6 +26,10 @@
   const PATCHED = Symbol('papertrench-patched');
   const MAX_DEPTH = 7;
   const MAX_CANDIDATES = 32;
+  const bridgeHostname = (() => {
+    try { return location.hostname || new URL(location.href).hostname; } catch (_) { return ''; }
+  })();
+  const hostIsPadre = /(^|\.)padre\.gg$/.test(bridgeHostname);
   // Upper bound on frames the generic path will JSON.parse. Parse cost at
   // this size is ~10-20 ms occasionally; the collector walk is separately
   // bounded by NODE_BUDGET, so bigger frames cannot runaway the main thread.
@@ -179,13 +183,128 @@
     return null;
   }
 
+  // Padre's multiplex socket uses MessagePack. Decode only the first value:
+  // the transport may append another value, but the first envelope is the
+  // complete page-owned message we need. The byte and node caps keep malformed
+  // or adversarial frames from turning the bridge into an unbounded parser.
+  function decodeMsgpack(input) {
+    try {
+      const bytes = input instanceof Uint8Array
+        ? input
+        : input instanceof ArrayBuffer ? new Uint8Array(input) : null;
+      if (!bytes || bytes.byteLength > 512 * 1024) return null;
+      const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+      let offset = 0;
+      let budget = NODE_BUDGET;
+      const fail = () => { throw new Error('invalid msgpack'); };
+      const need = (count) => {
+        if (count < 0 || offset + count > bytes.byteLength) fail();
+        const start = offset;
+        offset += count;
+        return start;
+      };
+      const text = (start, length) => {
+        const chunk = bytes.subarray(start, start + length);
+        if (typeof TextDecoder === 'function') return new TextDecoder().decode(chunk);
+        let out = '';
+        for (let i = 0; i < chunk.length; i++) out += String.fromCharCode(chunk[i]);
+        return out;
+      };
+      const parse = (depth) => {
+        if (depth > MAX_DEPTH * 4 || budget-- <= 0 || offset >= bytes.byteLength) fail();
+        const tag = bytes[offset++];
+        if (tag <= 0x7f) return tag;
+        if (tag >= 0xe0) return tag - 0x100;
+        if (tag >= 0xa0 && tag <= 0xbf) {
+          const length = tag & 0x1f;
+          return text(need(length), length);
+        }
+        if (tag >= 0x90 && tag <= 0x9f) {
+          const out = [];
+          for (let i = 0; i < (tag & 0x0f); i++) out.push(parse(depth + 1));
+          return out;
+        }
+        if (tag >= 0x80 && tag <= 0x8f) {
+          const out = {};
+          for (let i = 0; i < (tag & 0x0f); i++) {
+            const key = String(parse(depth + 1));
+            out[key] = parse(depth + 1);
+          }
+          return out;
+        }
+        switch (tag) {
+          case 0xc0: return null;
+          case 0xc2: return false;
+          case 0xc3: return true;
+          case 0xcc: { const at = need(1); return view.getUint8(at); }
+          case 0xcd: { const at = need(2); return view.getUint16(at); }
+          case 0xce: { const at = need(4); return view.getUint32(at); }
+          case 0xcf: {
+            const at = need(8);
+            return view.getUint32(at) * 4294967296 + view.getUint32(at + 4);
+          }
+          case 0xd0: { const at = need(1); return view.getInt8(at); }
+          case 0xd1: { const at = need(2); return view.getInt16(at); }
+          case 0xd2: { const at = need(4); return view.getInt32(at); }
+          case 0xd3: {
+            const at = need(8);
+            const high = view.getInt32(at);
+            return high * 4294967296 + view.getUint32(at + 4);
+          }
+          case 0xca: { const at = need(4); return view.getFloat32(at); }
+          case 0xcb: { const at = need(8); return view.getFloat64(at); }
+          case 0xd9: { const length = bytes[need(1)]; return text(need(length), length); }
+          case 0xda: { const at = need(2); const length = view.getUint16(at); return text(need(length), length); }
+          case 0xdb: { const at = need(4); const length = view.getUint32(at); return text(need(length), length); }
+          case 0xc4: { const length = bytes[need(1)]; return bytes.slice(need(length), offset); }
+          case 0xc5: { const at = need(2); const length = view.getUint16(at); return bytes.slice(need(length), offset); }
+          case 0xc6: { const at = need(4); const length = view.getUint32(at); return bytes.slice(need(length), offset); }
+          case 0xdc: {
+            const at = need(2);
+            const out = [];
+            for (let i = 0; i < view.getUint16(at); i++) out.push(parse(depth + 1));
+            return out;
+          }
+          case 0xdd: {
+            const at = need(4);
+            const out = [];
+            for (let i = 0; i < view.getUint32(at); i++) out.push(parse(depth + 1));
+            return out;
+          }
+          case 0xde: {
+            const at = need(2);
+            const out = {};
+            for (let i = 0; i < view.getUint16(at); i++) {
+              const key = String(parse(depth + 1));
+              out[key] = parse(depth + 1);
+            }
+            return out;
+          }
+          case 0xdf: {
+            const at = need(4);
+            const out = {};
+            for (let i = 0; i < view.getUint32(at); i++) {
+              const key = String(parse(depth + 1));
+              out[key] = parse(depth + 1);
+            }
+            return out;
+          }
+          default: fail();
+        }
+      };
+      return parse(0);
+    } catch (_) {
+      return null;
+    }
+  }
+
   const BASE58_RE = /^[1-9A-HJ-NP-Za-km-z]{32,44}$/;
   // avgPrice is deliberately ABSENT: it is a position-average field, not a
   // live price. When the user holds a REAL position, the site streams their
   // real entry average under that key, and treating it as a market tick let
   // the user's own entry price pollute the paper feed (DEFECT F-30 — the
   // average line "blended" a real buy with the paper buy).
-  const PRICE_KEY = /^(price|priceNative|priceUsd|priceInSol|priceSol|solPrice|usdPrice|tokenPrice|lastPrice|last|close|c|markPrice|currentPrice|quote)$/i;
+  const PRICE_KEY = /^(price|priceNative|priceUsd|priceInSol|priceSol|priceInUsd|solPrice|usdPrice|tokenPrice|lastPrice|last|close|c|markPrice|currentPrice|quote)$/i;
   // Subtrees that describe the USER'S OWN holdings, not the market. Prices
   // inside them are historical facts about the user (entry averages, cost
   // bases, unrealized P&L) and must never become market-price candidates.
@@ -193,7 +312,7 @@
   // positions-of-SOMEONE either way, and prices inside them are entries,
   // not the market.
   const POSITION_SUBTREE_KEY = /^(positions?|holdings?|portfolio|userPositions?|myPositions?|openOrders?|hodlers?|holders?|topHolders?|toptraders?|balances?)$/i;
-  const MCAP_KEY = /^(marketCap|marketCapInUsd|mcap|mcapInUsd|fdv|fullyDilutedValuation)$/i;
+  const MCAP_KEY = /^(marketCap|marketCapInUsd|mcap|mcapInUsd|fdv|fdvInUsd|fullyDilutedValuation)$/i;
   // A record that IS a trade event — an id-carrying or user-attributed
   // swap/trade object (fomo's social feed, tx-hash trade tapes). Its price
   // and cap fields describe the moment that trade happened, minutes to
@@ -560,9 +679,16 @@
         ? new OriginalWebSocket(url)
         : new OriginalWebSocket(url, protocols);
       socket.addEventListener('message', (event) => {
-        // Padre's multiplex messages are binary protobuf and are deliberately
-        // handled after Padre decodes them through its TradingView datafeed.
         if (typeof event.data === 'string') forwardJson(event.data, 'ws');
+        else if (hostIsPadre && event.data instanceof ArrayBuffer) {
+          const decoded = decodeMsgpack(new Uint8Array(event.data));
+          if (decoded !== null) forwardJson(decoded, 'ws');
+        } else if (hostIsPadre && typeof Blob === 'function' && event.data instanceof Blob) {
+          Promise.resolve(event.data.arrayBuffer()).then((buffer) => {
+            const decoded = decodeMsgpack(new Uint8Array(buffer));
+            if (decoded !== null) forwardJson(decoded, 'ws');
+          }, () => {});
+        }
       });
       return socket;
     };
@@ -584,9 +710,6 @@
   // port.start() — on an object the host site owns. Other sites keep their
   // native SharedWorker untouched.
   const OriginalSharedWorker = window.SharedWorker;
-  const bridgeHostname = (() => {
-    try { return location.hostname || new URL(location.href).hostname; } catch (_) { return ''; }
-  })();
   const hostUsesSharedWorkerFeed = /(^|\.)gmgn\.ai$/.test(bridgeHostname);
   if (typeof OriginalSharedWorker === 'function' && hostUsesSharedWorkerFeed) {
     const WrappedSharedWorker = function (url, options) {

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -678,15 +678,28 @@
       const socket = protocols === undefined
         ? new OriginalWebSocket(url)
         : new OriginalWebSocket(url, protocols);
+      let socketSeq = 0;
+      let lastForwardedSeq = 0;
       socket.addEventListener('message', (event) => {
-        if (typeof event.data === 'string') forwardJson(event.data, 'ws');
-        else if (hostIsPadre && event.data instanceof ArrayBuffer) {
+        const seq = ++socketSeq;
+        if (typeof event.data === 'string') {
+          if (seq >= lastForwardedSeq) {
+            lastForwardedSeq = seq;
+            forwardJson(event.data, 'ws');
+          }
+        } else if (hostIsPadre && feedActive() && event.data instanceof ArrayBuffer) {
           const decoded = decodeMsgpack(new Uint8Array(event.data));
-          if (decoded !== null) forwardJson(decoded, 'ws');
-        } else if (hostIsPadre && typeof Blob === 'function' && event.data instanceof Blob) {
+          if (decoded !== null && seq >= lastForwardedSeq) {
+            lastForwardedSeq = seq;
+            forwardJson(decoded, 'ws');
+          }
+        } else if (hostIsPadre && feedActive()
+          && typeof Blob === 'function' && event.data instanceof Blob) {
           Promise.resolve(event.data.arrayBuffer()).then((buffer) => {
             const decoded = decodeMsgpack(new Uint8Array(buffer));
-            if (decoded !== null) forwardJson(decoded, 'ws');
+            if (decoded === null || seq < lastForwardedSeq) return;
+            lastForwardedSeq = seq;
+            forwardJson(decoded, 'ws');
           }, () => {});
         }
       });

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -473,7 +473,11 @@
   const ACTIVITY_TICK_MIN_MS = 100;
   const activityLastEmitByMint = new Map();
 
-  function forwardTokenActivity(parsed) {
+  function withReceivedAt(payload, receivedAt) {
+    return Number.isFinite(receivedAt) ? { ...payload, at: receivedAt } : payload;
+  }
+
+  function forwardTokenActivity(parsed, receivedAt) {
     if (!parsed || parsed.channel !== 'token_activity' || !Array.isArray(parsed.data)) return false;
     const now = Date.now();
     const latestByMint = new Map();
@@ -490,14 +494,14 @@
     const due = (mint) => now - (activityLastEmitByMint.get(mint) || 0) >= ACTIVITY_TICK_MIN_MS;
     const emitTick = (mint, priceUsd) => {
       activityLastEmitByMint.set(mint, now);
-      emit('tick', {
+      emit('tick', withReceivedAt({
         candidates: [{ value: priceUsd, unit: 'usd', key: 'tokenActivityPriceUsd' }],
         mcap: null,
         mint,
         symbol: currentSymbolInfo.mint === mint ? currentSymbolInfo.symbol : null,
         name: null,
         source: 'gmgn-ws-trade',
-      });
+      }, receivedAt));
     };
     const watchedMint = currentSymbolInfo.mint;
     if (watchedMint && latestByMint.has(watchedMint) && due(watchedMint)) {
@@ -522,7 +526,7 @@
     return true;
   }
 
-  function forwardJson(raw, source, url) {
+  function forwardJson(raw, source, url, receivedAt) {
     // No consumer, no parse — the cheapest frame is the one never read.
     if (!feedActive()) return;
     let parsed = raw;
@@ -538,7 +542,7 @@
       // forwardTokenActivity still validates the parsed shape.
       if (trimmed.length > 15 && trimmed.slice(0, 120).indexOf('"token_activity"') !== -1) {
         try { parsed = JSON.parse(raw); } catch (_) { return; }
-        forwardTokenActivity(parsed);
+        forwardTokenActivity(parsed, receivedAt);
         return;
       }
       if (url && /\/api\/v1\/token_mcap_candles\//.test(url)) {
@@ -577,13 +581,13 @@
         // C-08: this close IS the value on GMGN's Y axis — the scale anchor
         // for every GMGN line and fill shape (see gmgnCapScale).
         gmgnLastCandleClose = mcap;
-        emit('tick', {
+        emit('tick', withReceivedAt({
           candidates: [],
           mcap,
           mint: currentSymbolInfo.mint,
           symbol: currentSymbolInfo.symbol,
           source: 'gmgn-mcap-candle',
-        });
+        }, receivedAt));
         return;
       }
     }
@@ -597,18 +601,21 @@
         || (currentSymbolInfo.pairAddress && records.get(currentSymbolInfo.pairAddress))
         || null;
       let emitted = 0;
-      if (watched && hasContent(watched)) { emit('tick', { ...watched, source }); emitted++; }
+      if (watched && hasContent(watched)) {
+        emit('tick', withReceivedAt({ ...watched, source }, receivedAt));
+        emitted++;
+      }
       for (const rec of records.values()) {
         if (rec === watched || !hasContent(rec)) continue;
         if (emitted++ >= 5) break;
-        emit('tick', { ...rec, source });
+        emit('tick', withReceivedAt({ ...rec, source }, receivedAt));
       }
       if (emitted) return;
       // Records existed but carried no prices; fall through to the
       // unattributed finds so a lone top-level price still ticks.
     }
     if (!top.candidates.length && top.mcap === null) return;
-    emit('tick', { ...top, source });
+    emit('tick', withReceivedAt({ ...top, source }, receivedAt));
   }
 
   /* ---------------- SPA navigation signal ----------------
@@ -672,34 +679,27 @@
     };
   }
 
+  // Padre's binary socket frames are MessagePack, not protobuf. Capture the
+  // receive time before a Blob's asynchronous body conversion so consumers
+  // can reject an older frame that completes after a newer one.
   const OriginalWebSocket = window.WebSocket;
   if (typeof OriginalWebSocket === 'function') {
     const WrappedWebSocket = function (url, protocols) {
       const socket = protocols === undefined
         ? new OriginalWebSocket(url)
         : new OriginalWebSocket(url, protocols);
-      let socketSeq = 0;
-      let lastForwardedSeq = 0;
       socket.addEventListener('message', (event) => {
-        const seq = ++socketSeq;
+        const receivedAt = Date.now();
         if (typeof event.data === 'string') {
-          if (seq >= lastForwardedSeq) {
-            lastForwardedSeq = seq;
-            forwardJson(event.data, 'ws');
-          }
+          forwardJson(event.data, 'ws', undefined, receivedAt);
         } else if (hostIsPadre && feedActive() && event.data instanceof ArrayBuffer) {
           const decoded = decodeMsgpack(new Uint8Array(event.data));
-          if (decoded !== null && seq >= lastForwardedSeq) {
-            lastForwardedSeq = seq;
-            forwardJson(decoded, 'ws');
-          }
+          if (decoded !== null) forwardJson(decoded, 'ws', undefined, receivedAt);
         } else if (hostIsPadre && feedActive()
           && typeof Blob === 'function' && event.data instanceof Blob) {
           Promise.resolve(event.data.arrayBuffer()).then((buffer) => {
             const decoded = decodeMsgpack(new Uint8Array(buffer));
-            if (decoded === null || seq < lastForwardedSeq) return;
-            lastForwardedSeq = seq;
-            forwardJson(decoded, 'ws');
+            if (decoded !== null) forwardJson(decoded, 'ws', undefined, receivedAt);
           }, () => {});
         }
       });

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3594,11 +3594,11 @@
         const fields = {};
         let barePrice = null;
         for (const [name, value] of Object.entries(obj)) {
-          if (badKey.test(name)) continue;
           if (identityKeys.has(name)) {
             if (typeof value === 'string' && BASE58_RE.test(value)) fields[name] = value;
             continue;
           }
+          if (badKey.test(name)) continue;
           if (name === 'supply' || name === 'total_supply' || name === 'totalSupply'
               || priceKeys.has(name)) {
             const number = numberValue(value);
@@ -3610,11 +3610,13 @@
             if (number !== null && number > 0) barePrice = number;
           }
         }
-        if (fields.address !== undefined) fields.mint = fields.address;
-        if (fields.pool_address !== undefined) fields.pair = fields.pool_address;
-        if (fields.total_supply !== undefined) fields.supply = fields.total_supply;
-        if (fields.totalSupply !== undefined) fields.supply = fields.totalSupply;
-        if (fields.usd_market_cap !== undefined) fields.mcapUsd = fields.usd_market_cap;
+        if (fields.address !== undefined && fields.mint === undefined) fields.mint = fields.address;
+        if (fields.pool_address !== undefined && fields.pair === undefined) fields.pair = fields.pool_address;
+        if (fields.total_supply !== undefined && fields.supply === undefined) fields.supply = fields.total_supply;
+        if (fields.totalSupply !== undefined && fields.supply === undefined) fields.supply = fields.totalSupply;
+        if (fields.usd_market_cap !== undefined && fields.mcapUsd === undefined) {
+          fields.mcapUsd = fields.usd_market_cap;
+        }
         const barePriceProven = barePrice !== null && fields.supply > 0 && fields.mcapUsd > 0
           && Math.abs(barePrice * fields.supply / fields.mcapUsd - 1) <= 0.02;
         if (barePriceProven) {

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3226,7 +3226,10 @@
     for (const entry of rowChips.values()) {
       if (entry.el === chip) {
         chip.classList.add('busy');
-        emit('row-buy', { address: entry.address });
+        emit('row-buy', {
+          address: entry.address,
+          quote: rowQuoteFromFiber(entry.row, entry.address),
+        });
         break;
       }
     }
@@ -3564,6 +3567,94 @@
         if (fiber.sibling) stack.push(fiber.sibling);
       }
       return best ? best.address : null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  function rowQuoteFromFiber(row, tappedAddress) {
+    try {
+      if (!row || !BASE58_RE.test(tappedAddress || '')) return null;
+      const key = Object.getOwnPropertyNames(row).find((k) => k.indexOf('__reactFiber$') === 0);
+      const start = key && row[key];
+      if (!start) return null;
+      const seen = new Set();
+      const stack = [start];
+      const candidates = [];
+      const identityKeys = new Set(['tokenAddress', 'mint', 'pairAddress']);
+      const priceKeys = new Set([
+        'priceSol', 'priceNative', 'tokenPriceUsd', 'priceUsd',
+        'marketCapSol', 'marketCapUsd',
+      ]);
+      const badKey = /change|pct|percent|min|hr|24h|ratio/i;
+      const fieldsFor = (obj) => {
+        if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return null;
+        const fields = {};
+        for (const [name, value] of Object.entries(obj)) {
+          if (badKey.test(name)) continue;
+          if (identityKeys.has(name)) {
+            if (typeof value === 'string' && BASE58_RE.test(value)) fields[name] = value;
+            continue;
+          }
+          if (name === 'supply' || priceKeys.has(name)) {
+            const number = numberValue(value);
+            if (number !== null && number > 0) fields[name] = number;
+          }
+        }
+        return fields;
+      };
+      const walk = (obj, depth, inheritedPrices) => {
+        if (!obj || typeof obj !== 'object' || depth > 3) return;
+        const own = fieldsFor(obj) || {};
+        const hasIdentity = own.tokenAddress || own.mint || own.pairAddress;
+        const fields = hasIdentity ? { ...inheritedPrices, ...own } : own;
+        const hasPrice = [...priceKeys].some((name) => fields[name] !== undefined);
+        if (hasIdentity && hasPrice) candidates.push(fields);
+        const childPrices = hasIdentity ? {} : { ...inheritedPrices };
+        for (const name of [...priceKeys, 'supply']) {
+          if (own[name] !== undefined) childPrices[name] = own[name];
+        }
+        for (const value of Object.values(obj)) {
+          if (value && typeof value === 'object') walk(value, depth + 1, childPrices);
+        }
+      };
+      let steps = 0;
+      while (stack.length && steps++ < 80) {
+        const fiber = stack.pop();
+        if (!fiber || seen.has(fiber)) continue;
+        seen.add(fiber);
+        walk(fiber.memoizedProps, 0, {});
+        walk(fiber.memoizedState, 0, {});
+        if (fiber.child) stack.push(fiber.child);
+        if (fiber.sibling) stack.push(fiber.sibling);
+      }
+      const matching = candidates.filter((fields) =>
+        fields.tokenAddress === tappedAddress
+        || fields.mint === tappedAddress
+        || fields.pairAddress === tappedAddress);
+      if (!matching.length) return null;
+      const selected = matching.reduce((best, fields) =>
+        !best || Object.keys(fields).length > Object.keys(best).length ? fields : best, null);
+      const usd = candidates.find((fields) =>
+        fields.tokenAddress
+        && fields.tokenAddress === selected.tokenAddress
+        && (fields.tokenPriceUsd !== undefined
+          || fields.priceUsd !== undefined
+          || fields.marketCapUsd !== undefined));
+      const merged = { ...selected };
+      if (usd) {
+        for (const name of ['tokenPriceUsd', 'priceUsd', 'marketCapUsd']) {
+          if (merged[name] === undefined && usd[name] !== undefined) merged[name] = usd[name];
+        }
+      }
+      return {
+        mint: merged.tokenAddress || merged.mint || null,
+        pair: merged.pairAddress || null,
+        priceSol: merged.priceSol || merged.priceNative || null,
+        priceUsd: merged.tokenPriceUsd || merged.priceUsd || null,
+        mcapUsd: merged.marketCapUsd || null,
+        supply: merged.supply || null,
+      };
     } catch (_) {
       return null;
     }

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3581,26 +3581,48 @@
       const seen = new Set();
       const stack = [start];
       const candidates = [];
-      const identityKeys = new Set(['tokenAddress', 'mint', 'pairAddress']);
+      const identityKeys = new Set([
+        'tokenAddress', 'mint', 'address', 'pairAddress', 'pool_address',
+      ]);
       const priceKeys = new Set([
         'priceSol', 'priceNative', 'tokenPriceUsd', 'priceUsd',
-        'marketCapSol', 'marketCapUsd',
+        'marketCapSol', 'marketCapUsd', 'usd_market_cap',
       ]);
       const badKey = /change|pct|percent|min|hr|24h|ratio/i;
       const fieldsFor = (obj) => {
         if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return null;
         const fields = {};
+        let barePrice = null;
         for (const [name, value] of Object.entries(obj)) {
           if (badKey.test(name)) continue;
           if (identityKeys.has(name)) {
             if (typeof value === 'string' && BASE58_RE.test(value)) fields[name] = value;
             continue;
           }
-          if (name === 'supply' || priceKeys.has(name)) {
+          if (name === 'supply' || name === 'total_supply' || name === 'totalSupply'
+              || priceKeys.has(name)) {
             const number = numberValue(value);
             if (number !== null && number > 0) fields[name] = number;
+            continue;
+          }
+          if (name === 'price') {
+            const number = numberValue(value);
+            if (number !== null && number > 0) barePrice = number;
           }
         }
+        if (fields.address !== undefined) fields.mint = fields.address;
+        if (fields.pool_address !== undefined) fields.pair = fields.pool_address;
+        if (fields.total_supply !== undefined) fields.supply = fields.total_supply;
+        if (fields.totalSupply !== undefined) fields.supply = fields.totalSupply;
+        if (fields.usd_market_cap !== undefined) fields.mcapUsd = fields.usd_market_cap;
+        const barePriceProven = barePrice !== null && fields.supply > 0 && fields.mcapUsd > 0
+          && Math.abs(barePrice * fields.supply / fields.mcapUsd - 1) <= 0.02;
+        if (barePriceProven) {
+          fields.priceUsd = barePrice;
+        }
+        const hasExplicitPrice = fields.priceSol !== undefined || fields.priceNative !== undefined
+          || fields.tokenPriceUsd !== undefined || fields.priceUsd !== undefined;
+        if (barePrice !== null && !barePriceProven && !hasExplicitPrice) return null;
         return fields;
       };
       const walk = (obj, depth) => {
@@ -3626,7 +3648,9 @@
       const matching = candidates.filter((fields) =>
         fields.tokenAddress === tappedAddress
         || fields.mint === tappedAddress
-        || fields.pairAddress === tappedAddress);
+        || fields.address === tappedAddress
+        || fields.pairAddress === tappedAddress
+        || fields.pair === tappedAddress);
       if (!matching.length) return null;
       const selected = matching.reduce((best, fields) =>
         !best || Object.keys(fields).length > Object.keys(best).length ? fields : best, null);
@@ -3643,12 +3667,12 @@
         }
       }
       return {
-        mint: merged.tokenAddress || merged.mint || null,
-        pair: merged.pairAddress || null,
+        mint: merged.tokenAddress || merged.mint || merged.address || null,
+        pair: merged.pairAddress || merged.pair || merged.pool_address || null,
         priceSol: merged.priceSol || merged.priceNative || null,
         priceUsd: merged.tokenPriceUsd || merged.priceUsd || null,
-        mcapUsd: merged.marketCapUsd || null,
-        supply: merged.supply || null,
+        mcapUsd: merged.marketCapUsd || merged.mcapUsd || null,
+        supply: merged.supply || merged.total_supply || merged.totalSupply || null,
       };
     } catch (_) {
       return null;

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3782,11 +3782,20 @@
     if (ev.type !== 'click') return;
     for (const entry of rowChips.values()) {
       if (entry.el === chip) {
-        chip.classList.add('busy');
-        emit('row-buy', {
-          address: entry.address,
-          quote: rowQuoteFromFiber(entry.row, entry.address),
-        });
+        const decision = rowChipTapDecision(entry, currentRowAddress(entry), Date.now());
+        entry.pressedAt = 0;
+        entry.pressedAddress = null;
+        if (decision.address) {
+          chip.classList.add('busy');
+          emit('row-buy', {
+            address: decision.address,
+            quote: typeof rowQuoteFromFiber === 'function'
+              ? rowQuoteFromFiber(entry.row, decision.address)
+              : undefined,
+          });
+        } else {
+          emit('row-buy-refused', decision.refuse);
+        }
         break;
       }
     }

--- a/extension/test/background.test.js
+++ b/extension/test/background.test.js
@@ -6,6 +6,7 @@ const vm = require('node:vm');
 
 const ROOT = path.join(__dirname, '..');
 const MINT = 'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263';
+const ARMED_ROW_KEY = 'pt_armed_row_intent';
 
 function serviceWorker(opts = {}) {
   const values = {
@@ -39,6 +40,11 @@ function serviceWorker(opts = {}) {
   const set = (update, callback) => {
     if (opts.failWrites) { failingCallback(callback); return Promise.resolve(); }
     Object.assign(values, update);
+    if (callback) callback();
+    return Promise.resolve();
+  };
+  const remove = (key, callback) => {
+    delete values[key];
     if (callback) callback();
     return Promise.resolve();
   };
@@ -104,7 +110,10 @@ function serviceWorker(opts = {}) {
       };
     },
     chrome: {
-      storage: { local: { get, set } },
+      storage: {
+        local: { get, set, remove },
+        session: { get, set, remove },
+      },
       runtime: {
         id: 'papertrench-test',
         openOptionsPage: () => {},
@@ -162,6 +171,11 @@ function serviceWorker(opts = {}) {
     get isAllowedEndpoint() { return context.isAllowedEndpoint; },
     get maybeNoteSlowPool() { return context.maybeNoteSlowPool; },
     get rpcPool() { return context.PTRpcPool; },
+    armed: {
+      read: context.readArmedRowIntent,
+      write: context.writeArmedRowIntent,
+      clear: context.clearArmedRowIntent,
+    },
     get storage() {
       return {
         getSettings: context.getSettings,
@@ -184,6 +198,58 @@ function send(listener, message) {
     assert.equal(asyncResponse, true, 'background messages must keep the response channel open');
   });
 }
+
+test('armed-row mirror write refuses a failed read without clobbering storage', async () => {
+  const worker = serviceWorker({ failReads: true });
+  const existing = [{ address: MINT, amount: 0.1, at: 1_800_000_000_000 }];
+  worker.values[ARMED_ROW_KEY] = existing;
+
+  const result = await worker.armed.write({
+    address: 'OtherMint111111111111111111111111111',
+    amount: 0.2,
+    at: 1_800_000_000_001,
+  });
+
+  assert.equal(result, false);
+  assert.equal(JSON.stringify(worker.values[ARMED_ROW_KEY]), JSON.stringify(existing));
+});
+
+test('armed-row selective clear removes all on a failed read without throwing', async () => {
+  const worker = serviceWorker({ failReads: true });
+  worker.values[ARMED_ROW_KEY] = [{ address: MINT, amount: 0.1, at: 1_800_000_000_000 }];
+
+  await assert.doesNotReject(() => worker.armed.clear(MINT));
+  assert.equal(Object.hasOwn(worker.values, ARMED_ROW_KEY), false);
+});
+
+test('concurrent armed-row writes preserve both intents', async () => {
+  const worker = serviceWorker();
+  const other = 'OtherMint111111111111111111111111111';
+
+  await Promise.all([
+    worker.armed.write({ address: MINT, amount: 0.1, at: 1_800_000_000_000 }),
+    worker.armed.write({ address: other, amount: 0.2, at: 1_800_000_000_001 }),
+  ]);
+
+  assert.equal(worker.values[ARMED_ROW_KEY].length, 2);
+  assert.equal(
+    JSON.stringify(worker.values[ARMED_ROW_KEY].map((intent) => intent.address)),
+    JSON.stringify([MINT, other]),
+  );
+});
+
+test('concurrent armed-row write and selective clear preserve the other intent', async () => {
+  const worker = serviceWorker();
+  const other = 'OtherMint111111111111111111111111111';
+
+  await Promise.all([
+    worker.armed.write({ address: MINT, amount: 0.1, at: 1_800_000_000_000 }),
+    worker.armed.clear(other),
+  ]);
+
+  assert.equal(JSON.stringify(worker.values[ARMED_ROW_KEY].map((intent) => intent.address)),
+    JSON.stringify([MINT]));
+});
 
 test('service worker captures a real pt_trade_event into the replay store', async () => {
   const worker = serviceWorker();
@@ -760,4 +826,3 @@ test('relayed bridge requests honor the origin gate and the Site-sync toggle', a
   assert.equal(empty.ok, false);
   assert.equal(empty.reason, 'chain-empty', 'toggle on: the relay reaches the same record path');
 });
-

--- a/extension/test/chiphonesty.test.js
+++ b/extension/test/chiphonesty.test.js
@@ -29,8 +29,8 @@ test('fillRowBuy anchors its witness on the position itself', () => {
 test('a quote diverging >2x from the anchor needs independent vouching', () => {
   const body = bodyOf('async function fillRowBuy');
   assert.match(body, /ratio > 2/, 'the divergence gate is 2x');
-  assert.match(body, /data\.priceSource === 'row-feed' \|\| !data\.priceSource/,
-    'row-fed candidates are corroborated by the resolver');
+  assert.match(body, /data\.priceSource === 'row-feed' \|\| data\.priceSource === 'row-props' \|\| !data\.priceSource/,
+    'page-row candidates are corroborated by the resolver');
   assert.match(body, /recentRowPrices\.get\(data\.mint\)/,
     'resolver-fed candidates are corroborated by the row feed');
   assert.match(body, /<= 1\.6/, 'vouching tolerance is 1.6x');

--- a/extension/test/padrebridge.test.js
+++ b/extension/test/padrebridge.test.js
@@ -285,7 +285,6 @@ test('Padre Blob frames carry their receive time when conversions complete backw
   const env = runBridge({ deferBlobs: true });
   const socket = env.openSocket();
   socket.emit(new env.Blob([PADRE_UPDATE_FRAME]));
-  env.advanceNow(10);
   socket.emit(new env.Blob([PADRE_NEWER_UPDATE_FRAME]));
   assert.equal(env.pendingBlobs.length, 2);
 
@@ -299,7 +298,9 @@ test('Padre Blob frames carry their receive time when conversions complete backw
   const ticks = env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws');
   assert.equal(ticks.length, 2);
   assert.equal(ticks[0].payload.candidates[0].value, 9.99);
-  assert.equal(ticks[0].payload.at, ticks[1].payload.at + 10);
+  assert.equal(ticks[0].payload.at, ticks[1].payload.at);
+  assert.equal(ticks[0].payload.seq, 2);
+  assert.equal(ticks[1].payload.seq, 1);
 });
 
 test('a later Padre frame without a quote does not suppress a valid tick', () => {

--- a/extension/test/padrebridge.test.js
+++ b/extension/test/padrebridge.test.js
@@ -21,12 +21,17 @@ const PADRE_NEWER_UPDATE_FRAME = Uint8Array.from(Buffer.from(
   'kwVVgqR0eXBlpnVwZGF0ZaZ1cGRhdGWCpGFkZHOQp3VwZGF0ZXORg6x0b2tlbkFkZHJlc3PZLEZRVGtncTZHa1l6a3JRRjNCMWNyaGZ2WUdrbjJ1THlNRTI4eFNIYnBwdW1wqnByaWNlSW5Vc2TLQCP64UeuFHuoZmR2SW5Vc2TNJwY=',
   'base64',
 ));
+const PADRE_OTHER_UPDATE_FRAME = Uint8Array.from(Buffer.from(
+  'kwVVgqR0eXBlpnVwZGF0ZaZ1cGRhdGWCpGFkZHOQp3VwZGF0ZXORg6x0b2tlbkFkZHJlc3PZIDExMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExqnByaWNlSW5Vc2TLQB4AAAAAAACoZmR2SW5Vc2TPAAAAAb8I6wA=',
+  'base64',
+));
 const PADRE_NATIVE_RATE_FRAME = Uint8Array.from(Buffer.from(
   'kwVVgqx0b2tlbkFkZHJlc3PZLEZRVGtncTZHa1l6a3JRRjNCMWNyaGZ2WUdrbjJ1THlNRTI4eFNIYnBwdW1wsm5hdGl2ZVByaWNlSW5Vc2RVactAWZfzf6mDcg==',
   'base64',
 ));
 
 function runBridge(opts = {}) {
+  let clock = Date.now();
   const timers = [];
   const emitted = [];
   const listeners = {};
@@ -37,6 +42,11 @@ function runBridge(opts = {}) {
   let refreshMarksCount = 0;
   const orderLines = [];
   const NativeDataView = DataView;
+
+  class TestDate extends Date {
+    constructor(...args) { super(...(args.length ? args : [clock])); }
+    static now() { return clock; }
+  }
 
   class TestBlob {
     constructor(parts) {
@@ -172,7 +182,7 @@ function runBridge(opts = {}) {
       return { href, hostname: new URL(href).hostname };
     })(),
     console,
-    Date,
+    Date: TestDate,
     Math,
     Number,
     String,
@@ -217,6 +227,7 @@ function runBridge(opts = {}) {
     Blob: TestBlob,
     dataViewCalls: () => dataViewCalls,
     pendingBlobs,
+    advanceNow(ms) { clock += ms; },
     send(type, payload) {
       listeners.message({
         source: win,
@@ -270,39 +281,48 @@ test('Padre Blob frames are decoded without blocking the WebSocket handler', asy
     'a Padre Blob frame must reach the same generic tick pipeline');
 });
 
-test('Padre Blob frames preserve receive order when conversions complete backwards', async () => {
+test('Padre Blob frames carry their receive time when conversions complete backwards', async () => {
   const env = runBridge({ deferBlobs: true });
   const socket = env.openSocket();
   socket.emit(new env.Blob([PADRE_UPDATE_FRAME]));
+  env.advanceNow(10);
   socket.emit(new env.Blob([PADRE_NEWER_UPDATE_FRAME]));
   assert.equal(env.pendingBlobs.length, 2);
 
   env.resolveBlob(1);
   await Promise.resolve();
   assert.equal(env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws').length, 1);
-  assert.equal(
-    env.emitted.find((m) => m.type === 'tick' && m.payload?.source === 'ws').payload.candidates[0].value,
-    9.99,
-  );
   env.resolveBlob(0);
   await Promise.resolve();
   await Promise.resolve();
 
-  assert.equal(env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws').length, 1,
-    'an older Blob completion must be discarded after a newer frame publishes');
+  const ticks = env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws');
+  assert.equal(ticks.length, 2);
+  assert.equal(ticks[0].payload.candidates[0].value, 9.99);
+  assert.equal(ticks[0].payload.at, ticks[1].payload.at + 10);
 });
 
-test('Padre binary frame sequence state is independent per socket', async () => {
-  const env = runBridge({ deferBlobs: true });
-  const socketA = env.openSocket();
-  const socketB = env.openSocket();
-  socketA.emit(new env.Blob([PADRE_UPDATE_FRAME]));
-  socketB.emit(PADRE_UPDATE_FRAME.buffer);
-  env.resolveBlob(0);
-  await Promise.resolve();
+test('a later Padre frame without a quote does not suppress a valid tick', () => {
+  const env = runBridge();
+  const socket = env.openSocket();
+  socket.emit(PADRE_UPDATE_FRAME.buffer);
+  socket.emit(PADRE_NATIVE_RATE_FRAME.buffer);
 
-  assert.equal(env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws').length, 2,
-    'one socket must not suppress a frame from another socket');
+  const ticks = env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws');
+  assert.equal(ticks.length, 1);
+  assert.equal(ticks[0].payload.mint, 'FQTkgq6GkYzkrQF3B1crhfvYGkn2uLyME28xSHbppump');
+});
+
+test('a Padre frame for another mint does not suppress the first mint', () => {
+  const env = runBridge();
+  const socket = env.openSocket();
+  socket.emit(PADRE_UPDATE_FRAME.buffer);
+  socket.emit(PADRE_OTHER_UPDATE_FRAME.buffer);
+
+  const ticks = env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws');
+  assert.equal(ticks.length, 2);
+  assert.equal(ticks[0].payload.mint, 'FQTkgq6GkYzkrQF3B1crhfvYGkn2uLyME28xSHbppump');
+  assert.equal(ticks[1].payload.mint, '11111111111111111111111111111111');
 });
 
 test('Padre binary frames are gated before decoding when feed demand is off', () => {

--- a/extension/test/padrebridge.test.js
+++ b/extension/test/padrebridge.test.js
@@ -37,6 +37,18 @@ const PADRE_COHERENT_FDV_FRAME = Uint8Array.from(Buffer.from(
   'kwVVgqR0eXBlpnVwZGF0ZaZ1cGRhdGWCpGFkZHORhax0b2tlbkFkZHJlc3PZLENvelh5M1VlTkJ4NzNib0JqRnA0UjNrZ2VVVlRYckp4cWRoeXdXTVBwdW1wqnByaWNlSW5Vc2TLPtR/YFTL1qWoZmR2SW5Vc2TLQLMXAAAAAACrdG90YWxTdXBwbHnPAAONfqTGgACoZGVjaW1hbHMGp3VwZGF0ZXOQ',
   'base64',
 ));
+const PADRE_METADATA_FRAME = Uint8Array.from(Buffer.from(
+  'gqR0eXBlonVwpnVwZGF0ZYGkZGF0YZGErHRva2VuQWRkcmVzc9ksRlFUa2dxNkdrWXprclFGM0IxY3JoZnZZR2tuMnVMeU1FMjh4U0hicHB1bXCqcHJpY2VJblVzZMs/864UeuFHrqt0b2tlblRpY2tlcqZTT0xDQVSpdG9rZW5OYW1lp1NvbCBDYXQ=',
+  'base64',
+));
+const PADRE_SIBLING_METADATA_FRAME = Uint8Array.from(Buffer.from(
+  'gqR0eXBlonVwpnVwZGF0ZYGkZGF0YZKCrHRva2VuQWRkcmVzc9ksRlFUa2dxNkdrWXprclFGM0IxY3JoZnZZR2tuMnVMeU1FMjh4U0hicHB1bXCqcHJpY2VJblVzZMs/864UeuFHroKsdG9rZW5BZGRyZXNz2SAxMTExMTExMTExMTExMTExMTExMTExMTExMTExMTExMat0b2tlblRpY2tlcqRMRUFL',
+  'base64',
+));
+const PADRE_ADDRESS_TICKER_FRAME = Uint8Array.from(Buffer.from(
+  'gqR0eXBlonVwpnVwZGF0ZYGkZGF0YZGDrHRva2VuQWRkcmVzc9ksRlFUa2dxNkdrWXprclFGM0IxY3JoZnZZR2tuMnVMeU1FMjh4U0hicHB1bXCqcHJpY2VJblVzZMs/864UeuFHrqt0b2tlblRpY2tlctksRlFUa2dxNkdrWXprclFGM0IxY3JoZnZZR2tuMnVMeU1FMjh4U0hicHB1bXA=',
+  'base64',
+));
 
 function runBridge(opts = {}) {
   let clock = Date.now();
@@ -276,6 +288,36 @@ test('Padre MessagePack frames emit mint-tagged USD ticks without an unverified 
   assert.equal(message.payload.candidates[0].unit, 'usd');
   assert.equal(message.payload.candidates[0].value, 3.10644703526886e-06);
   assert.equal(message.payload.mcap, null);
+});
+
+test('Padre forwards ticker and name from the price-bearing object', () => {
+  const env = runBridge();
+  env.openSocket().emit(PADRE_METADATA_FRAME.buffer);
+
+  const message = env.emitted.find((m) => m.type === 'tick' && m.payload?.source === 'ws');
+  assert.ok(message);
+  assert.equal(message.payload.symbol, 'SOLCAT');
+  assert.equal(message.payload.name, 'Sol Cat');
+});
+
+test('Padre does not borrow metadata from a different mint record', () => {
+  const env = runBridge();
+  env.openSocket().emit(PADRE_SIBLING_METADATA_FRAME.buffer);
+
+  const message = env.emitted.find((m) => m.type === 'tick' && m.payload?.source === 'ws');
+  assert.ok(message);
+  assert.equal(message.payload.mint, 'FQTkgq6GkYzkrQF3B1crhfvYGkn2uLyME28xSHbppump');
+  assert.equal(message.payload.symbol, null);
+  assert.equal(message.payload.name, null);
+});
+
+test('Padre rejects an address-shaped ticker', () => {
+  const env = runBridge();
+  env.openSocket().emit(PADRE_ADDRESS_TICKER_FRAME.buffer);
+
+  const message = env.emitted.find((m) => m.type === 'tick' && m.payload?.source === 'ws');
+  assert.ok(message);
+  assert.equal(message.payload.symbol, null);
 });
 
 test('Padre replaces a doubled FDV with price times the derived supply', () => {

--- a/extension/test/padrebridge.test.js
+++ b/extension/test/padrebridge.test.js
@@ -29,6 +29,14 @@ const PADRE_NATIVE_RATE_FRAME = Uint8Array.from(Buffer.from(
   'kwVVgqx0b2tlbkFkZHJlc3PZLEZRVGtncTZHa1l6a3JRRjNCMWNyaGZ2WUdrbjJ1THlNRTI4eFNIYnBwdW1wsm5hdGl2ZVByaWNlSW5Vc2RVactAWZfzf6mDcg==',
   'base64',
 ));
+const PADRE_DOUBLED_FDV_FRAME = Uint8Array.from(Buffer.from(
+  'kwVVgqR0eXBlpnVwZGF0ZaZ1cGRhdGWCpGFkZHORhax0b2tlbkFkZHJlc3PZLDI1YXBwb1hxTTV4cloxRnNKa3ozRDZUOW16MUpLWXF6OHhab0ZCVExwdW1wqnByaWNlSW5Vc2TLPnYzGcku/HuoZmR2SW5Vc2TLQGSuFHrhR66rdG90YWxTdXBwbHnPAAONfqTGgACoZGVjaW1hbHMGp3VwZGF0ZXOQ',
+  'base64',
+));
+const PADRE_COHERENT_FDV_FRAME = Uint8Array.from(Buffer.from(
+  'kwVVgqR0eXBlpnVwZGF0ZaZ1cGRhdGWCpGFkZHORhax0b2tlbkFkZHJlc3PZLENvelh5M1VlTkJ4NzNib0JqRnA0UjNrZ2VVVlRYckp4cWRoeXdXTVBwdW1wqnByaWNlSW5Vc2TLPtR/YFTL1qWoZmR2SW5Vc2TLQLMXAAAAAACrdG90YWxTdXBwbHnPAAONfqTGgACoZGVjaW1hbHMGp3VwZGF0ZXOQ',
+  'base64',
+));
 
 function runBridge(opts = {}) {
   let clock = Date.now();
@@ -257,7 +265,7 @@ test('Padre decoded TradingView bars emit an immediate PaperTrench tick', () => 
     'the unknown chart close is offered as mcap so quote validation can identify chart mode');
 });
 
-test('Padre MessagePack frames emit mint-tagged USD ticks with their FDV cap', () => {
+test('Padre MessagePack frames emit mint-tagged USD ticks without an unverified cap', () => {
   const env = runBridge();
   const socket = env.openSocket();
   socket.emit(PADRE_UPDATE_FRAME.buffer);
@@ -267,7 +275,28 @@ test('Padre MessagePack frames emit mint-tagged USD ticks with their FDV cap', (
   assert.equal(message.payload.mint, 'FQTkgq6GkYzkrQF3B1crhfvYGkn2uLyME28xSHbppump');
   assert.equal(message.payload.candidates[0].unit, 'usd');
   assert.equal(message.payload.candidates[0].value, 3.10644703526886e-06);
-  assert.equal(message.payload.mcap, 3106.4470352688604);
+  assert.equal(message.payload.mcap, null);
+});
+
+test('Padre replaces a doubled FDV with price times the derived supply', () => {
+  const env = runBridge();
+  env.openSocket().emit(PADRE_DOUBLED_FDV_FRAME.buffer);
+
+  const message = env.emitted.find((m) => m.type === 'tick' && m.payload?.source === 'ws');
+  assert.ok(message);
+  assert.equal(message.payload.mint, '25appoXqM5xrZ1FsJkz3D6T9mz1JKYqz8xZoFBTLpump');
+  assert.equal(message.payload.candidates[0].value, 8.27e-8);
+  assert.equal(message.payload.mcap, 82.7);
+});
+
+test('Padre keeps a coherent FDV when the derived supply proves it', () => {
+  const env = runBridge();
+  env.openSocket().emit(PADRE_COHERENT_FDV_FRAME.buffer);
+
+  const message = env.emitted.find((m) => m.type === 'tick' && m.payload?.source === 'ws');
+  assert.ok(message);
+  assert.equal(message.payload.mint, 'CozXy3UeNBx73boBjFp4R3kgeUVTXrJxqdhywWMPpump');
+  assert.equal(message.payload.mcap, 4887);
 });
 
 test('Padre Blob frames are decoded without blocking the WebSocket handler', async () => {

--- a/extension/test/padrebridge.test.js
+++ b/extension/test/padrebridge.test.js
@@ -17,6 +17,10 @@ const PADRE_UPDATE_FRAME = Uint8Array.from(Buffer.from(
   'kwVVgqR0eXBlpnVwZGF0ZaZ1cGRhdGWCpGFkZHOQp3VwZGF0ZXORg6x0b2tlbkFkZHJlc3PZLEZRVGtncTZHa1l6a3JRRjNCMWNyaGZ2WUdrbjJ1THlNRTI4eFNIYnBwdW1wqGZkdkluVXNky0CoROThzofUqnByaWNlSW5Vc2TLPsoPC1Fz3To=',
   'base64',
 ));
+const PADRE_NEWER_UPDATE_FRAME = Uint8Array.from(Buffer.from(
+  'kwVVgqR0eXBlpnVwZGF0ZaZ1cGRhdGWCpGFkZHOQp3VwZGF0ZXORg6x0b2tlbkFkZHJlc3PZLEZRVGtncTZHa1l6a3JRRjNCMWNyaGZ2WUdrbjJ1THlNRTI4eFNIYnBwdW1wqnByaWNlSW5Vc2TLQCP64UeuFHuoZmR2SW5Vc2TNJwY=',
+  'base64',
+));
 const PADRE_NATIVE_RATE_FRAME = Uint8Array.from(Buffer.from(
   'kwVVgqx0b2tlbkFkZHJlc3PZLEZRVGtncTZHa1l6a3JRRjNCMWNyaGZ2WUdrbjJ1THlNRTI4eFNIYnBwdW1wsm5hdGl2ZVByaWNlSW5Vc2RVactAWZfzf6mDcg==',
   'base64',
@@ -26,10 +30,52 @@ function runBridge(opts = {}) {
   const timers = [];
   const emitted = [];
   const listeners = {};
+  let dataViewCalls = 0;
+  const pendingBlobs = [];
   let realtimeCallback = null;
   let clearMarksCount = 0;
   let refreshMarksCount = 0;
   const orderLines = [];
+  const NativeDataView = DataView;
+
+  class TestBlob {
+    constructor(parts) {
+      const bytes = Uint8Array.from(parts[0] || []);
+      this.bytes = bytes;
+      this.arrayBufferCalls = 0;
+      if (opts.deferBlobs) {
+        this.promise = new Promise((resolve) => {
+          this.resolve = resolve;
+        });
+        pendingBlobs.push(this);
+      }
+    }
+
+    arrayBuffer() {
+      this.arrayBufferCalls++;
+      if (this.promise) return this.promise;
+      return Promise.resolve(this.bytes.buffer.slice(
+        this.bytes.byteOffset,
+        this.bytes.byteOffset + this.bytes.byteLength,
+      ));
+    }
+
+    resolveFrame() {
+      if (this.resolve) {
+        this.resolve(this.bytes.buffer.slice(
+          this.bytes.byteOffset,
+          this.bytes.byteOffset + this.bytes.byteLength,
+        ));
+        this.resolve = null;
+      }
+    }
+  }
+
+  function TestDataView(...args) {
+    dataViewCalls++;
+    return new NativeDataView(...args);
+  }
+  TestDataView.prototype = NativeDataView.prototype;
 
   function makeOrderLine() {
     const line = { removed: false, values: {}, calls: [] };
@@ -141,9 +187,9 @@ function runBridge(opts = {}) {
     JSON,
     ArrayBuffer,
     Uint8Array,
-    DataView,
+    DataView: TestDataView,
     TextDecoder,
-    Blob,
+    Blob: TestBlob,
     Promise,
     isFinite,
     setInterval(fn, ms) { timers.push(fn); return timers.length; },
@@ -168,6 +214,16 @@ function runBridge(opts = {}) {
     refreshMarksCount: () => refreshMarksCount,
     orderLines,
     win,
+    Blob: TestBlob,
+    dataViewCalls: () => dataViewCalls,
+    pendingBlobs,
+    send(type, payload) {
+      listeners.message({
+        source: win,
+        data: { source: 'papertrench-content', type, payload },
+      });
+    },
+    resolveBlob(index) { pendingBlobs[index].resolveFrame(); },
     openSocket() { return new win.WebSocket('wss://backend.padre.gg/_multiplex?desc=/trenches'); },
   };
 }
@@ -206,12 +262,69 @@ test('Padre MessagePack frames emit mint-tagged USD ticks with their FDV cap', (
 test('Padre Blob frames are decoded without blocking the WebSocket handler', async () => {
   const env = runBridge();
   const socket = env.openSocket();
-  socket.emit(new Blob([PADRE_UPDATE_FRAME]));
+  socket.emit(new env.Blob([PADRE_UPDATE_FRAME]));
   await Promise.resolve();
   await Promise.resolve();
 
   assert.ok(env.emitted.some((m) => m.type === 'tick' && m.payload?.source === 'ws'),
     'a Padre Blob frame must reach the same generic tick pipeline');
+});
+
+test('Padre Blob frames preserve receive order when conversions complete backwards', async () => {
+  const env = runBridge({ deferBlobs: true });
+  const socket = env.openSocket();
+  socket.emit(new env.Blob([PADRE_UPDATE_FRAME]));
+  socket.emit(new env.Blob([PADRE_NEWER_UPDATE_FRAME]));
+  assert.equal(env.pendingBlobs.length, 2);
+
+  env.resolveBlob(1);
+  await Promise.resolve();
+  assert.equal(env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws').length, 1);
+  assert.equal(
+    env.emitted.find((m) => m.type === 'tick' && m.payload?.source === 'ws').payload.candidates[0].value,
+    9.99,
+  );
+  env.resolveBlob(0);
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.equal(env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws').length, 1,
+    'an older Blob completion must be discarded after a newer frame publishes');
+});
+
+test('Padre binary frame sequence state is independent per socket', async () => {
+  const env = runBridge({ deferBlobs: true });
+  const socketA = env.openSocket();
+  const socketB = env.openSocket();
+  socketA.emit(new env.Blob([PADRE_UPDATE_FRAME]));
+  socketB.emit(PADRE_UPDATE_FRAME.buffer);
+  env.resolveBlob(0);
+  await Promise.resolve();
+
+  assert.equal(env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws').length, 2,
+    'one socket must not suppress a frame from another socket');
+});
+
+test('Padre binary frames are gated before decoding when feed demand is off', () => {
+  const env = runBridge();
+  env.send('page-state', { wantsTicks: false });
+  const socket = env.openSocket();
+  const blob = new env.Blob([PADRE_UPDATE_FRAME]);
+  socket.emit(PADRE_UPDATE_FRAME.buffer);
+  socket.emit(blob);
+
+  assert.equal(env.dataViewCalls(), 0, 'inactive feeds must not decode binary frames');
+  assert.equal(blob.arrayBufferCalls, 0, 'inactive feeds must not copy Blob bodies');
+  assert.equal(env.emitted.filter((m) => m.type === 'tick' && m.payload?.source === 'ws').length, 0);
+});
+
+test('Padre binary frames decode when feed demand is on', () => {
+  const env = runBridge();
+  const socket = env.openSocket();
+  socket.emit(PADRE_UPDATE_FRAME.buffer);
+
+  assert.ok(env.dataViewCalls() > 0, 'active feeds decode the captured binary envelope');
+  assert.ok(env.emitted.some((m) => m.type === 'tick' && m.payload?.source === 'ws'));
 });
 
 test('Padre nativePriceInUsdUi is never treated as a token price', () => {

--- a/extension/test/padrebridge.test.js
+++ b/extension/test/padrebridge.test.js
@@ -13,6 +13,14 @@ const path = require('node:path');
 const vm = require('node:vm');
 
 const ROOT = path.join(__dirname, '..');
+const PADRE_UPDATE_FRAME = Uint8Array.from(Buffer.from(
+  'kwVVgqR0eXBlpnVwZGF0ZaZ1cGRhdGWCpGFkZHOQp3VwZGF0ZXORg6x0b2tlbkFkZHJlc3PZLEZRVGtncTZHa1l6a3JRRjNCMWNyaGZ2WUdrbjJ1THlNRTI4eFNIYnBwdW1wqGZkdkluVXNky0CoROThzofUqnByaWNlSW5Vc2TLPsoPC1Fz3To=',
+  'base64',
+));
+const PADRE_NATIVE_RATE_FRAME = Uint8Array.from(Buffer.from(
+  'kwVVgqx0b2tlbkFkZHJlc3PZLEZRVGtncTZHa1l6a3JRRjNCMWNyaGZ2WUdrbjJ1THlNRTI4eFNIYnBwdW1wsm5hdGl2ZVByaWNlSW5Vc2RVactAWZfzf6mDcg==',
+  'base64',
+));
 
 function runBridge(opts = {}) {
   const timers = [];
@@ -56,8 +64,16 @@ function runBridge(opts = {}) {
     createOrderLine: makeOrderLine,
   };
 
-  function FakeWebSocket() {}
-  FakeWebSocket.prototype.addEventListener = () => {};
+  function FakeWebSocket() {
+    this.listeners = {};
+    FakeWebSocket.last = this;
+  }
+  FakeWebSocket.prototype.addEventListener = function (type, listener) {
+    this.listeners[type] = listener;
+  };
+  FakeWebSocket.prototype.emit = function (data) {
+    if (this.listeners.message) this.listeners.message({ data });
+  };
   FakeWebSocket.CONNECTING = 0;
   FakeWebSocket.OPEN = 1;
   FakeWebSocket.CLOSING = 2;
@@ -123,6 +139,11 @@ function runBridge(opts = {}) {
     WeakSet,
     Symbol,
     JSON,
+    ArrayBuffer,
+    Uint8Array,
+    DataView,
+    TextDecoder,
+    Blob,
     Promise,
     isFinite,
     setInterval(fn, ms) { timers.push(fn); return timers.length; },
@@ -147,6 +168,7 @@ function runBridge(opts = {}) {
     refreshMarksCount: () => refreshMarksCount,
     orderLines,
     win,
+    openSocket() { return new win.WebSocket('wss://backend.padre.gg/_multiplex?desc=/trenches'); },
   };
 }
 
@@ -166,6 +188,56 @@ test('Padre decoded TradingView bars emit an immediate PaperTrench tick', () => 
   assert.equal(message.payload.candidates[0].value, bar.close);
   assert.equal(message.payload.mcap, bar.close,
     'the unknown chart close is offered as mcap so quote validation can identify chart mode');
+});
+
+test('Padre MessagePack frames emit mint-tagged USD ticks with their FDV cap', () => {
+  const env = runBridge();
+  const socket = env.openSocket();
+  socket.emit(PADRE_UPDATE_FRAME.buffer);
+
+  const message = env.emitted.find((m) => m.type === 'tick' && m.payload?.source === 'ws');
+  assert.ok(message, 'a decoded Padre update must feed the generic tick pipeline');
+  assert.equal(message.payload.mint, 'FQTkgq6GkYzkrQF3B1crhfvYGkn2uLyME28xSHbppump');
+  assert.equal(message.payload.candidates[0].unit, 'usd');
+  assert.equal(message.payload.candidates[0].value, 3.10644703526886e-06);
+  assert.equal(message.payload.mcap, 3106.4470352688604);
+});
+
+test('Padre Blob frames are decoded without blocking the WebSocket handler', async () => {
+  const env = runBridge();
+  const socket = env.openSocket();
+  socket.emit(new Blob([PADRE_UPDATE_FRAME]));
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.ok(env.emitted.some((m) => m.type === 'tick' && m.payload?.source === 'ws'),
+    'a Padre Blob frame must reach the same generic tick pipeline');
+});
+
+test('Padre nativePriceInUsdUi is never treated as a token price', () => {
+  const env = runBridge();
+  env.openSocket().emit(PADRE_NATIVE_RATE_FRAME.buffer);
+
+  assert.ok(!env.emitted.some((m) => m.type === 'tick' && m.payload?.source === 'ws'),
+    'the chain SOL/USD rate must not become an unattributed token tick');
+});
+
+test('malformed and oversized Padre frames are rejected without throwing', () => {
+  const env = runBridge();
+  const socket = env.openSocket();
+  assert.doesNotThrow(() => {
+    socket.emit(PADRE_UPDATE_FRAME.slice(0, 12).buffer);
+    socket.emit(new Uint8Array(512 * 1024 + 1).buffer);
+  });
+  assert.ok(!env.emitted.some((m) => m.type === 'tick' && m.payload?.source === 'ws'),
+    'invalid frames must not produce partial ticks');
+});
+
+test('non-Padre hosts ignore binary WebSocket frames', () => {
+  const env = runBridge({ href: 'https://axiom.trade/pulse' });
+  env.openSocket().emit(PADRE_UPDATE_FRAME.buffer);
+  assert.ok(!env.emitted.some((m) => m.type === 'tick' && m.payload?.source === 'ws'),
+    'binary Padre decoding must remain host-scoped');
 });
 
 test('paper buys are merged into Padre native getMarks with hover details', () => {

--- a/extension/test/quickbuy.test.js
+++ b/extension/test/quickbuy.test.js
@@ -486,8 +486,14 @@ test('armed row intents use a bounded selective service-worker mirror', () => {
     'the service-worker mirror evicts the oldest entry');
   assert.match(bg, /function clearArmedRowIntent\(address\)/,
     'mirror clear accepts an optional address');
+  assert.match(bg, /let armedRowChain = Promise\.resolve\(\)/,
+    'mirror updates serialize through one chain');
+  assert.match(bg, /function readArmedRowList\(\)/,
+    'mirror reads expose controlled success state');
   assert.match(content, /type: 'pt_armed_row_clear',\s*\n\s*address: intent\.address/,
     'chart adoption clears only the matching intent');
+  assert.match(content, /&& Date\.now\(\) - candidate\.at <= ARMED_ROW_TTL_MS/,
+    'chart adoption ignores expired candidates before selecting one');
 });
 
 test('an armed row snipe keeps probing until filled or expired (D-42 Bug 4)', () => {

--- a/extension/test/quickbuy.test.js
+++ b/extension/test/quickbuy.test.js
@@ -344,10 +344,10 @@ test('a fresh-coin chip miss ARMS the intent — the row path never refuses (D-4
     'the refusal string is scrubbed from the row path forever (D-40)');
   assert.match(content, /rowArmed\.push\(\{ address, amount, at: armedAt \}\);/,
     'a cascade miss arms the click instead of refusing');
-  assert.match(content, /async function flushRowArmed\(\)/,
+  assert.match(content, /async function flushRowArmed\(preferAddress\)/,
     'the armed-row flush exists');
   // Wakes: the board's own mint-tagged tick is the fastest possible one.
-  assert.match(content, /if \(rowArmed\.length\) flushRowArmed\(\);/,
+  assert.match(content, /if \(rowArmed\.length\) flushRowArmed\(payload\.mint\);/,
     'a board tick wakes the armed snipe immediately');
   assert.match(content, /setTimeout\(\(\) => flushRowArmed\(\), 1200\);/,
     'a near-delayed re-probe follows the arm');

--- a/extension/test/quickbuy.test.js
+++ b/extension/test/quickbuy.test.js
@@ -342,19 +342,19 @@ test('a fresh-coin chip miss ARMS the intent — the row path never refuses (D-4
   // arms and fires the instant any source lands a fillable price.
   assert.doesNotMatch(content, /Could not price that token yet/,
     'the refusal string is scrubbed from the row path forever (D-40)');
-  assert.match(content, /rowArmed = \{ address, amount, at: Date\.now\(\) \};/,
+  assert.match(content, /rowArmed\.push\(\{ address, amount, at: armedAt \}\);/,
     'a cascade miss arms the click instead of refusing');
   assert.match(content, /async function flushRowArmed\(\)/,
     'the armed-row flush exists');
   // Wakes: the board's own mint-tagged tick is the fastest possible one.
-  assert.match(content, /if \(rowArmed\) flushRowArmed\(\);/,
+  assert.match(content, /if \(rowArmed\.length\) flushRowArmed\(\);/,
     'a board tick wakes the armed snipe immediately');
   assert.match(content, /setTimeout\(\(\) => flushRowArmed\(\), 1200\);/,
     'a near-delayed re-probe follows the arm');
   assert.match(content, /setTimeout\(\(\) => flushRowArmed\(\), 4000\);/,
     'a second delayed re-probe bridges a quiet feed');
   // The bar heartbeat is the watchdog: keep probing, expire visibly.
-  assert.match(content, /if \(rowArmed\) flushRowArmed\(\);\s*\n\s*\/\/ D-41 latch hygiene/,
+  assert.match(content, /if \(rowArmed\.length\) flushRowArmed\(\);\s*\n\s*\/\/ D-41 latch hygiene/,
     'the 1s board heartbeat watchdog keeps the armed snipe honest');
   // TTL honesty — the same doctrine as the panel's armed buys.
   assert.match(content, /ARMED_ROW_TTL_MS = 60_000/,
@@ -363,7 +363,7 @@ test('a fresh-coin chip miss ARMS the intent — the row path never refuses (D-4
     'expiry is stated, never a silent drop or a guessed fill');
   // The intent dies with the page context — no zombie fills from a
   // detached board.
-  assert.match(content, /onTeardown\(\(\) => \{ rowArmed = null; \}\);/,
+  assert.match(content, /onTeardown\(\(\) => \{\s*\n\s*rowArmed\.length = 0;/,
     'the armed intent is torn down with the content script');
   // The commit core is ONE extractor shared by the click and the flush, so
   // an armed fill commits identically to a direct one.
@@ -457,7 +457,7 @@ test('a row-snipe intent survives the navigation to the coin chart (D-42 Bug 3)'
   // with it. It must mirror into the SW and be adopted by the coin's page.
   assert.match(content, /type: 'pt_armed_row_arm'/,
     'arming a row snipe mirrors the intent to the service worker');
-  assert.match(content, /const intent = await sendMessage\(\{ type: 'pt_armed_row_get' \}\)/,
+  assert.match(content, /const mirrored = await sendMessage\(\{ type: 'pt_armed_row_get' \}\)/,
     'the coin page asks the SW for a mirrored intent at detection');
   assert.match(content, /adoptedFromRow: true/,
     'an adopted intent is marked and runs the panel D-39 flush');
@@ -468,12 +468,34 @@ test('a row-snipe intent survives the navigation to the coin chart (D-42 Bug 3)'
     'the service worker holds the intent in session storage');
 });
 
+test('armed row intents use a bounded selective service-worker mirror', () => {
+  const bg = fs.readFileSync(path.join(ROOT, 'background.js'), 'utf8');
+  assert.match(content, /const ARMED_ROW_MAX = ROW_BUY_QUEUE_MAX;/,
+    'content keeps armed intents on the same bound as queued taps');
+  assert.match(content, /rowArmed\.find\(\(intent\) => intent\.address === address\)/,
+    'same-address armed taps are deduplicated locally');
+  assert.match(content, /if \(!rowArmed\.length\) \{\s*\n\s*clearInterval\(rowArmedFlushTimer\)/,
+    'the armed probe self-clears when the list empties');
+  assert.match(bg, /const ARMED_ROW_MAX = 3;/,
+    'the service-worker mirror is bounded');
+  assert.match(bg, /Array\.isArray\(value\) \? value : \(value && value\.address \? \[value\] : \[\]\)/,
+    'legacy single-object storage is wrapped as a list');
+  assert.match(bg, /list\.findIndex\(\(item\) => item\.address === intent\.address\)/,
+    'the service-worker mirror deduplicates by address');
+  assert.match(bg, /while \(list\.length > ARMED_ROW_MAX\) list\.shift\(\)/,
+    'the service-worker mirror evicts the oldest entry');
+  assert.match(bg, /function clearArmedRowIntent\(address\)/,
+    'mirror clear accepts an optional address');
+  assert.match(content, /type: 'pt_armed_row_clear',\s*\n\s*address: intent\.address/,
+    'chart adoption clears only the matching intent');
+});
+
 test('an armed row snipe keeps probing until filled or expired (D-42 Bug 4)', () => {
   // Live report: "some coins still not instant". Two one-shot timers left
   // gaps; the repeating probe closes them inside the TTL.
   assert.match(content, /rowArmedFlushTimer = managedInterval\(\(\) => \{/,
     'the armed intent runs a repeating 1.5 s flush probe');
-  assert.match(content, /if \(!rowArmed\) \{\s*\n\s*clearInterval\(rowArmedFlushTimer\)/,
+  assert.match(content, /if \(!rowArmed\.length\) \{\s*\n\s*clearInterval\(rowArmedFlushTimer\)/,
     'the probe self-clears when the intent fills or expires');
 });
 /* ------------------------------------------------------------------------

--- a/extension/test/quickbuy.test.js
+++ b/extension/test/quickbuy.test.js
@@ -188,13 +188,13 @@ test('row buys run the full fill pipeline and never navigate the row', () => {
   // F-61 widened it once more: a row-fed candidate with a missing/echoed
   // mint gets ONE bounded prewatch probe to heal the key before commit —
   // the stand-in stranding the 8/17 report chased (jb).
-  assert.match(content, /async function fillRowBuy\(address, data, amount\)/,
+  assert.match(content, /async function fillRowBuy\(address, data, amount, ownerToken\)/,
     'the shared commit extractor exists (one commit path for click + armed flush)');
   assert.match(content, /fillRowBuy[\s\S]{0,5200}E\.buy\(state, settings/,
     'the extractor runs the engine buy');
   assert.match(content, /fillRowBuy[\s\S]{0,5600}commitFill\(filled\.trade\)/,
     'the extractor appends the attestation chain');
-  assert.match(content, /await fillRowBuy\(address, data, amount\);/,
+  assert.match(content, /await fillRowBuy\(address, data, amount, rowBuyToken\);/,
     'the click path commits through the shared extractor');
   // The screener's own realtime price is preferred when fresh.
   assert.match(content, /recentRowPrices/);
@@ -367,7 +367,7 @@ test('a fresh-coin chip miss ARMS the intent — the row path never refuses (D-4
     'the armed intent is torn down with the content script');
   // The commit core is ONE extractor shared by the click and the flush, so
   // an armed fill commits identically to a direct one.
-  assert.match(content, /await fillRowBuy\(armed\.address, data, armed\.amount\);/,
+  assert.match(content, /await fillRowBuy\(armed\.address, data, armed\.amount, rowBuyToken\);/,
     'the flush commits through the shared extractor');
 });
 

--- a/extension/test/quickbuy.test.js
+++ b/extension/test/quickbuy.test.js
@@ -167,7 +167,7 @@ test('row buys run the full fill pipeline and never navigate the row', () => {
   assert.match(bridge, /function scanScreenerRows\(spec\)/);
   assert.match(bridge, /function addressFromRowFiber\(row\)/);
   // Chips forward their tap back to the content script's fill pipeline.
-  assert.match(bridge, /emit\('row-buy', \{\s*address: entry\.address,\s*quote: rowQuoteFromFiber\(entry\.row, entry\.address\),/s);
+  assert.match(bridge, /emit\('row-buy', \{\s*address: decision\.address,\s*quote: typeof rowQuoteFromFiber/s);
   assert.match(content, /ev\.type === 'row-buy'/);
   // The chip shows a busy state until the content script settles the fill.
   assert.match(bridge, /type === 'row-buy-done'/);

--- a/extension/test/quickbuy.test.js
+++ b/extension/test/quickbuy.test.js
@@ -194,9 +194,9 @@ test('row buys run the full fill pipeline and never navigate the row', () => {
   // the stand-in stranding the 8/17 report chased (jb).
   assert.match(content, /async function fillRowBuy\(address, data, amount, ownerToken\)/,
     'the shared commit extractor exists (one commit path for click + armed flush)');
-  assert.match(content, /fillRowBuy[\s\S]{0,5200}E\.buy\(state, settings/,
+  assert.match(content, /fillRowBuy[\s\S]{0,6000}E\.buy\(state, settings/,
     'the extractor runs the engine buy');
-  assert.match(content, /fillRowBuy[\s\S]{0,5600}commitFill\(filled\.trade\)/,
+  assert.match(content, /fillRowBuy[\s\S]{0,6400}commitFill\(filled\.trade\)/,
     'the extractor appends the attestation chain');
   assert.match(content, /await fillRowBuy\(address, data, amount, rowBuyToken\);/,
     'the click path commits through the shared extractor');
@@ -204,7 +204,7 @@ test('row buys run the full fill pipeline and never navigate the row', () => {
   assert.match(content, /recentRowPrices/);
   // The new position surfaces immediately in the rail. (D-40: the rail
   // refresh lives in the extractor now — both paths surface it instantly.)
-  assert.match(content, /fillRowBuy[\s\S]{0,3000}renderPositionsBar\(\)/);
+  assert.match(content, /fillRowBuy[\s\S]{0,3400}renderPositionsBar\(\)/);
   // The scanner runs on the positions-bar cadence, which works on pages with
   // no detected token — exactly the screener situation.
   assert.match(content, /renderPositionsBar\(\);\s*\n\s*\/\/ Screener rows render continuously; catch new ones on this cadence\.\s*\n\s*scanRowBuys\(\);/);

--- a/extension/test/quickbuy.test.js
+++ b/extension/test/quickbuy.test.js
@@ -163,7 +163,7 @@ test('row buys run the full fill pipeline and never navigate the row', () => {
   assert.match(bridge, /function scanScreenerRows\(spec\)/);
   assert.match(bridge, /function addressFromRowFiber\(row\)/);
   // Chips forward their tap back to the content script's fill pipeline.
-  assert.match(bridge, /emit\('row-buy', \{ address: entry\.address \}\)/);
+  assert.match(bridge, /emit\('row-buy', \{\s*address: entry\.address,\s*quote: rowQuoteFromFiber\(entry\.row, entry\.address\),/s);
   assert.match(content, /ev\.type === 'row-buy'/);
   // The chip shows a busy state until the content script settles the fill.
   assert.match(bridge, /type === 'row-buy-done'/);
@@ -394,8 +394,8 @@ test('chip fills run the same honesty gate as panel fills (F-56)', () => {
   assert.match(content, /Price sources disagree — paper fill refused\. Try again in a moment\./,
     'a divergent candidate with no vouching second source refuses visibly');
   // The witness must be INDEPENDENT of the candidate's source.
-  assert.match(content, /if \(data\.priceSource === 'row-feed' \|\| !data\.priceSource\) \{\s*\n\s*const obs = await R\.resolve\(address/,
-    'a row-feed candidate is witnessed by the resolver, not by itself');
+  assert.match(content, /if \(data\.priceSource === 'row-feed' \|\| data\.priceSource === 'row-props' \|\| !data\.priceSource\) \{\s*\n\s*const obs = await R\.resolve\(address/,
+    'page-row candidates are witnessed by the resolver, not by themselves');
 });
 
 test('a panel buy on a fresh coin acquires the quote on the click before arming (D-38)', () => {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -137,7 +137,7 @@ function bootRace(options = {}) {
     PaperTrenchSites: {},
     PaperTrenchResolver: {},
     PTChartMarkers: { destroyChartMarkers() {} },
-    PTTitleFeed: {},
+    PTTitleFeed: { start() {}, stop() {}, onMarketCap() { return () => {}; } },
     innerWidth: 1400,
     innerHeight: 1050,
     addEventListener(type, fn) {
@@ -341,6 +341,8 @@ function bootRace(options = {}) {
     getRowArmedFlushTimer: () => rowArmedFlushTimer,
     getRowBuyQueue: () => rowBuyQueue.slice(),
     drainRowBuyQueue,
+    disableOverlay,
+    setPresetBuy: (amount) => { settings.presetsBuy = [amount]; },
     getRecentRowPrice: (mint) => recentRowPrices.get(mint) || null,
   };
 `
@@ -771,6 +773,64 @@ test('a second tap queues and fills at its own captured quote', async () => {
   assert.equal(harness.getState().journal[0].priceNative, 0.000064);
   assert.equal(harness.getState().journal[1].priceNative, 0.000032);
   assert.equal(race.debugLines.filter((line) => line.includes('row-buy')).length, 2);
+});
+
+test('a fresh tap joins the queue before a scheduled drain', async () => {
+  const race = bootRace({ holdPairIdentity: true });
+  const { harness } = race;
+  const first = harness.doRowBuy(PAIR, null, { pair: PAIR, priceSol: 0.000032 });
+  await waitFor(() => race.isPairIdentityRequested());
+  harness.doRowBuy(B, null, { mint: B, priceSol: 0.000064, priceUsd: 0.0064 });
+  race.releasePairIdentity();
+  await first;
+  harness.doRowBuy(C, null, { mint: C, priceSol: 0.000096, priceUsd: 0.0096 });
+  assert.deepEqual(Array.from(harness.getRowBuyQueue(), (entry) => entry.address), [B, C]);
+  await race.advance(1);
+  await waitFor(() => race.isBIdentityRequested());
+  race.releaseB();
+  await waitFor(() => harness.getState().journal.length === 2);
+  await waitFor(() => !harness.getRowBuyInFlight());
+  await race.advance(1);
+  await waitFor(() => race.isCIdentityRequested());
+  race.releaseC();
+  await waitFor(() => harness.getState().journal.length === 3);
+  assert.deepEqual(
+    Array.from(harness.getState().journal, (trade) => trade.mint),
+    [C, B, B],
+  );
+});
+
+test('a queued tap keeps the preset amount captured at tap time', async () => {
+  const race = bootRace({ holdPairIdentity: true });
+  const { harness } = race;
+  const first = harness.doRowBuy(PAIR, null, { pair: PAIR, priceSol: 0.000032 });
+  await waitFor(() => race.isPairIdentityRequested());
+  harness.doRowBuy(B, null, { mint: B, priceSol: 0.000064, priceUsd: 0.0064 });
+  race.releasePairIdentity();
+  await first;
+  harness.setPresetBuy(0.7);
+  await race.advance(1);
+  await waitFor(() => race.isBIdentityRequested());
+  race.releaseB();
+  await waitFor(() => harness.getState().journal.length === 2);
+  assert.equal(harness.getState().journal[0].solGross, 0.1);
+});
+
+test('disabling the overlay clears queued taps without stranding them', async () => {
+  const race = bootRace({ holdPairIdentity: true });
+  const { harness } = race;
+  await harness.enableOverlay();
+  const first = harness.doRowBuy(PAIR, null, { pair: PAIR, priceSol: 0.000032 });
+  await waitFor(() => race.isPairIdentityRequested());
+  harness.doRowBuy(B, null, { mint: B, priceSol: 0.000064, priceUsd: 0.0064 });
+  assert.equal(harness.getRowBuyQueue().length, 1);
+  harness.disableOverlay();
+  assert.equal(harness.getRowBuyQueue().length, 0);
+  race.releasePairIdentity();
+  await first;
+  await race.advance(1);
+  assert.equal(harness.getState().journal.length, 1);
+  assert.equal(race.isBIdentityRequested(), false);
 });
 
 test('the row-buy queue holds three taps and refuses the fifth tap', async () => {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -181,6 +181,7 @@ function bootRace(options = {}) {
     }
     if (payload.type === 'pt_sol_usd') {
       solUsdRequested = true;
+      if (options.solUsdFails) return Promise.reject(new Error('rate unavailable'));
       return solUsdPending ? solUsd : Promise.resolve(100);
     }
     if (payload.type === 'pt_state_commit') return Promise.resolve({ ok: true });
@@ -550,24 +551,76 @@ test('a row-props quote fills at the tapped price without resolver or identity l
   assert.equal(harness.getState().journal[0].priceNative, 0.000032);
 });
 
-test('an invalid row-props identity is refused instead of filling or arming', async () => {
+test('row-props validation has its own exact address check', () => {
+  assert.match(CONTENT, /const ROW_ADDR_RE = \/\[1-9A-HJ-NP-Za-km-z\]\{32,44\}\//);
+  assert.match(CONTENT, /const ROW_ADDR_EXACT_RE = \/\^\[1-9A-HJ-NP-Za-km-z\]\{32,44\}\$\//);
+});
+
+test('an invalid row-props identity falls back to the resolver', async () => {
   const race = bootRace();
   const { harness } = race;
 
-  await harness.doRowBuy(B, null, {
+  const buy = harness.doRowBuy(B, null, {
     mint: A,
     pair: PAIR,
     priceSol: 1,
     priceUsd: 100,
     mcapUsd: 100_000,
   });
+  await waitFor(() => race.isBIdentityRequested());
+  race.releaseB();
+  await buy;
 
-  assert.equal(harness.getState().journal.length, 0, 'a foreign row quote cannot fill');
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B],
+    'a foreign row quote falls back to the tapped address');
   assert.equal(harness.getRowArmed(), null, 'a foreign row quote cannot arm');
   assert.equal(
     race.messages.filter((message) => message.type === 'pt_resolve').length,
+    1,
+    'a rejected row quote uses the resolver cascade',
+  );
+});
+
+test('an inconsistent row-props SOL/USD rate falls back to the resolver', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  const buy = harness.doRowBuy(B, null, {
+    mint: B,
+    priceSol: 1,
+    priceUsd: 1000,
+  });
+  await waitFor(() => race.isBIdentityRequested());
+  race.releaseB();
+  await buy;
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
+  assert.equal(harness.getState().journal[0].priceNative, 1);
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
+    1,
+    'an inconsistent row quote is discarded before the resolver cascade',
+  );
+  assert.equal(harness.getRowArmed(), null);
+});
+
+test('a coherent row-props quote survives when SOL/USD lookup fails', async () => {
+  const race = bootRace({ solUsdFails: true });
+  const { harness } = race;
+
+  await harness.doRowBuy(PAIR, null, {
+    mint: B,
+    pair: PAIR,
+    priceSol: 0.000032,
+    priceUsd: 0.0032,
+  });
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
+  assert.equal(harness.getState().journal[0].priceNative, 0.000032);
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
     0,
-    'a rejected row quote must not fall through to a different price source',
+    'an unavailable SOL/USD rate does not force the resolver cascade',
   );
 });
 

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -1,0 +1,320 @@
+/* Regression harness for the two independent row-buy entry paths.
+ *
+ * The test boots the shipped content script with a deferred identity lookup
+ * for the clicked row. That leaves its real doRowBuy path in flight while a
+ * board tick wakes the armed-row path for another token.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const CONTENT = fs.readFileSync(path.join(ROOT, 'content.js'), 'utf8');
+const ENGINE = fs.readFileSync(path.join(ROOT, 'engine.js'), 'utf8');
+
+const A = 'A'.repeat(32);
+const B = 'B'.repeat(32);
+
+function bootRace() {
+  let clock = Date.now();
+  class HarnessDate extends Date {
+    constructor(...args) { super(...(args.length ? args : [clock])); }
+    static now() { return clock; }
+  }
+  const listeners = new Map();
+  const storage = {};
+  let bIdentityPending = true;
+  let bIdentityRequested = false;
+  let releaseBIdentity;
+  const bIdentity = new Promise((resolve) => { releaseBIdentity = resolve; });
+  const messages = [];
+  let settings;
+  let initialState;
+
+  const win = {
+    PaperEngine: null,
+    PaperQuote: {
+      STALE_AFTER_MS: 60_000,
+      positionRows: () => [],
+      portfolioSummary: () => ({ up: false }),
+    },
+    PaperTrenchSites: {},
+    PaperTrenchResolver: {},
+    PTChartMarkers: {},
+    PTTitleFeed: {},
+    addEventListener(type, fn) {
+      if (!listeners.has(type)) listeners.set(type, []);
+      listeners.get(type).push(fn);
+    },
+    removeEventListener() {},
+    postMessage() {},
+    location: {
+      href: 'https://axiom.trade/pulse',
+      hostname: 'axiom.trade',
+      pathname: '/pulse',
+      search: '',
+    },
+  };
+
+  function sendMessage(payload) {
+    messages.push(payload);
+    if (payload.type === 'pt_resolve') {
+      if (payload.address === B) {
+        return Promise.resolve({
+          mint: B,
+          pairAddress: null,
+          symbol: 'B',
+          name: 'Token B',
+          priceNative: 1,
+          priceUsd: 100,
+          mcap: 100_000,
+          priceSource: 'resolver',
+        });
+      }
+      return Promise.resolve(null);
+    }
+    if (payload.type === 'pt_onchain_prewatch') {
+      const address = payload.mint || payload.pool;
+      if (address === B) {
+        bIdentityRequested = true;
+        return bIdentityPending ? bIdentity : Promise.resolve({ mint: B });
+      }
+      if (address === A) return Promise.resolve({ mint: A });
+      return Promise.resolve(null);
+    }
+    if (payload.type === 'pt_sol_usd') return Promise.resolve(100);
+    if (payload.type === 'pt_state_commit') return Promise.resolve({ ok: true });
+    if (payload.type === 'pt_attest_append') return Promise.resolve({ ok: true });
+    return Promise.resolve({});
+  }
+
+  const document = {
+    readyState: 'loading',
+    hidden: false,
+    body: null,
+    documentElement: {},
+    addEventListener(type, fn) {
+      if (!listeners.has(`document:${type}`)) listeners.set(`document:${type}`, []);
+      listeners.get(`document:${type}`).push(fn);
+    },
+    removeEventListener() {},
+    createElement: () => ({
+      style: {},
+      classList: { add() {}, remove() {}, toggle() {} },
+      appendChild() {},
+      addEventListener() {},
+    }),
+    querySelector: () => null,
+    querySelectorAll: () => [],
+  };
+
+  const chrome = {
+    runtime: {
+      id: 'papertrench-test',
+      lastError: null,
+      sendMessage,
+      onMessage: { addListener() {} },
+    },
+    storage: {
+      local: {
+        get(keys, callback) {
+          const out = {};
+          for (const key of (Array.isArray(keys) ? keys : [keys])) {
+            if (key in storage) out[key] = storage[key];
+          }
+          callback(out);
+        },
+        set(values, callback) {
+          Object.assign(storage, values);
+          if (callback) callback();
+        },
+      },
+      onChanged: { addListener() {}, removeListener() {} },
+    },
+  };
+
+  const sandbox = {
+    window: win,
+    self: win,
+    document,
+    location: win.location,
+    chrome,
+    console,
+    URL,
+    URLSearchParams,
+    Promise,
+    JSON,
+    Math,
+    Date: HarnessDate,
+    Number,
+    String,
+    Array,
+    Object,
+    Boolean,
+    RegExp,
+    Error,
+    Set,
+    Map,
+    WeakSet,
+    WeakMap,
+    Infinity,
+    NaN,
+    parseInt,
+    parseFloat,
+    isNaN,
+    AbortController: function () { this.signal = {}; this.abort = () => {}; },
+    MutationObserver: function () { this.observe = () => {}; this.disconnect = () => {}; },
+    ResizeObserver: function () { this.observe = () => {}; this.disconnect = () => {}; },
+    NodeFilter: { SHOW_TEXT: 4 },
+    fetch: () => Promise.resolve({ ok: false, status: 404, json: async () => ({}) }),
+    setTimeout: () => 1,
+    clearTimeout() {},
+    setInterval: () => 1,
+    clearInterval() {},
+    requestAnimationFrame: (fn) => { fn(); return 1; },
+    cancelAnimationFrame() {},
+    performance: { now: () => 1 },
+  };
+  vm.createContext(sandbox);
+  vm.runInContext(ENGINE, sandbox, { filename: 'engine.js' });
+  win.PaperEngine = sandbox.window.PaperEngine;
+  settings = win.PaperEngine.defaultSettings();
+  settings.balanceStartSol = 100;
+  initialState = win.PaperEngine.defaultState(settings);
+  storage.pt_state = initialState;
+  storage.pt_settings = settings;
+
+  const end = CONTENT.lastIndexOf('\n})();');
+  assert.ok(end > 0, 'content script has its IIFE terminator');
+  const instrumented = CONTENT.slice(0, end)
+    + `
+  window.__rowHarness = {
+    doRowBuy,
+    noteRowPrice,
+    flushRowArmed,
+    getState: () => state,
+    setSite: (next) => { site = next; },
+    getRowArmed: () => rowArmed,
+    getRowArmedFlushing: () => rowArmedFlushing,
+  };
+`
+    + CONTENT.slice(end);
+  vm.runInContext(instrumented, sandbox, { filename: 'content.js' });
+  const harness = sandbox.window.__rowHarness;
+  harness.setSite({ id: 'axiom', rowBuy: { kind: 'pair' } });
+
+  return {
+    harness,
+    storage,
+    isBIdentityRequested: () => bIdentityRequested,
+    releaseB() {
+      bIdentityPending = false;
+      releaseBIdentity({ mint: B });
+    },
+    messages,
+    setNow(next) { clock = next; },
+  };
+}
+
+async function waitFor(predicate) {
+  for (let i = 0; i < 2000; i++) {
+    if (predicate()) return;
+    await Promise.resolve();
+  }
+  assert.fail('timed out waiting for the row-buy harness');
+}
+
+test('an armed row fill defers behind a different clicked row fill', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  // Drive A through the real cascade miss so it arms rather than touching
+  // the closure's rowArmed state directly.
+  const arm = harness.doRowBuy(A);
+  await arm;
+  assert.ok(harness.getRowArmed(), 'A should remain armed after an unpriced click');
+
+  // B has a price, but its identity lookup is intentionally held open. This
+  // is the in-flight window in which the board tick for A can wake its flush.
+  const clickB = harness.doRowBuy(B);
+  await waitFor(() => race.isBIdentityRequested());
+  assert.equal(race.isBIdentityRequested(), true, 'B should be mid-fill before the tick');
+
+  harness.noteRowPrice({
+    mint: A,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'A',
+    name: 'Token A',
+  });
+  await waitFor(() => harness.getRowArmedFlushing());
+  await waitFor(() => !harness.getRowArmedFlushing());
+
+  const midJournal = Array.from(harness.getState().journal, (trade) => trade.mint);
+  assert.deepEqual(midJournal, [],
+    'the armed A fill stays deferred while clicked B is still in flight');
+  assert.ok(harness.getRowArmed(), 'the deferred A intent must remain armed');
+
+  race.releaseB();
+  await clickB;
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B],
+    'the direct B intent commits exactly once');
+
+  // The next board wake retries the still-armed intent after the direct
+  // commit releases the shared latch.
+  harness.noteRowPrice({
+    mint: A,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'A',
+    name: 'Token A',
+  });
+  await waitFor(() => harness.getState().journal.length === 2);
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [A, B],
+    'the deferred A intent commits exactly once on a later wake');
+});
+
+test('an armed row fill commits on its first available price without competition', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  await harness.doRowBuy(A);
+  assert.ok(harness.getRowArmed(), 'A should arm when its cascade cannot price');
+  harness.noteRowPrice({
+    mint: A,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'A',
+    name: 'Token A',
+  });
+  await waitFor(() => harness.getState().journal.length === 1 && !harness.getRowArmed());
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [A]);
+  assert.equal(harness.getRowArmed(), null, 'a successful armed fill clears its intent');
+});
+
+test('a priced row click still commits without an armed intent', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  const clickB = harness.doRowBuy(B);
+  await waitFor(() => race.isBIdentityRequested());
+  race.releaseB();
+  await clickB;
+  await waitFor(() => harness.getState().journal.length === 1);
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
+  assert.equal(harness.getRowArmed(), null, 'a priced click does not create an armed intent');
+});
+
+test('a row buy still expires at its existing TTL', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  await harness.doRowBuy(A);
+  const armedAt = harness.getRowArmed().at;
+  race.setNow(armedAt + 60_001);
+  await harness.flushRowArmed();
+
+  assert.equal(harness.getRowArmed(), null, 'an expired armed intent is cleared');
+  assert.equal(harness.getState().journal.length, 0, 'an expired intent does not fill');
+});

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -323,6 +323,7 @@ function bootRace(options = {}) {
   window.__rowHarness = {
     doRowBuy,
     noteRowPrice,
+    validRowPropsQuote,
     flushRowArmed,
     enableOverlay,
     getState: () => state,
@@ -750,6 +751,8 @@ test('a row-props quote fills at the tapped price without resolver or identity l
     priceUsd: 0.0032,
     mcapUsd: 3200,
     supply: 100_000_000,
+    symbol: 'CRAP',
+    name: 'dinosaur crap',
   });
 
   assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
@@ -765,6 +768,8 @@ test('a row-props quote fills at the tapped price without resolver or identity l
     'an authoritative row-props mint skips identity probing',
   );
   assert.equal(harness.getState().journal[0].priceNative, 0.000032);
+  assert.equal(harness.getState().journal[0].symbol, 'CRAP');
+  assert.equal(harness.getState().positions[B].name, 'dinosaur crap');
 });
 
 test('a USD-only GMGN row-props quote converts with the site rate', async () => {
@@ -819,6 +824,34 @@ test('a USD-only row-props quote without a SOL/USD rate falls back', async () =>
 test('row-props validation has its own exact address check', () => {
   assert.match(CONTENT, /const ROW_ADDR_RE = \/\[1-9A-HJ-NP-Za-km-z\]\{32,44\}\//);
   assert.match(CONTENT, /const ROW_ADDR_EXACT_RE = \/\^\[1-9A-HJ-NP-Za-km-z\]\{32,44\}\$\//);
+});
+
+test('row-props validation drops an incoherent cap but keeps the price', async () => {
+  const race = bootRace();
+  const quote = await race.harness.validRowPropsQuote({
+    mint: B,
+    pair: PAIR,
+    priceSol: 0.000032,
+    priceUsd: 0.0032,
+    mcapUsd: 6400,
+    supply: 1_000_000,
+  }, B);
+  assert.equal(quote.priceSol, 0.000032);
+  assert.equal(quote.priceUsd, 0.0032);
+  assert.equal(quote.mcapUsd, null);
+});
+
+test('row-props validation rejects address-shaped metadata', async () => {
+  const race = bootRace();
+  const quote = await race.harness.validRowPropsQuote({
+    mint: B,
+    pair: PAIR,
+    priceSol: 0.000032,
+    symbol: A,
+    name: A,
+  }, B);
+  assert.equal(quote.symbol, null);
+  assert.equal(quote.name, null);
 });
 
 test('an invalid row-props identity falls back to the resolver', async () => {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -602,6 +602,55 @@ test('a row-props quote fills at the tapped price without resolver or identity l
   assert.equal(harness.getState().journal[0].priceNative, 0.000032);
 });
 
+test('a USD-only GMGN row-props quote converts with the site rate', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  const buy = harness.doRowBuy(B, null, {
+    mint: B,
+    pair: PAIR,
+    priceUsd: 0.0032,
+    mcapUsd: 3200,
+    supply: 1_000_000,
+  });
+  await waitFor(() => race.isBIdentityRequested());
+  race.releaseB();
+  await buy;
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
+  assert.equal(harness.getState().journal[0].priceNative, 0.000032);
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
+    0,
+    'a reconciled GMGN quote skips the resolver cascade',
+  );
+});
+
+test('a USD-only row-props quote without a SOL/USD rate falls back', async () => {
+  const race = bootRace({ solUsdFails: true });
+  const { harness } = race;
+
+  const buy = harness.doRowBuy(B, null, {
+    mint: B,
+    pair: PAIR,
+    priceUsd: 0.0032,
+    mcapUsd: 3200,
+    supply: 1_000_000,
+  });
+  await waitFor(() => race.isBIdentityRequested());
+  race.releaseB();
+  await buy;
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
+  assert.equal(harness.getState().journal[0].priceNative, 1);
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
+    1,
+    'an unavailable conversion rate uses the resolver cascade',
+  );
+  assert.equal(harness.getRowArmed(), null, 'a quote with no conversion rate does not arm');
+});
+
 test('row-props validation has its own exact address check', () => {
   assert.match(CONTENT, /const ROW_ADDR_RE = \/\[1-9A-HJ-NP-Za-km-z\]\{32,44\}\//);
   assert.match(CONTENT, /const ROW_ADDR_EXACT_RE = \/\^\[1-9A-HJ-NP-Za-km-z\]\{32,44\}\$\//);

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -519,6 +519,69 @@ test('multiple armed row intents fill once each in FIFO order and stay bounded',
   assert.equal(harness.getState().journal.length, 3);
 });
 
+test('a board wake prefers the armed intent whose price just arrived', async () => {
+  const race = bootRace({ unpricedB: true });
+  const { harness } = race;
+
+  await harness.doRowBuy(A);
+  await harness.doRowBuy(B);
+  const originalA = harness.getRowArmedList().find((intent) => intent.address === A);
+  harness.noteRowPrice({
+    mint: B,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'B',
+    name: 'Token B',
+  });
+  await waitFor(() => harness.getState().journal.length === 1
+    && !harness.getRowBuyInFlight()
+    && !harness.getRowArmedFlushing());
+
+  assert.equal(harness.getState().journal[0].mint, B);
+  assert.deepEqual(
+    Array.from(harness.getRowArmedList(), (intent) => intent.address),
+    [A],
+  );
+  assert.equal(harness.getRowArmedList()[0].at, originalA.at);
+});
+
+test('an armed miss rotates FIFO so a no-argument wake tries the next intent', async () => {
+  const race = bootRace({ unpricedB: true });
+  const { harness } = race;
+
+  await harness.doRowBuy(A);
+  await harness.doRowBuy(B);
+  await harness.flushRowArmed();
+  assert.deepEqual(
+    Array.from(harness.getRowArmedList(), (intent) => intent.address),
+    [B, A],
+  );
+  await harness.flushRowArmed();
+  assert.deepEqual(
+    Array.from(harness.getRowArmedList(), (intent) => intent.address),
+    [A, B],
+  );
+});
+
+test('armed FIFO rotation preserves the original expiry timestamp', async () => {
+  const race = bootRace({ unpricedB: true });
+  const { harness } = race;
+
+  await harness.doRowBuy(A);
+  const originalA = harness.getRowArmedList().find((intent) => intent.address === A);
+  await race.advance(10);
+  await harness.doRowBuy(B);
+  await harness.flushRowArmed();
+  const rotatedA = harness.getRowArmedList().find((intent) => intent.address === A);
+  assert.equal(rotatedA.at, originalA.at);
+
+  race.setNow(originalA.at + 60_001);
+  await harness.flushRowArmed();
+  assert.deepEqual(
+    Array.from(harness.getRowArmedList(), (intent) => intent.address),
+    [B],
+  );
+});
+
 test('an expired armed entry is cleared without disturbing its sibling', async () => {
   const race = bootRace({ unpricedB: true });
   const { harness } = race;
@@ -982,10 +1045,16 @@ test('disabling the overlay clears queued taps without stranding them', async ()
   await waitFor(() => race.isPairIdentityRequested());
   harness.doRowBuy(B, null, { mint: B, priceSol: 0.000064, priceUsd: 0.0064 });
   assert.equal(harness.getRowBuyQueue().length, 1);
-  harness.disableOverlay();
-  assert.equal(harness.getRowBuyQueue().length, 0);
   race.releasePairIdentity();
   await first;
+  assert.equal(harness.getRowBuyInFlight(), false);
+  harness.disableOverlay();
+  assert.equal(harness.getRowBuyQueue().length, 0);
+  assert.equal(
+    harness.getMarkers().filter((message) => message.type === 'row-buy-done').length,
+    1,
+    'clearing the queue must release the chip busy state',
+  );
   await race.advance(1);
   assert.equal(harness.getState().journal.length, 1);
   assert.equal(race.isBIdentityRequested(), false);

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -19,6 +19,7 @@ const SITES = fs.readFileSync(path.join(ROOT, 'sites.js'), 'utf8');
 const A = 'A'.repeat(32);
 const B = 'B'.repeat(32);
 const C = 'C'.repeat(32);
+const D = 'D'.repeat(32);
 const PAIR = 'P'.repeat(32);
 
 function bootRace(options = {}) {
@@ -35,11 +36,11 @@ function bootRace(options = {}) {
   const listeners = new Map();
   const timers = [];
   const storage = {};
-  let bIdentityPending = true;
+  let bIdentityPending = options.unpricedB ? false : true;
   let bIdentityRequested = false;
   let releaseBIdentity;
   const bIdentity = new Promise((resolve) => { releaseBIdentity = resolve; });
-  let cIdentityPending = true;
+  let cIdentityPending = options.unpricedC ? false : true;
   let cIdentityRequested = false;
   let releaseCIdentity;
   const cIdentity = new Promise((resolve) => { releaseCIdentity = resolve; });
@@ -61,6 +62,7 @@ function bootRace(options = {}) {
   let releaseSolUsd;
   const solUsd = new Promise((resolve) => { releaseSolUsd = resolve; });
   const messages = [];
+  const markers = [];
   let settings;
   let initialState;
 
@@ -145,7 +147,7 @@ function bootRace(options = {}) {
       listeners.get(type).push(fn);
     },
     removeEventListener() {},
-    postMessage() {},
+    postMessage(message) { markers.push(message); },
     location: {
       href: 'https://axiom.trade/pulse',
       hostname: 'axiom.trade',
@@ -153,6 +155,7 @@ function bootRace(options = {}) {
       search: '',
     },
     __rowToastMessages: [],
+    __rowMarkers: markers,
   };
 
   function sendMessage(payload) {
@@ -172,6 +175,7 @@ function bootRace(options = {}) {
         });
       }
       if (payload.address === C) {
+        if (options.unpricedC) return Promise.resolve(null);
         return Promise.resolve({
           mint: C,
           pairAddress: null,
@@ -336,7 +340,8 @@ function bootRace(options = {}) {
     enableOverlay,
     getState: () => state,
     setSite: (next) => { site = next; },
-    getRowArmed: () => rowArmed,
+    getRowArmed: () => rowArmed[0] || null,
+    getRowArmedList: () => rowArmed.slice(),
     getRowArmedFlushing: () => rowArmedFlushing,
     getRowBuyInFlight: () => rowBuyInFlight,
     getRowBuyInFlightAt: () => rowBuyInFlightAt,
@@ -344,6 +349,7 @@ function bootRace(options = {}) {
     getRowArmedFlushTimer: () => rowArmedFlushTimer,
     getRowBuyQueue: () => rowBuyQueue.slice(),
     getToastMessages: () => window.__rowToastMessages.slice(),
+    getMarkers: () => window.__rowMarkers.slice(),
     drainRowBuyQueue,
     disableOverlay,
     setPresetBuy: (amount) => { settings.presetsBuy = [amount]; },
@@ -392,6 +398,7 @@ function bootRace(options = {}) {
       releaseSolUsd(100);
     },
     messages,
+    markers,
     debugLines,
     now: () => clock,
     setNow(next) { clock = next; },
@@ -473,6 +480,144 @@ test('an armed row fill commits on its first available price without competition
   assert.equal(harness.getRowArmed(), null, 'a successful armed fill clears its intent');
 });
 
+test('multiple armed row intents fill once each in FIFO order and stay bounded', async () => {
+  const race = bootRace({ unpricedB: true, unpricedC: true });
+  const { harness } = race;
+
+  await harness.doRowBuy(A);
+  await harness.doRowBuy(B);
+  await harness.doRowBuy(C);
+  assert.equal(
+    JSON.stringify(harness.getRowArmedList().map((intent) => intent.address)),
+    JSON.stringify([A, B, C]),
+  );
+
+  await harness.doRowBuy(D);
+  assert.equal(
+    JSON.stringify(harness.getRowArmedList().map((intent) => intent.address)),
+    JSON.stringify([A, B, C]),
+    'a fourth armed intent is refused instead of silently replacing one',
+  );
+  assert.ok(harness.getToastMessages().includes(
+    'Armed row queue full — tap again after current buys finish',
+  ));
+
+  for (const [address, symbol] of [[A, 'A'], [B, 'B'], [C, 'C']]) {
+    assert.equal(harness.getRowArmedList()[0].address, address);
+    harness.noteRowPrice({
+      mint: address,
+      candidates: [{ unit: 'usd', value: 100 }],
+      symbol,
+      name: `Token ${symbol}`,
+    });
+    await harness.flushRowArmed();
+    await waitFor(() => harness.getState().journal.length >= (
+      address === A ? 1 : address === B ? 2 : 3
+    ) && !harness.getRowBuyInFlight());
+  }
+  assert.equal(harness.getState().journal.length, 3);
+});
+
+test('an expired armed entry is cleared without disturbing its sibling', async () => {
+  const race = bootRace({ unpricedB: true });
+  const { harness } = race;
+
+  await harness.doRowBuy(A);
+  const first = harness.getRowArmed();
+  await race.advance(10);
+  await harness.doRowBuy(B);
+  race.setNow(first.at + 60_001);
+  await harness.flushRowArmed();
+
+  assert.equal(
+    JSON.stringify(harness.getRowArmedList().map((intent) => intent.address)),
+    JSON.stringify([B]),
+  );
+  assert.equal(
+    harness.getToastMessages().filter((message) => message === 'Armed row buy expired — no fillable price arrived in time').length,
+    1,
+  );
+  const expired = race.messages.filter((message) => message.type === 'pt_armed_row_clear');
+  assert.equal(expired.length, 1);
+  assert.equal(expired[0].address, A);
+});
+
+test('re-tapping an armed row refreshes its existing FIFO entry', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  await harness.doRowBuy(A);
+  const first = harness.getRowArmed();
+  await race.advance(10);
+  await harness.doRowBuy(A);
+  const second = harness.getRowArmed();
+
+  assert.equal(harness.getRowArmedList().length, 1);
+  assert.equal(second, first);
+  assert.ok(second.at >= first.at);
+});
+
+test('armed completion holds the chip busy and emits one terminal timing line', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  await harness.doRowBuy(A);
+  assert.equal(
+    harness.getMarkers().filter((message) => message.type === 'row-buy-done').length,
+    0,
+    'arming keeps the chip busy',
+  );
+  harness.noteRowPrice({
+    mint: A,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'A',
+    name: 'Token A',
+  });
+  await waitFor(() => harness.getState().journal.length === 1 && !harness.getRowArmed());
+
+  assert.equal(
+    harness.getMarkers().filter((message) => message.type === 'row-buy-done').length,
+    1,
+  );
+  const terminal = race.debugLines.filter((line) => line.includes('outcome=done'));
+  assert.equal(terminal.length, 1, 'one armed completion line is emitted');
+  assert.match(terminal[0], /source=row-feed outcome=done/);
+});
+
+test('a queued row tap withholds the done marker until all work completes', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  const active = harness.doRowBuy(B);
+  await waitFor(() => race.isBIdentityRequested());
+  await harness.doRowBuy(C);
+  assert.equal(
+    harness.getMarkers().filter((message) => message.type === 'row-buy-done').length,
+    0,
+  );
+
+  race.releaseB();
+  race.releaseC();
+  await waitFor(() => harness.getState().journal.length === 1);
+  await waitFor(() => !harness.getRowBuyInFlight());
+  assert.equal(
+    harness.getMarkers().filter((message) => message.type === 'row-buy-done').length,
+    0,
+    'the active completion does not clear the chip while C remains outstanding',
+  );
+  harness.noteRowPrice({
+    mint: C,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'C',
+    name: 'Token C',
+  });
+  await harness.drainRowBuyQueue();
+  await waitFor(() => harness.getState().journal.length === 2);
+  await active;
+  await waitFor(() => harness.getMarkers()
+    .filter((message) => message.type === 'row-buy-done').length === 1);
+});
+
 test('a newer armed intent survives an older flush commit', async () => {
   const race = bootRace({ unpricedB: true, holdSolUsd: true });
   const { harness } = race;
@@ -490,9 +635,8 @@ test('a newer armed intent survives an older flush commit', async () => {
   await waitFor(() => race.isSolUsdRequested());
   assert.equal(harness.getRowArmedFlushing(), true, 'A should be flushing its newly available price');
 
-  race.releaseB();
   await harness.doRowBuy(B);
-  const secondIntent = harness.getRowArmed();
+  const secondIntent = harness.getRowArmedList()[1];
   assert.ok(secondIntent, 'B should arm after its own cascade misses');
   assert.notEqual(secondIntent, firstIntent, 'each unpriced click gets a fresh intent object');
   assert.equal(
@@ -509,8 +653,8 @@ test('a newer armed intent survives an older flush commit', async () => {
     'the older A flush cannot discard newer B');
   assert.equal(
     race.messages.filter((message) => message.type === 'pt_armed_row_clear').length,
-    0,
-    'the older flush cannot clear B from the service worker',
+    1,
+    'the older flush clears only A from the service worker',
   );
   assert.ok(harness.getRowArmedFlushTimer(),
     'the repeating armed flush remains alive for B');
@@ -528,7 +672,7 @@ test('a newer armed intent survives an older flush commit', async () => {
   assert.equal(harness.getRowArmed(), null, 'B clears only after its own successful fill');
   assert.equal(
     race.messages.filter((message) => message.type === 'pt_armed_row_clear').length,
-    1,
+    2,
     'the service worker mirror clears once for the filled B intent',
   );
 });

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -23,6 +23,11 @@ const PAIR = 'P'.repeat(32);
 
 function bootRace(options = {}) {
   let clock = Date.now();
+  const debugLines = [];
+  const testConsole = {
+    ...console,
+    debug(...args) { debugLines.push(args.join(' ')); },
+  };
   class HarnessDate extends Date {
     constructor(...args) { super(...(args.length ? args : [clock])); }
     static now() { return clock; }
@@ -269,7 +274,7 @@ function bootRace(options = {}) {
     document,
     location: win.location,
     chrome,
-    console,
+    console: testConsole,
     URL,
     URLSearchParams,
     Promise,
@@ -334,6 +339,8 @@ function bootRace(options = {}) {
     getRowBuyInFlightAt: () => rowBuyInFlightAt,
     getRowBuyOwner: () => rowBuyOwner,
     getRowArmedFlushTimer: () => rowArmedFlushTimer,
+    getRowBuyQueue: () => rowBuyQueue.slice(),
+    drainRowBuyQueue,
     getRecentRowPrice: (mint) => recentRowPrices.get(mint) || null,
   };
 `
@@ -379,6 +386,7 @@ function bootRace(options = {}) {
       releaseSolUsd(100);
     },
     messages,
+    debugLines,
     now: () => clock,
     setNow(next) { clock = next; },
     advance,
@@ -738,6 +746,113 @@ test('a fresh row tick with a hung SOL/USD lookup falls through to the resolver'
   );
   assert.equal(harness.getState().journal.length, 1, 'the timed-out tap still fills');
   assert.equal(harness.getRowBuyInFlight(), false, 'the row-buy latch is released');
+});
+
+test('a second tap queues and fills at its own captured quote', async () => {
+  const race = bootRace({ holdPairIdentity: true });
+  const { harness } = race;
+  const first = harness.doRowBuy(PAIR, null, { pair: PAIR, priceSol: 0.000032 });
+  await waitFor(() => race.isPairIdentityRequested());
+  const second = harness.doRowBuy(B, null, {
+    mint: B, priceSol: 0.000064, priceUsd: 0.0064,
+  });
+  await Promise.resolve();
+  assert.equal(harness.getRowBuyQueue().length, 1);
+  race.releasePairIdentity();
+  race.releaseB();
+  await first;
+  for (let i = 0; i < 4; i++) await race.advance(1);
+  await second;
+  await waitFor(() => harness.getState().journal.length === 2);
+  assert.deepEqual(
+    Array.from(harness.getState().journal, (trade) => trade.mint),
+    [B, B],
+  );
+  assert.equal(harness.getState().journal[0].priceNative, 0.000064);
+  assert.equal(harness.getState().journal[1].priceNative, 0.000032);
+  assert.equal(race.debugLines.filter((line) => line.includes('row-buy')).length, 2);
+});
+
+test('the row-buy queue holds three taps and refuses the fifth tap', async () => {
+  const race = bootRace({ holdPairIdentity: true });
+  const { harness } = race;
+  const first = harness.doRowBuy(PAIR, null, { pair: PAIR, priceSol: 0.000032 });
+  await waitFor(() => race.isPairIdentityRequested());
+  for (const [mint, price] of [[B, 0.000064], [C, 0.000096], [A, 0.000128], [B, 0.00016]]) {
+    harness.doRowBuy(mint, null, { mint, priceSol: price, priceUsd: price * 100 });
+  }
+  assert.equal(harness.getRowBuyQueue().length, 3);
+  race.releasePairIdentity();
+  race.releaseB();
+  race.releaseC();
+  await first;
+  for (let i = 0; i < 12; i++) await race.advance(1);
+  await waitFor(() => harness.getState().journal.length === 4);
+  assert.equal(harness.getRowBuyQueue().length, 0);
+  assert.ok(race.debugLines.some((line) => line.includes('outcome=refused')));
+});
+
+test('an expired queued tap is reported and the queue continues', async () => {
+  const race = bootRace({ holdPairIdentity: true });
+  const { harness } = race;
+  const first = harness.doRowBuy(PAIR, null, { pair: PAIR, priceSol: 0.000032 });
+  await waitFor(() => race.isPairIdentityRequested());
+  harness.doRowBuy(B, null, { mint: B, priceSol: 0.000064, priceUsd: 0.0064 });
+  await race.advance(4999);
+  harness.doRowBuy(C, null, { mint: C, priceSol: 0.000096, priceUsd: 0.0096 });
+  race.setNow(race.now() + 2);
+  race.releasePairIdentity();
+  race.releaseB();
+  race.releaseC();
+  await first;
+  harness.drainRowBuyQueue();
+  for (let i = 0; i < 8; i++) await race.advance(1);
+  await waitFor(() => harness.getState().journal.length === 2);
+  assert.deepEqual(
+    Array.from(harness.getState().journal, (trade) => trade.mint),
+    [C, B],
+  );
+  assert.equal(harness.getRowBuyQueue().length, 0);
+  assert.ok(race.debugLines.some((line) => line.includes('outcome=expired')));
+});
+
+test('a drain attempt while the latch is held leaves the queued tap intact', async () => {
+  const race = bootRace({ holdPairIdentity: true });
+  const { harness } = race;
+  const first = harness.doRowBuy(PAIR, null, { pair: PAIR, priceSol: 0.000032 });
+  await waitFor(() => race.isPairIdentityRequested());
+  harness.doRowBuy(B, null, { mint: B, priceSol: 0.000064, priceUsd: 0.0064 });
+  harness.drainRowBuyQueue();
+  assert.equal(harness.getRowBuyQueue().length, 1);
+  race.releasePairIdentity();
+  race.releaseB();
+  await first;
+  for (let i = 0; i < 4; i++) await race.advance(1);
+  await waitFor(() => harness.getState().journal.length === 2);
+});
+
+test('the stuck-latch watchdog releases and drains a queued tap', async () => {
+  const race = bootRace({ holdPairIdentity: true });
+  const { harness } = race;
+  const first = harness.doRowBuy(PAIR, null, { pair: PAIR, priceSol: 0.000032 });
+  await waitFor(() => race.isPairIdentityRequested());
+  race.setHoldStateRead(true);
+  race.releasePairIdentity();
+  await waitFor(() => race.isStateReadRequested());
+  const startedAt = harness.getRowBuyInFlightAt();
+  race.setNow(startedAt + 20_001);
+  harness.doRowBuy(B, null, { mint: B, priceSol: 0.000064, priceUsd: 0.0064 });
+  await harness.enableOverlay();
+  await race.advance(1001);
+  assert.ok(harness.getRowBuyOwner() > 1);
+  assert.equal(harness.getRowBuyQueue().length, 0);
+  race.releaseStateRead();
+  race.releaseB();
+  await first;
+  for (let i = 0; i < 4; i++) await race.advance(1);
+  await waitFor(() => harness.getState().journal.length === 1);
+  assert.equal(harness.getState().journal[0].mint, B);
+  assert.equal(harness.getRowBuyQueue().length, 0);
 });
 
 test('a row-props quote fills at the tapped price without resolver or identity lookup', async () => {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -353,6 +353,7 @@ function bootRace(options = {}) {
     drainRowBuyQueue,
     disableOverlay,
     setPresetBuy: (amount) => { settings.presetsBuy = [amount]; },
+    setSettings: (patch) => { Object.assign(settings, patch); },
     getRecentRowPrice: (mint) => recentRowPrices.get(mint) || null,
   };
 `
@@ -1263,6 +1264,28 @@ test('an inconsistent row-props SOL/USD rate falls back to the resolver', async 
     'an inconsistent row quote is discarded before the resolver cascade',
   );
   assert.equal(harness.getRowArmed(), null);
+});
+
+test('a direct row-buy refusal reports refused rather than done', async () => {
+  const race = bootRace();
+  const { harness } = race;
+  harness.setSettings({ guardMaxPositionPct: 100 });
+
+  const buy = harness.doRowBuy(B);
+  await waitFor(() => race.isBIdentityRequested());
+  harness.setSettings({ guardMaxPositionPct: 0.01 });
+  race.releaseB();
+  await buy;
+
+  assert.equal(harness.getState().journal.length, 0);
+  assert.equal(
+    race.debugLines.filter((line) => line.includes('outcome=refused')).length,
+    1,
+  );
+  assert.equal(
+    race.debugLines.filter((line) => line.includes('outcome=done')).length,
+    0,
+  );
 });
 
 test('a coherent row-props quote survives when SOL/USD lookup fails', async () => {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -38,6 +38,15 @@ function bootRace(options = {}) {
   let cIdentityRequested = false;
   let releaseCIdentity;
   const cIdentity = new Promise((resolve) => { releaseCIdentity = resolve; });
+  let aIdentityPending = options.holdAIdentity === true;
+  let aIdentityRequested = false;
+  let aIdentityRequestCount = 0;
+  let releaseAIdentity;
+  const aIdentity = new Promise((resolve) => { releaseAIdentity = resolve; });
+  let pairIdentityPending = options.holdPairIdentity === true;
+  let pairIdentityRequested = false;
+  let releasePairIdentity;
+  const pairIdentity = new Promise((resolve) => { releasePairIdentity = resolve; });
   let solUsdPending = options.holdSolUsd === true;
   let solUsdRequested = false;
   let releaseSolUsd;
@@ -176,8 +185,15 @@ function bootRace(options = {}) {
         cIdentityRequested = true;
         return cIdentityPending ? cIdentity : Promise.resolve({ mint: C });
       }
-      if (address === A) return Promise.resolve({ mint: A });
-      if (address === PAIR) return Promise.resolve({ mint: B, pool: PAIR });
+      if (address === A) {
+        aIdentityRequested = true;
+        aIdentityRequestCount += 1;
+        return aIdentityPending ? aIdentity : Promise.resolve({ mint: A });
+      }
+      if (address === PAIR) {
+        pairIdentityRequested = true;
+        return pairIdentityPending ? pairIdentity : Promise.resolve({ mint: B, pool: PAIR });
+      }
       return Promise.resolve(null);
     }
     if (payload.type === 'pt_sol_usd') {
@@ -313,6 +329,18 @@ function bootRace(options = {}) {
     storage,
     isBIdentityRequested: () => bIdentityRequested,
     isCIdentityRequested: () => cIdentityRequested,
+    isAIdentityRequested: () => aIdentityRequested,
+    getAIdentityRequestCount: () => aIdentityRequestCount,
+    releaseAIdentity() {
+      aIdentityPending = false;
+      releaseAIdentity({ mint: A });
+    },
+    setHoldAIdentity(value) { aIdentityPending = value; },
+    isPairIdentityRequested: () => pairIdentityRequested,
+    releasePairIdentity() {
+      pairIdentityPending = false;
+      releasePairIdentity({ mint: B, pool: PAIR });
+    },
     releaseB() {
       bIdentityPending = false;
       releaseBIdentity({ mint: B });
@@ -501,13 +529,13 @@ test('a timed-out row buy cannot release a newer latch owner', async () => {
     'a third click is refused while the second buy remains in flight');
   assert.equal(harness.getRowBuyOwner(), secondOwner,
     'the refused third click cannot take ownership');
-  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B],
-    'the first fill may finish, but the newer held operation stays exclusive');
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [],
+    'the superseded first operation never commits alongside the newer owner');
 
   race.releaseC();
   await second;
-  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [C, B],
-    'both original intents eventually commit exactly once');
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [C],
+    'only the non-superseded operation commits');
 });
 
 test('a priced row click still commits without an armed intent', async () => {
@@ -643,26 +671,75 @@ test('a pair-only row-props quote is repaired to the canonical mint', async () =
 });
 
 test('a superseded direct row buy does not commit after watchdog release', async () => {
-  const race = bootRace({ holdSolUsd: true });
+  const race = bootRace({ holdPairIdentity: true });
   const { harness } = race;
 
-  const buy = harness.doRowBuy(PAIR, null, {
-    mint: B,
+  const first = harness.doRowBuy(PAIR, null, {
     pair: PAIR,
     priceSol: 0.000032,
-    priceUsd: 0.0032,
   });
-  await waitFor(() => race.isSolUsdRequested());
+  await waitFor(() => race.isPairIdentityRequested());
   const startedAt = harness.getRowBuyInFlightAt();
 
   await harness.enableOverlay();
   race.setNow(startedAt + 20_001);
   await race.advance(1);
-  await buy;
+  const second = harness.doRowBuy(PAIR, null, {
+    mint: B,
+    pair: PAIR,
+    priceSol: 0.000032,
+  });
+  await second;
+  race.releasePairIdentity();
+  await first;
 
-  assert.equal(harness.getState().journal.length, 0,
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B],
     'a watchdog-superseded direct operation must not commit');
   assert.equal(harness.getRowBuyInFlight(), false);
+});
+
+test('a superseded armed flush does not commit and stays armed', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  await harness.doRowBuy(A);
+  assert.ok(harness.getRowArmed(), 'A should be armed before its retry');
+  race.setHoldAIdentity(true);
+  const aIdentityRequests = race.getAIdentityRequestCount();
+  harness.noteRowPrice({
+    mint: A,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'A',
+    name: 'Token A',
+  });
+  await waitFor(() => race.getAIdentityRequestCount() > aIdentityRequests);
+  const startedAt = harness.getRowBuyInFlightAt();
+
+  await harness.enableOverlay();
+  race.setNow(startedAt + 20_001);
+  await race.advance(1);
+  await harness.doRowBuy(PAIR, null, {
+    mint: B,
+    pair: PAIR,
+    priceSol: 0.000032,
+  });
+  race.releaseAIdentity();
+  await waitFor(() => !harness.getRowArmedFlushing());
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B],
+    'a watchdog-superseded armed operation must not commit');
+  assert.equal(harness.getRowArmed().address, A,
+    'a superseded armed intent remains available for retry');
+
+  harness.noteRowPrice({
+    mint: A,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'A',
+    name: 'Token A',
+  });
+  await waitFor(() => harness.getState().journal.length === 2);
+  assert.equal(harness.getState().journal[0].mint, A,
+    'the retained armed intent commits on a later wake');
 });
 
 test('a coherent row-props quote fills when SOL/USD lookup hangs', async () => {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -47,6 +47,10 @@ function bootRace(options = {}) {
   let pairIdentityRequested = false;
   let releasePairIdentity;
   const pairIdentity = new Promise((resolve) => { releasePairIdentity = resolve; });
+  let stateReadPending = false;
+  let stateReadRequested = false;
+  let releaseStateRead;
+  const stateRead = new Promise((resolve) => { releaseStateRead = resolve; });
   let solUsdPending = options.holdSolUsd === true;
   let solUsdRequested = false;
   let releaseSolUsd;
@@ -232,8 +236,20 @@ function bootRace(options = {}) {
     storage: {
       local: {
         get(keys, callback) {
+          const requestedKeys = Array.isArray(keys) ? keys : [keys];
+          if (stateReadPending && requestedKeys.includes('pt_state')) {
+            stateReadRequested = true;
+            stateRead.then(() => {
+              const out = {};
+              for (const key of requestedKeys) {
+                if (key in storage) out[key] = storage[key];
+              }
+              callback(out);
+            });
+            return;
+          }
           const out = {};
-          for (const key of (Array.isArray(keys) ? keys : [keys])) {
+          for (const key of requestedKeys) {
             if (key in storage) out[key] = storage[key];
           }
           callback(out);
@@ -340,6 +356,12 @@ function bootRace(options = {}) {
     releasePairIdentity() {
       pairIdentityPending = false;
       releasePairIdentity({ mint: B, pool: PAIR });
+    },
+    isStateReadRequested: () => stateReadRequested,
+    setHoldStateRead(value) { stateReadPending = value; },
+    releaseStateRead() {
+      stateReadPending = false;
+      releaseStateRead();
     },
     releaseB() {
       bIdentityPending = false;
@@ -679,6 +701,9 @@ test('a superseded direct row buy does not commit after watchdog release', async
     priceSol: 0.000032,
   });
   await waitFor(() => race.isPairIdentityRequested());
+  race.releasePairIdentity();
+  race.setHoldStateRead(true);
+  await waitFor(() => race.isStateReadRequested());
   const startedAt = harness.getRowBuyInFlightAt();
 
   await harness.enableOverlay();
@@ -689,8 +714,9 @@ test('a superseded direct row buy does not commit after watchdog release', async
     pair: PAIR,
     priceSol: 0.000032,
   });
+  await waitFor(() => harness.getRowBuyOwner() > 1);
+  race.releaseStateRead();
   await second;
-  race.releasePairIdentity();
   await first;
 
   assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B],

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -574,6 +574,80 @@ test('a priced row click still commits without an armed intent', async () => {
   assert.equal(harness.getRowArmed(), null, 'a priced click does not create an armed intent');
 });
 
+test('a fresh Padre row tick wins before the resolver and carries its cap', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  harness.noteRowPrice({
+    mint: B,
+    candidates: [{ unit: 'usd', value: 0.0032 }],
+    mcap: 3200,
+    symbol: 'B',
+    name: 'Token B',
+  });
+  const buy = harness.doRowBuy(B);
+  await waitFor(() => race.isBIdentityRequested());
+  race.releaseB();
+  await buy;
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
+  assert.equal(harness.getState().journal[0].priceNative, 0.000032);
+  assert.equal(harness.getState().journal[0].priceUsd, 0.0032);
+  assert.equal(harness.getState().journal[0].mcap, 3200);
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
+    0,
+    'a fresh row tick skips resolver pricing',
+  );
+});
+
+test('a stale Padre row tick falls through to the resolver cascade', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  harness.noteRowPrice({
+    mint: B,
+    candidates: [{ unit: 'usd', value: 0.0032 }],
+    mcap: 3200,
+  });
+  race.setNow(Date.now() + 120_001);
+  const buy = harness.doRowBuy(B);
+  await waitFor(() => race.isBIdentityRequested());
+  race.releaseB();
+  await buy;
+
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
+    1,
+    'an expired row tick must use the existing resolver cascade',
+  );
+  assert.equal(harness.getState().journal[0].priceNative, 1);
+  assert.equal(harness.getState().journal[0].mcap, 100_000);
+});
+
+test('a fresh row tick without SOL/USD falls through rather than guessing', async () => {
+  const race = bootRace({ solUsdFails: true });
+  const { harness } = race;
+
+  harness.noteRowPrice({
+    mint: B,
+    candidates: [{ unit: 'usd', value: 0.0032 }],
+    mcap: 3200,
+  });
+  const buy = harness.doRowBuy(B);
+  await waitFor(() => race.isBIdentityRequested());
+  race.releaseB();
+  await buy;
+
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
+    1,
+    'without a conversion rate the row tick must fall through',
+  );
+  assert.equal(harness.getState().journal[0].priceNative, 0.000032);
+  assert.ok(Math.abs(harness.getState().journal[0].mcap - 3.2) < 1e-9);
+});
+
 test('a row-props quote fills at the tapped price without resolver or identity lookup', async () => {
   const race = bootRace();
   const { harness } = race;

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -19,6 +19,7 @@ const SITES = fs.readFileSync(path.join(ROOT, 'sites.js'), 'utf8');
 const A = 'A'.repeat(32);
 const B = 'B'.repeat(32);
 const C = 'C'.repeat(32);
+const PAIR = 'P'.repeat(32);
 
 function bootRace(options = {}) {
   let clock = Date.now();
@@ -519,6 +520,55 @@ test('a priced row click still commits without an armed intent', async () => {
 
   assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
   assert.equal(harness.getRowArmed(), null, 'a priced click does not create an armed intent');
+});
+
+test('a row-props quote fills at the tapped price without resolver or identity lookup', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  await harness.doRowBuy(PAIR, null, {
+    mint: B,
+    pair: PAIR,
+    priceSol: 0.000032,
+    priceUsd: 0.0032,
+    mcapUsd: 3200,
+    supply: 100_000_000,
+  });
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
+  assert.equal(harness.getRowArmed(), null, 'a valid row-props quote never arms');
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
+    0,
+    'row-props pricing skips the resolver cascade',
+  );
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_onchain_prewatch').length,
+    0,
+    'an authoritative row-props mint skips identity probing',
+  );
+  assert.equal(harness.getState().journal[0].priceNative, 0.000032);
+});
+
+test('an invalid row-props identity is refused instead of filling or arming', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  await harness.doRowBuy(B, null, {
+    mint: A,
+    pair: PAIR,
+    priceSol: 1,
+    priceUsd: 100,
+    mcapUsd: 100_000,
+  });
+
+  assert.equal(harness.getState().journal.length, 0, 'a foreign row quote cannot fill');
+  assert.equal(harness.getRowArmed(), null, 'a foreign row quote cannot arm');
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
+    0,
+    'a rejected row quote must not fall through to a different price source',
+  );
 });
 
 test('a row buy still expires at its existing TTL', async () => {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -333,6 +333,7 @@ function bootRace(options = {}) {
     getRowBuyInFlightAt: () => rowBuyInFlightAt,
     getRowBuyOwner: () => rowBuyOwner,
     getRowArmedFlushTimer: () => rowArmedFlushTimer,
+    getRecentRowPrice: (mint) => recentRowPrices.get(mint) || null,
   };
 `
     + CONTENT.slice(end);
@@ -377,6 +378,7 @@ function bootRace(options = {}) {
       releaseSolUsd(100);
     },
     messages,
+    now: () => clock,
     setNow(next) { clock = next; },
     advance,
   };
@@ -572,6 +574,44 @@ test('a priced row click still commits without an armed intent', async () => {
 
   assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
   assert.equal(harness.getRowArmed(), null, 'a priced click does not create an armed intent');
+});
+
+test('row ticks use bounded frame times and reject older same-mint ticks', () => {
+  const race = bootRace();
+  const { harness } = race;
+  const now = race.now();
+
+  harness.noteRowPrice({
+    mint: A,
+    at: now - 1_000,
+    candidates: [{ unit: 'usd', value: 100 }],
+    mcap: 100_000,
+  });
+  harness.noteRowPrice({
+    mint: A,
+    at: now - 2_000,
+    candidates: [{ unit: 'usd', value: 90 }],
+    mcap: 90_000,
+  });
+  const retained = harness.getRecentRowPrice(A);
+  assert.equal(retained.usd, 100);
+  assert.equal(retained.at, now - 1_000);
+  assert.equal(retained.symbol, null);
+  assert.equal(retained.name, null);
+  assert.equal(retained.mcap, 100_000);
+
+  harness.noteRowPrice({
+    mint: B,
+    at: now + 60_000,
+    candidates: [{ unit: 'usd', value: 200 }],
+  });
+  harness.noteRowPrice({
+    mint: C,
+    at: now - 60_000,
+    candidates: [{ unit: 'usd', value: 300 }],
+  });
+  assert.equal(harness.getRecentRowPrice(B).at, now);
+  assert.equal(harness.getRecentRowPrice(C).at, now);
 });
 
 test('a fresh Padre row tick wins before the resolver and carries its cap', async () => {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -327,7 +327,16 @@ function bootRace(options = {}) {
     getAResolveRequestCount: () => aResolveRequestCount,
     releaseAResolve() {
       aResolvePending = false;
-      releaseAResolve(null);
+      releaseAResolve({
+        mint: A,
+        pairAddress: null,
+        symbol: 'A',
+        name: 'Token A',
+        priceNative: 1,
+        priceUsd: 100,
+        mcap: 100_000,
+        priceSource: 'resolver',
+      });
     },
     setHoldResolveA(value) { aResolvePending = value; },
     releaseB() {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -152,6 +152,7 @@ function bootRace(options = {}) {
       pathname: '/pulse',
       search: '',
     },
+    __rowToastMessages: [],
   };
 
   function sendMessage(payload) {
@@ -324,6 +325,8 @@ function bootRace(options = {}) {
   const end = CONTENT.lastIndexOf('\n})();');
   assert.ok(end > 0, 'content script has its IIFE terminator');
   const instrumented = CONTENT.slice(0, end)
+    .replace('  function toast(msg) {',
+      '  function toast(msg) { window.__rowToastMessages.push(msg);')
     + `
   window.__rowHarness = {
     doRowBuy,
@@ -340,6 +343,7 @@ function bootRace(options = {}) {
     getRowBuyOwner: () => rowBuyOwner,
     getRowArmedFlushTimer: () => rowArmedFlushTimer,
     getRowBuyQueue: () => rowBuyQueue.slice(),
+    getToastMessages: () => window.__rowToastMessages.slice(),
     drainRowBuyQueue,
     disableOverlay,
     setPresetBuy: (amount) => { settings.presetsBuy = [amount]; },
@@ -773,6 +777,15 @@ test('a second tap queues and fills at its own captured quote', async () => {
   assert.equal(harness.getState().journal[0].priceNative, 0.000064);
   assert.equal(harness.getState().journal[1].priceNative, 0.000032);
   assert.equal(race.debugLines.filter((line) => line.includes('row-buy')).length, 2);
+  const timingLine = race.debugLines.find((line) => line.includes('outcome=done'));
+  const timingValues = timingLine.match(
+    /guard\+state=(\d+)ms.*withState=(\d+)ms persist=(\d+)ms attempts=(\d+)/,
+  );
+  assert.ok(timingValues, 'timing line must expose state wait, persistence, and attempts');
+  assert.ok(
+    Number(timingValues[2]) + Number(timingValues[3]) <= Number(timingValues[1]),
+    'state wait and persistence must not overlap the guard/state boundary',
+  );
 });
 
 test('a fresh tap joins the queue before a scheduled drain', async () => {
@@ -1175,6 +1188,21 @@ test('a superseded direct row buy does not commit after watchdog release', async
   assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B],
     'a watchdog-superseded direct operation must not commit');
   assert.equal(harness.getRowBuyInFlight(), false);
+  assert.equal(
+    race.debugLines.filter((line) => line.includes('outcome=superseded')).length,
+    1,
+    'the released direct tap must report one superseded timing line',
+  );
+  assert.match(
+    race.debugLines.find((line) => line.includes('outcome=superseded')),
+    /withState=\d+ms persist=-ms attempts=-/,
+  );
+  assert.equal(
+    harness.getToastMessages().filter((message) =>
+      message === 'That tap was released after taking too long — nothing was filled').length,
+    1,
+    'the released direct tap must toast exactly once',
+  );
 });
 
 test('a superseded armed flush does not commit and stays armed', async () => {
@@ -1209,6 +1237,12 @@ test('a superseded armed flush does not commit and stays armed', async () => {
     'a watchdog-superseded armed operation must not commit');
   assert.equal(harness.getRowArmed().address, A,
     'a superseded armed intent remains available for retry');
+  assert.equal(
+    harness.getToastMessages().filter((message) =>
+      message === 'That tap was released after taking too long — nothing was filled').length,
+    1,
+    'the released armed tap must toast exactly once',
+  );
 
   harness.noteRowPrice({
     mint: A,

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -156,6 +156,7 @@ function bootRace(options = {}) {
     },
     __rowToastMessages: [],
     __rowMarkers: markers,
+    __rowPendingTimerCount: () => timers.filter((timer) => !timer.dead).length,
   };
 
   function sendMessage(payload) {
@@ -348,6 +349,8 @@ function bootRace(options = {}) {
     getRowBuyOwner: () => rowBuyOwner,
     getRowArmedFlushTimer: () => rowArmedFlushTimer,
     getRowBuyQueue: () => rowBuyQueue.slice(),
+    getRowBuyExpiryTimer: () => rowBuyExpiryTimer,
+    getPendingTimerCount: () => window.__rowPendingTimerCount(),
     getToastMessages: () => window.__rowToastMessages.slice(),
     getMarkers: () => window.__rowMarkers.slice(),
     drainRowBuyQueue,
@@ -1132,6 +1135,104 @@ test('an expired queued tap is reported and the queue continues', async () => {
   );
   assert.equal(harness.getRowBuyQueue().length, 0);
   assert.ok(race.debugLines.some((line) => line.includes('outcome=expired')));
+});
+
+test('a queued tap expires on its own TTL while another fill remains in flight', async () => {
+  const race = bootRace({ holdPairIdentity: true });
+  const { harness } = race;
+  const first = harness.doRowBuy(PAIR, null, { pair: PAIR, priceSol: 0.000032 });
+  await waitFor(() => race.isPairIdentityRequested());
+  harness.doRowBuy(B, null, { mint: B, priceSol: 0.000064, priceUsd: 0.0064 });
+
+  await race.advance(5001);
+  assert.equal(harness.getRowBuyQueue().length, 0);
+  const expired = race.debugLines.filter((line) => line.includes('outcome=expired'));
+  assert.equal(expired.length, 1);
+  assert.match(expired[0], /total=5000ms/);
+  assert.equal(
+    harness.getMarkers().filter((message) => message.type === 'row-buy-done').length,
+    0,
+    'queue expiry must not clear the chip while a fill remains in flight',
+  );
+
+  race.releasePairIdentity();
+  race.releaseB();
+  await first;
+  await waitFor(() => harness.getMarkers()
+    .filter((message) => message.type === 'row-buy-done').length === 1);
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
+});
+
+test('queued entries expire in tap order and emit one final done marker', async () => {
+  const race = bootRace({ holdPairIdentity: true });
+  const { harness } = race;
+  const first = harness.doRowBuy(PAIR, null, { pair: PAIR, priceSol: 0.000032 });
+  await waitFor(() => race.isPairIdentityRequested());
+  harness.doRowBuy(B, null, { mint: B, priceSol: 0.000064, priceUsd: 0.0064 });
+  await race.advance(1000);
+  harness.doRowBuy(C, null, { mint: C, priceSol: 0.000096, priceUsd: 0.0096 });
+
+  await race.advance(4001);
+  const expired = race.debugLines.filter((line) => line.includes('outcome=expired'));
+  assert.equal(expired.length, 1);
+  await race.advance(1000);
+  const allExpired = race.debugLines.filter((line) => line.includes('outcome=expired'));
+  assert.equal(allExpired.length, 2);
+  assert.match(allExpired[0], /total=500[01]ms/);
+  assert.match(allExpired[1], /total=500[01]ms/);
+  assert.equal(harness.getRowBuyQueue().length, 0);
+  assert.equal(
+    harness.getMarkers().filter((message) => message.type === 'row-buy-done').length,
+    0,
+  );
+
+  race.releasePairIdentity();
+  race.releaseB();
+  race.releaseC();
+  await first;
+  await waitFor(() => harness.getMarkers()
+    .filter((message) => message.type === 'row-buy-done').length === 1);
+  assert.equal(
+    harness.getMarkers().filter((message) => message.type === 'row-buy-done').length,
+    1,
+  );
+});
+
+test('draining a queued entry before its TTL cancels expiry', async () => {
+  const race = bootRace({ holdPairIdentity: true });
+  const { harness } = race;
+  const first = harness.doRowBuy(PAIR, null, { pair: PAIR, priceSol: 0.000032 });
+  await waitFor(() => race.isPairIdentityRequested());
+  harness.doRowBuy(B, null, { mint: B, priceSol: 0.000064, priceUsd: 0.0064 });
+  assert.ok(harness.getRowBuyExpiryTimer());
+
+  race.releasePairIdentity();
+  race.releaseB();
+  await first;
+  await waitFor(() => !harness.getRowBuyInFlight());
+  harness.drainRowBuyQueue();
+  await waitFor(() => harness.getState().journal.length === 2);
+  assert.equal(harness.getRowBuyExpiryTimer(), null);
+  await race.advance(5001);
+  assert.equal(race.debugLines.filter((line) => line.includes('outcome=expired')).length, 0);
+});
+
+test('clearing the queue through overlay disable removes its expiry timer', async () => {
+  const race = bootRace({ holdPairIdentity: true });
+  const { harness } = race;
+  const first = harness.doRowBuy(PAIR, null, { pair: PAIR, priceSol: 0.000032 });
+  await waitFor(() => race.isPairIdentityRequested());
+  harness.doRowBuy(B, null, { mint: B, priceSol: 0.000064, priceUsd: 0.0064 });
+  assert.ok(harness.getRowBuyExpiryTimer());
+
+  harness.disableOverlay();
+  assert.equal(harness.getRowBuyQueue().length, 0);
+  assert.equal(harness.getRowBuyExpiryTimer(), null);
+  assert.equal(harness.getPendingTimerCount(), 0);
+
+  race.releasePairIdentity();
+  race.releaseB();
+  await first;
 });
 
 test('a drain attempt while the latch is held leaves the queued tap intact', async () => {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -779,7 +779,7 @@ test('a second tap queues and fills at its own captured quote', async () => {
   assert.equal(race.debugLines.filter((line) => line.includes('row-buy')).length, 2);
   const timingLine = race.debugLines.find((line) => line.includes('outcome=done'));
   const timingValues = timingLine.match(
-    /guard\+state=(\d+)ms.*withState=(\d+)ms persist=(\d+)ms attempts=(\d+)/,
+    /guard\+state=(\d+)ms.*fill->state=(\d+)ms persist=(\d+)ms attempts=(\d+)/,
   );
   assert.ok(timingValues, 'timing line must expose state wait, persistence, and attempts');
   assert.ok(
@@ -1195,7 +1195,7 @@ test('a superseded direct row buy does not commit after watchdog release', async
   );
   assert.match(
     race.debugLines.find((line) => line.includes('outcome=superseded')),
-    /withState=\d+ms persist=-ms attempts=-/,
+    /fill->state=\d+ms persist=-ms attempts=-/,
   );
   assert.equal(
     harness.getToastMessages().filter((message) =>

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -20,7 +20,7 @@ const A = 'A'.repeat(32);
 const B = 'B'.repeat(32);
 const C = 'C'.repeat(32);
 
-function bootRace() {
+function bootRace(options = {}) {
   let clock = Date.now();
   class HarnessDate extends Date {
     constructor(...args) { super(...(args.length ? args : [clock])); }
@@ -37,6 +37,10 @@ function bootRace() {
   let cIdentityRequested = false;
   let releaseCIdentity;
   const cIdentity = new Promise((resolve) => { releaseCIdentity = resolve; });
+  let solUsdPending = options.holdSolUsd === true;
+  let solUsdRequested = false;
+  let releaseSolUsd;
+  const solUsd = new Promise((resolve) => { releaseSolUsd = resolve; });
   const messages = [];
   let settings;
   let initialState;
@@ -135,6 +139,7 @@ function bootRace() {
     messages.push(payload);
     if (payload.type === 'pt_resolve') {
       if (payload.address === B) {
+        if (options.unpricedB) return Promise.resolve(null);
         return Promise.resolve({
           mint: B,
           pairAddress: null,
@@ -173,7 +178,10 @@ function bootRace() {
       if (address === A) return Promise.resolve({ mint: A });
       return Promise.resolve(null);
     }
-    if (payload.type === 'pt_sol_usd') return Promise.resolve(100);
+    if (payload.type === 'pt_sol_usd') {
+      solUsdRequested = true;
+      return solUsdPending ? solUsd : Promise.resolve(100);
+    }
     if (payload.type === 'pt_state_commit') return Promise.resolve({ ok: true });
     if (payload.type === 'pt_attest_append') return Promise.resolve({ ok: true });
     return Promise.resolve({});
@@ -289,6 +297,7 @@ function bootRace() {
     getRowBuyInFlight: () => rowBuyInFlight,
     getRowBuyInFlightAt: () => rowBuyInFlightAt,
     getRowBuyOwner: () => rowBuyOwner,
+    getRowArmedFlushTimer: () => rowArmedFlushTimer,
   };
 `
     + CONTENT.slice(end);
@@ -308,6 +317,11 @@ function bootRace() {
     releaseC() {
       cIdentityPending = false;
       releaseCIdentity({ mint: C });
+    },
+    isSolUsdRequested: () => solUsdRequested,
+    releaseSolUsd() {
+      solUsdPending = false;
+      releaseSolUsd(100);
     },
     messages,
     setNow(next) { clock = next; },
@@ -387,6 +401,66 @@ test('an armed row fill commits on its first available price without competition
 
   assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [A]);
   assert.equal(harness.getRowArmed(), null, 'a successful armed fill clears its intent');
+});
+
+test('a newer armed intent survives an older flush commit', async () => {
+  const race = bootRace({ unpricedB: true, holdSolUsd: true });
+  const { harness } = race;
+
+  await harness.doRowBuy(A);
+  const firstIntent = harness.getRowArmed();
+  assert.ok(firstIntent, 'A should arm when its cascade cannot price');
+
+  harness.noteRowPrice({
+    mint: A,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'A',
+    name: 'Token A',
+  });
+  await waitFor(() => race.isSolUsdRequested());
+  assert.equal(harness.getRowArmedFlushing(), true, 'A should be flushing its newly available price');
+
+  race.releaseB();
+  await harness.doRowBuy(B);
+  const secondIntent = harness.getRowArmed();
+  assert.ok(secondIntent, 'B should arm after its own cascade misses');
+  assert.notEqual(secondIntent, firstIntent, 'each unpriced click gets a fresh intent object');
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_armed_row_arm').length,
+    2,
+    'the service worker receives both armed intents',
+  );
+
+  race.releaseSolUsd();
+  await waitFor(() => harness.getState().journal.length === 1);
+  await waitFor(() => !harness.getRowArmedFlushing());
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [A]);
+  assert.equal(harness.getRowArmed(), secondIntent,
+    'the older A flush cannot discard newer B');
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_armed_row_clear').length,
+    0,
+    'the older flush cannot clear B from the service worker',
+  );
+  assert.ok(harness.getRowArmedFlushTimer(),
+    'the repeating armed flush remains alive for B');
+
+  harness.noteRowPrice({
+    mint: B,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'B',
+    name: 'Token B',
+  });
+  await waitFor(() => harness.getState().journal.length === 2);
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B, A],
+    'the newer B intent subsequently commits exactly once');
+  await waitFor(() => harness.getRowArmed() === null);
+  assert.equal(harness.getRowArmed(), null, 'B clears only after its own successful fill');
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_armed_row_clear').length,
+    1,
+    'the service worker mirror clears once for the filled B intent',
+  );
 });
 
 test('a timed-out row buy cannot release a newer latch owner', async () => {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -38,6 +38,11 @@ function bootRace(options = {}) {
   let cIdentityRequested = false;
   let releaseCIdentity;
   const cIdentity = new Promise((resolve) => { releaseCIdentity = resolve; });
+  let aResolvePending = options.holdResolveA === true;
+  let aResolveRequested = false;
+  let aResolveRequestCount = 0;
+  let releaseAResolve;
+  const aResolve = new Promise((resolve) => { releaseAResolve = resolve; });
   let solUsdPending = options.holdSolUsd === true;
   let solUsdRequested = false;
   let releaseSolUsd;
@@ -139,6 +144,11 @@ function bootRace(options = {}) {
   function sendMessage(payload) {
     messages.push(payload);
     if (payload.type === 'pt_resolve') {
+      if (payload.address === A) {
+        aResolveRequested = true;
+        aResolveRequestCount += 1;
+        return aResolvePending ? aResolve : Promise.resolve(null);
+      }
       if (payload.address === B) {
         if (options.unpricedB) return Promise.resolve(null);
         return Promise.resolve({
@@ -177,6 +187,7 @@ function bootRace(options = {}) {
         return cIdentityPending ? cIdentity : Promise.resolve({ mint: C });
       }
       if (address === A) return Promise.resolve({ mint: A });
+      if (address === PAIR) return Promise.resolve({ mint: B, pool: PAIR });
       return Promise.resolve(null);
     }
     if (payload.type === 'pt_sol_usd') {
@@ -312,6 +323,13 @@ function bootRace(options = {}) {
     storage,
     isBIdentityRequested: () => bIdentityRequested,
     isCIdentityRequested: () => cIdentityRequested,
+    isAResolveRequested: () => aResolveRequested,
+    getAResolveRequestCount: () => aResolveRequestCount,
+    releaseAResolve() {
+      aResolvePending = false;
+      releaseAResolve(null);
+    },
+    setHoldResolveA(value) { aResolvePending = value; },
     releaseB() {
       bIdentityPending = false;
       releaseBIdentity({ mint: B });
@@ -621,6 +639,118 @@ test('a coherent row-props quote survives when SOL/USD lookup fails', async () =
     race.messages.filter((message) => message.type === 'pt_resolve').length,
     0,
     'an unavailable SOL/USD rate does not force the resolver cascade',
+  );
+});
+
+test('a pair-only row-props quote is repaired to the canonical mint', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  await harness.doRowBuy(PAIR, null, {
+    pair: PAIR,
+    priceSol: 0.000032,
+  });
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_onchain_prewatch').length,
+    1,
+    'a pair-only quote must perform the identity prewatch',
+  );
+});
+
+test('a superseded direct row buy does not commit after watchdog release', async () => {
+  const race = bootRace({ holdSolUsd: true });
+  const { harness } = race;
+
+  const buy = harness.doRowBuy(PAIR, null, {
+    mint: B,
+    pair: PAIR,
+    priceSol: 0.000032,
+    priceUsd: 0.0032,
+  });
+  await waitFor(() => race.isSolUsdRequested());
+  const startedAt = harness.getRowBuyInFlightAt();
+
+  await harness.enableOverlay();
+  race.setNow(startedAt + 20_001);
+  await race.advance(1);
+  await buy;
+
+  assert.equal(harness.getState().journal.length, 0,
+    'a watchdog-superseded direct operation must not commit');
+  assert.equal(harness.getRowBuyInFlight(), false);
+});
+
+test('a superseded armed flush stays armed for a later retry', async () => {
+  const race = bootRace({ holdSolUsd: true });
+  const { harness } = race;
+
+  await harness.doRowBuy(A);
+  assert.ok(harness.getRowArmed(), 'A should be armed before the competing click');
+  race.setHoldResolveA(true);
+
+  const competing = harness.doRowBuy(PAIR, null, {
+    mint: B,
+    pair: PAIR,
+    priceSol: 0.000032,
+    priceUsd: 0.0032,
+  });
+  await waitFor(() => race.isSolUsdRequested());
+  const startedAt = harness.getRowBuyInFlightAt();
+
+  const aResolveRequests = race.getAResolveRequestCount();
+  harness.noteRowPrice({
+    mint: A,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'A',
+    name: 'Token A',
+  });
+  await waitFor(() => race.getAResolveRequestCount() > aResolveRequests);
+
+  await harness.enableOverlay();
+  race.setNow(startedAt + 20_001);
+  await race.advance(1);
+  race.releaseSolUsd();
+  await competing;
+  race.releaseAResolve();
+  await waitFor(() => !harness.getRowArmedFlushing());
+
+  assert.equal(harness.getState().journal.length, 0,
+    'the superseded armed flush must not commit');
+  assert.equal(harness.getRowArmed().address, A,
+    'the superseded armed intent remains available for retry');
+
+  harness.noteRowPrice({
+    mint: A,
+    candidates: [{ unit: 'usd', value: 100 }],
+    symbol: 'A',
+    name: 'Token A',
+  });
+  await waitFor(() => harness.getState().journal.length === 1);
+  assert.equal(harness.getState().journal[0].mint, A,
+    'the retained armed intent commits on a later wake');
+});
+
+test('a coherent row-props quote fills when SOL/USD lookup hangs', async () => {
+  const race = bootRace({ holdSolUsd: true });
+  const { harness } = race;
+
+  const buy = harness.doRowBuy(PAIR, null, {
+    mint: B,
+    pair: PAIR,
+    priceSol: 0.000032,
+    priceUsd: 0.0032,
+  });
+  await waitFor(() => race.isSolUsdRequested());
+  await race.advance(2_001);
+  await buy;
+
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B]);
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
+    0,
+    'a timed-out SOL/USD witness does not force resolver pricing',
   );
 });
 

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -584,34 +584,60 @@ test('row ticks use bounded frame times and reject older same-mint ticks', () =>
   harness.noteRowPrice({
     mint: A,
     at: now - 1_000,
+    seq: 10,
     candidates: [{ unit: 'usd', value: 100 }],
     mcap: 100_000,
   });
   harness.noteRowPrice({
     mint: A,
     at: now - 2_000,
+    seq: 9,
     candidates: [{ unit: 'usd', value: 90 }],
     mcap: 90_000,
   });
   const retained = harness.getRecentRowPrice(A);
   assert.equal(retained.usd, 100);
   assert.equal(retained.at, now - 1_000);
+  assert.equal(retained.seq, 10);
   assert.equal(retained.symbol, null);
   assert.equal(retained.name, null);
   assert.equal(retained.mcap, 100_000);
 
   harness.noteRowPrice({
     mint: B,
-    at: now + 60_000,
+    at: now - 45_000,
+    source: 'ws',
     candidates: [{ unit: 'usd', value: 200 }],
   });
   harness.noteRowPrice({
     mint: C,
-    at: now - 60_000,
+    at: now + 60_000,
     candidates: [{ unit: 'usd', value: 300 }],
   });
+  assert.equal(harness.getRecentRowPrice(B), null);
+  assert.equal(harness.getRecentRowPrice(C), null);
+
+  harness.noteRowPrice({
+    mint: B,
+    candidates: [{ unit: 'usd', value: 250 }],
+  });
   assert.equal(harness.getRecentRowPrice(B).at, now);
-  assert.equal(harness.getRecentRowPrice(C).at, now);
+  assert.equal(harness.getRecentRowPrice(B).seq, null);
+
+  harness.noteRowPrice({
+    mint: C,
+    at: now,
+    seq: 20,
+    candidates: [{ unit: 'usd', value: 400 }],
+  });
+  harness.noteRowPrice({
+    mint: C,
+    at: now,
+    seq: 19,
+    candidates: [{ unit: 'usd', value: 390 }],
+  });
+  assert.equal(harness.getRecentRowPrice(C).usd, 400);
+  assert.equal(harness.getRecentRowPrice(C).seq, 20);
 });
 
 test('a fresh Padre row tick wins before the resolver and carries its cap', async () => {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -833,6 +833,37 @@ test('disabling the overlay clears queued taps without stranding them', async ()
   assert.equal(race.isBIdentityRequested(), false);
 });
 
+test('a drained tap survives a full queue when the latch is retaken', async () => {
+  const race = bootRace({ holdPairIdentity: true });
+  const { harness } = race;
+  const first = harness.doRowBuy(PAIR, null, { pair: PAIR, priceSol: 0.000032 });
+  await waitFor(() => race.isPairIdentityRequested());
+  harness.doRowBuy(C, null, { mint: C, priceSol: 0.000064, priceUsd: 0.0064 });
+  harness.doRowBuy(C, null, { mint: C, priceSol: 0.000064, priceUsd: 0.0064 });
+  harness.doRowBuy(C, null, { mint: C, priceSol: 0.000064, priceUsd: 0.0064 });
+  assert.equal(harness.getRowBuyQueue().length, 3);
+
+  // This models an already-accepted entry whose drain was interrupted after
+  // a fresh tap filled the queue back to its cap.
+  harness.doRowBuy(C, null, { mint: C, priceSol: 0.000064, priceUsd: 0.0064 }, {
+    queuedAt: race.now(),
+    amount: 0.1,
+  });
+  assert.deepEqual(
+    Array.from(harness.getRowBuyQueue(), (entry) => entry.address),
+    [C, C, C, C],
+  );
+
+  race.releasePairIdentity();
+  race.releaseB();
+  race.releaseC();
+  await first;
+  for (let i = 0; i < 16; i++) await race.advance(1);
+  await waitFor(() => harness.getState().journal.length === 5);
+  assert.equal(harness.getRowBuyQueue().length, 0);
+  assert.ok(!race.debugLines.some((line) => line.includes('outcome=refused')));
+});
+
 test('the row-buy queue holds three taps and refuses the fifth tap', async () => {
   const race = bootRace({ holdPairIdentity: true });
   const { harness } = race;

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -648,6 +648,31 @@ test('a fresh row tick without SOL/USD falls through rather than guessing', asyn
   assert.ok(Math.abs(harness.getState().journal[0].mcap - 3.2) < 1e-9);
 });
 
+test('a fresh row tick with a hung SOL/USD lookup falls through to the resolver', async () => {
+  const race = bootRace({ holdSolUsd: true });
+  const { harness } = race;
+
+  harness.noteRowPrice({
+    mint: B,
+    candidates: [{ unit: 'usd', value: 0.0032 }],
+    mcap: 3200,
+  });
+  const buy = harness.doRowBuy(B);
+  await waitFor(() => race.isSolUsdRequested());
+  await race.advance(2_001);
+  await waitFor(() => race.isBIdentityRequested());
+  race.releaseB();
+  await buy;
+
+  assert.equal(
+    race.messages.filter((message) => message.type === 'pt_resolve').length,
+    1,
+    'a hung row-feed conversion must fall through to resolver pricing',
+  );
+  assert.equal(harness.getState().journal.length, 1, 'the timed-out tap still fills');
+  assert.equal(harness.getRowBuyInFlight(), false, 'the row-buy latch is released');
+});
+
 test('a row-props quote fills at the tapped price without resolver or identity lookup', async () => {
   const race = bootRace();
   const { harness } = race;

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -38,11 +38,6 @@ function bootRace(options = {}) {
   let cIdentityRequested = false;
   let releaseCIdentity;
   const cIdentity = new Promise((resolve) => { releaseCIdentity = resolve; });
-  let aResolvePending = options.holdResolveA === true;
-  let aResolveRequested = false;
-  let aResolveRequestCount = 0;
-  let releaseAResolve;
-  const aResolve = new Promise((resolve) => { releaseAResolve = resolve; });
   let solUsdPending = options.holdSolUsd === true;
   let solUsdRequested = false;
   let releaseSolUsd;
@@ -144,11 +139,6 @@ function bootRace(options = {}) {
   function sendMessage(payload) {
     messages.push(payload);
     if (payload.type === 'pt_resolve') {
-      if (payload.address === A) {
-        aResolveRequested = true;
-        aResolveRequestCount += 1;
-        return aResolvePending ? aResolve : Promise.resolve(null);
-      }
       if (payload.address === B) {
         if (options.unpricedB) return Promise.resolve(null);
         return Promise.resolve({
@@ -323,22 +313,6 @@ function bootRace(options = {}) {
     storage,
     isBIdentityRequested: () => bIdentityRequested,
     isCIdentityRequested: () => cIdentityRequested,
-    isAResolveRequested: () => aResolveRequested,
-    getAResolveRequestCount: () => aResolveRequestCount,
-    releaseAResolve() {
-      aResolvePending = false;
-      releaseAResolve({
-        mint: A,
-        pairAddress: null,
-        symbol: 'A',
-        name: 'Token A',
-        priceNative: 1,
-        priceUsd: 100,
-        mcap: 100_000,
-        priceSource: 'resolver',
-      });
-    },
-    setHoldResolveA(value) { aResolvePending = value; },
     releaseB() {
       bIdentityPending = false;
       releaseBIdentity({ mint: B });
@@ -689,56 +663,6 @@ test('a superseded direct row buy does not commit after watchdog release', async
   assert.equal(harness.getState().journal.length, 0,
     'a watchdog-superseded direct operation must not commit');
   assert.equal(harness.getRowBuyInFlight(), false);
-});
-
-test('a superseded armed flush stays armed for a later retry', async () => {
-  const race = bootRace({ holdSolUsd: true });
-  const { harness } = race;
-
-  await harness.doRowBuy(A);
-  assert.ok(harness.getRowArmed(), 'A should be armed before the competing click');
-  race.setHoldResolveA(true);
-
-  const competing = harness.doRowBuy(PAIR, null, {
-    mint: B,
-    pair: PAIR,
-    priceSol: 0.000032,
-    priceUsd: 0.0032,
-  });
-  await waitFor(() => race.isSolUsdRequested());
-  const startedAt = harness.getRowBuyInFlightAt();
-
-  const aResolveRequests = race.getAResolveRequestCount();
-  harness.noteRowPrice({
-    mint: A,
-    candidates: [{ unit: 'usd', value: 100 }],
-    symbol: 'A',
-    name: 'Token A',
-  });
-  await waitFor(() => race.getAResolveRequestCount() > aResolveRequests);
-
-  await harness.enableOverlay();
-  race.setNow(startedAt + 20_001);
-  await race.advance(1);
-  race.releaseSolUsd();
-  await competing;
-  race.releaseAResolve();
-  await waitFor(() => !harness.getRowArmedFlushing());
-
-  assert.equal(harness.getState().journal.length, 0,
-    'the superseded armed flush must not commit');
-  assert.equal(harness.getRowArmed().address, A,
-    'the superseded armed intent remains available for retry');
-
-  harness.noteRowPrice({
-    mint: A,
-    candidates: [{ unit: 'usd', value: 100 }],
-    symbol: 'A',
-    name: 'Token A',
-  });
-  await waitFor(() => harness.getState().journal.length === 1);
-  assert.equal(harness.getState().journal[0].mint, A,
-    'the retained armed intent commits on a later wake');
 });
 
 test('a coherent row-props quote fills when SOL/USD lookup hangs', async () => {

--- a/extension/test/rowbuyrace.test.js
+++ b/extension/test/rowbuyrace.test.js
@@ -13,9 +13,12 @@ const vm = require('node:vm');
 const ROOT = path.join(__dirname, '..');
 const CONTENT = fs.readFileSync(path.join(ROOT, 'content.js'), 'utf8');
 const ENGINE = fs.readFileSync(path.join(ROOT, 'engine.js'), 'utf8');
+const QUOTE = fs.readFileSync(path.join(ROOT, 'quote.js'), 'utf8');
+const SITES = fs.readFileSync(path.join(ROOT, 'sites.js'), 'utf8');
 
 const A = 'A'.repeat(32);
 const B = 'B'.repeat(32);
+const C = 'C'.repeat(32);
 
 function bootRace() {
   let clock = Date.now();
@@ -24,14 +27,82 @@ function bootRace() {
     static now() { return clock; }
   }
   const listeners = new Map();
+  const timers = [];
   const storage = {};
   let bIdentityPending = true;
   let bIdentityRequested = false;
   let releaseBIdentity;
   const bIdentity = new Promise((resolve) => { releaseBIdentity = resolve; });
+  let cIdentityPending = true;
+  let cIdentityRequested = false;
+  let releaseCIdentity;
+  const cIdentity = new Promise((resolve) => { releaseCIdentity = resolve; });
   const messages = [];
   let settings;
   let initialState;
+
+  function scheduleTimer(fn, ms, every) {
+    timers.push({ fn, at: clock + (ms || 0), every: every || 0, dead: false });
+    return timers.length;
+  }
+
+  function clearTimer(id) {
+    if (timers[id - 1]) timers[id - 1].dead = true;
+  }
+
+  async function advance(ms, step) {
+    step = step || 100;
+    for (let left = ms; left > 0; left -= step) {
+      clock += Math.min(step, left);
+      for (const timer of timers) {
+        if (timer.dead || timer.at > clock) continue;
+        if (timer.every) timer.at = clock + timer.every;
+        else timer.dead = true;
+        timer.fn();
+      }
+      for (let i = 0; i < 8; i++) await Promise.resolve();
+    }
+  }
+
+  const nodesById = {};
+  function makeNode(tag) {
+    return {
+      tag,
+      id: '',
+      style: { setProperty() {}, removeProperty() {} },
+      dataset: {},
+      className: '',
+      classList: { add() {}, remove() {}, toggle() {}, contains() { return false; } },
+      children: [],
+      get childNodes() { return this.children; },
+      appendChild(child) { this.children.push(child); return child; },
+      querySelector() { return makeNode('div'); },
+      querySelectorAll() { return []; },
+      remove() {},
+      addEventListener() {},
+      removeEventListener() {},
+      setAttribute() {},
+      getAttribute() { return null; },
+      getBoundingClientRect() { return { top: 0, left: 0, right: 0, width: 0, height: 0 }; },
+      attachShadow() { return shadowRoot; },
+      focus() {},
+      set innerHTML(value) { this._html = value; },
+      get innerHTML() { return this._html || ''; },
+      textContent: '',
+      offsetWidth: 1,
+    };
+  }
+  const shadowRoot = {
+    set innerHTML(value) { this._html = value; },
+    get innerHTML() { return this._html || ''; },
+    getElementById(id) {
+      if (!nodesById[id]) nodesById[id] = makeNode('div');
+      return nodesById[id];
+    },
+    querySelector() { return null; },
+    querySelectorAll() { return []; },
+    appendChild() {},
+  };
 
   const win = {
     PaperEngine: null,
@@ -42,8 +113,10 @@ function bootRace() {
     },
     PaperTrenchSites: {},
     PaperTrenchResolver: {},
-    PTChartMarkers: {},
+    PTChartMarkers: { destroyChartMarkers() {} },
     PTTitleFeed: {},
+    innerWidth: 1400,
+    innerHeight: 1050,
     addEventListener(type, fn) {
       if (!listeners.has(type)) listeners.set(type, []);
       listeners.get(type).push(fn);
@@ -73,6 +146,18 @@ function bootRace() {
           priceSource: 'resolver',
         });
       }
+      if (payload.address === C) {
+        return Promise.resolve({
+          mint: C,
+          pairAddress: null,
+          symbol: 'C',
+          name: 'Token C',
+          priceNative: 1,
+          priceUsd: 100,
+          mcap: 100_000,
+          priceSource: 'resolver',
+        });
+      }
       return Promise.resolve(null);
     }
     if (payload.type === 'pt_onchain_prewatch') {
@@ -80,6 +165,10 @@ function bootRace() {
       if (address === B) {
         bIdentityRequested = true;
         return bIdentityPending ? bIdentity : Promise.resolve({ mint: B });
+      }
+      if (address === C) {
+        cIdentityRequested = true;
+        return cIdentityPending ? cIdentity : Promise.resolve({ mint: C });
       }
       if (address === A) return Promise.resolve({ mint: A });
       return Promise.resolve(null);
@@ -93,19 +182,15 @@ function bootRace() {
   const document = {
     readyState: 'loading',
     hidden: false,
-    body: null,
+    body: makeNode('body'),
     documentElement: {},
     addEventListener(type, fn) {
       if (!listeners.has(`document:${type}`)) listeners.set(`document:${type}`, []);
       listeners.get(`document:${type}`).push(fn);
     },
     removeEventListener() {},
-    createElement: () => ({
-      style: {},
-      classList: { add() {}, remove() {}, toggle() {} },
-      appendChild() {},
-      addEventListener() {},
-    }),
+    createElement: (tag) => makeNode(tag),
+    getElementById: () => null,
     querySelector: () => null,
     querySelectorAll: () => [],
   };
@@ -169,16 +254,18 @@ function bootRace() {
     ResizeObserver: function () { this.observe = () => {}; this.disconnect = () => {}; },
     NodeFilter: { SHOW_TEXT: 4 },
     fetch: () => Promise.resolve({ ok: false, status: 404, json: async () => ({}) }),
-    setTimeout: () => 1,
-    clearTimeout() {},
-    setInterval: () => 1,
-    clearInterval() {},
+    setTimeout: (fn, ms) => scheduleTimer(fn, ms),
+    clearTimeout: clearTimer,
+    setInterval: (fn, ms) => scheduleTimer(fn, ms, ms),
+    clearInterval: clearTimer,
     requestAnimationFrame: (fn) => { fn(); return 1; },
     cancelAnimationFrame() {},
     performance: { now: () => 1 },
   };
   vm.createContext(sandbox);
   vm.runInContext(ENGINE, sandbox, { filename: 'engine.js' });
+  vm.runInContext(QUOTE, sandbox, { filename: 'quote.js' });
+  vm.runInContext(SITES, sandbox, { filename: 'sites.js' });
   win.PaperEngine = sandbox.window.PaperEngine;
   settings = win.PaperEngine.defaultSettings();
   settings.balanceStartSol = 100;
@@ -194,10 +281,14 @@ function bootRace() {
     doRowBuy,
     noteRowPrice,
     flushRowArmed,
+    enableOverlay,
     getState: () => state,
     setSite: (next) => { site = next; },
     getRowArmed: () => rowArmed,
     getRowArmedFlushing: () => rowArmedFlushing,
+    getRowBuyInFlight: () => rowBuyInFlight,
+    getRowBuyInFlightAt: () => rowBuyInFlightAt,
+    getRowBuyOwner: () => rowBuyOwner,
   };
 `
     + CONTENT.slice(end);
@@ -209,12 +300,18 @@ function bootRace() {
     harness,
     storage,
     isBIdentityRequested: () => bIdentityRequested,
+    isCIdentityRequested: () => cIdentityRequested,
     releaseB() {
       bIdentityPending = false;
       releaseBIdentity({ mint: B });
     },
+    releaseC() {
+      cIdentityPending = false;
+      releaseCIdentity({ mint: C });
+    },
     messages,
     setNow(next) { clock = next; },
+    advance,
   };
 }
 
@@ -290,6 +387,50 @@ test('an armed row fill commits on its first available price without competition
 
   assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [A]);
   assert.equal(harness.getRowArmed(), null, 'a successful armed fill clears its intent');
+});
+
+test('a timed-out row buy cannot release a newer latch owner', async () => {
+  const race = bootRace();
+  const { harness } = race;
+
+  const first = harness.doRowBuy(B);
+  await waitFor(() => race.isBIdentityRequested());
+  const firstAt = harness.getRowBuyInFlightAt();
+  const firstOwner = harness.getRowBuyOwner();
+
+  await harness.enableOverlay();
+  race.setNow(firstAt + 20_001);
+  await race.advance(1);
+  assert.equal(harness.getRowBuyInFlight(), false,
+    'the bar watchdog releases a buy that exceeds the latch age');
+  assert.notEqual(harness.getRowBuyOwner(), firstOwner,
+    'the watchdog supersedes the timed-out operation');
+
+  const second = harness.doRowBuy(C);
+  await waitFor(() => race.isCIdentityRequested());
+  const secondOwner = harness.getRowBuyOwner();
+  assert.equal(harness.getRowBuyInFlight(), true, 'the second buy acquires the freed latch');
+  assert.notEqual(secondOwner, firstOwner, 'the second buy has a new generation');
+
+  race.releaseB();
+  await first;
+  assert.equal(harness.getRowBuyInFlight(), true,
+    'the first buy finishing cannot clear the second buy latch');
+  assert.equal(harness.getRowBuyOwner(), secondOwner,
+    'the second buy remains the latch owner');
+
+  await harness.doRowBuy(A);
+  assert.equal(harness.getRowBuyInFlight(), true,
+    'a third click is refused while the second buy remains in flight');
+  assert.equal(harness.getRowBuyOwner(), secondOwner,
+    'the refused third click cannot take ownership');
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [B],
+    'the first fill may finish, but the newer held operation stays exclusive');
+
+  race.releaseC();
+  await second;
+  assert.deepEqual(Array.from(harness.getState().journal, (trade) => trade.mint), [C, B],
+    'both original intents eventually commit exactly once');
 });
 
 test('a priced row click still commits without an armed intent', async () => {

--- a/extension/test/rowchippressidentity.test.js
+++ b/extension/test/rowchippressidentity.test.js
@@ -275,7 +275,7 @@ test('a refusal emits no busy state and uses the refusal bridge message', () => 
   assert.match(click, /const decision = rowChipTapDecision\(entry, currentRowAddress\(entry\), Date\.now\(\)\)/);
   assert.match(click, /entry\.pressedAt = 0;\s*\n\s*entry\.pressedAddress = null;/,
     'every click decision must consume the press authorization');
-  assert.match(click, /if \(decision\.address\) \{[\s\S]*chip\.classList\.add\('busy'\)[\s\S]*emit\('row-buy', \{ address: decision\.address \}\)/);
+  assert.match(click, /if \(decision\.address\) \{[\s\S]*chip\.classList\.add\('busy'\)[\s\S]*emit\('row-buy', \{[\s\S]*address: decision\.address,[\s\S]*quote: typeof rowQuoteFromFiber/s);
   const refusalStart = click.indexOf("else {\n          emit('row-buy-refused'");
   assert.ok(refusalStart >= 0, 'refusal branch must emit row-buy-refused');
   assert.doesNotMatch(click.slice(refusalStart), /classList\.add\('busy'\)/,

--- a/extension/test/rowfillaccuracy.test.js
+++ b/extension/test/rowfillaccuracy.test.js
@@ -91,8 +91,8 @@ test('a first buy with no position anchors on the row\'s own print', () => {
   const body = bodyOf('async function rowPrintVouchesFirstBuy(');
   assert.match(body, /if \(posAnchor\) return true/,
     'an existing position keeps the F-56 anchor and skips this gate');
-  assert.match(body, /data\.priceSource === 'row-feed' \|\| data\.priceSource === 'row-onchain'/,
-    'row-fed and chain-fed candidates are exempt (the print IS their source)');
+  assert.match(body, /data\.priceSource === 'row-feed' \|\| data\.priceSource === 'row-props'\s*\n\s*\|\| data\.priceSource === 'row-onchain'/,
+    'page-row and chain-fed candidates are exempt (the print IS their source)');
   assert.match(body, /recentRowPrices\.get\(data\.pairAddress\)/,
     'the row print is looked up by every identity');
   assert.match(body, /> 2/, 'an aggregator diverging >2x from the print needs a witness');

--- a/extension/test/rowfillaccuracy.test.js
+++ b/extension/test/rowfillaccuracy.test.js
@@ -47,7 +47,7 @@ test('the row-price override tries every identity the token answers to', () => {
 });
 
 test('the armed-row flush override tries every identity too', () => {
-  const body = bodyOf('async function flushRowArmed()');
+  const body = bodyOf('async function flushRowArmed(preferAddress)');
   const override = body.slice(
     body.indexOf('The screener\'s own realtime price wins'),
     body.indexOf('await fillRowBuy(armed.address, data, armed.amount)')
@@ -76,7 +76,7 @@ test('a row-tick price override rescales the market cap with it', () => {
 });
 
 test('the armed-row flush override rescales the cap too', () => {
-  const body = bodyOf('async function flushRowArmed()');
+  const body = bodyOf('async function flushRowArmed(preferAddress)');
   const override = body.slice(
     body.indexOf('The screener\'s own realtime price wins'),
     body.indexOf('await fillRowBuy(armed.address, data, armed.amount)')

--- a/extension/test/rowprops.test.js
+++ b/extension/test/rowprops.test.js
@@ -150,6 +150,40 @@ test('a GMGN row proves its bare price is USD from supply and market cap', () =>
   });
 });
 
+test('an explicit mint wins over an unrelated generic address', () => {
+  const row = makeRow({
+    mint: A,
+    address: B,
+    pairAddress: PAIR,
+    priceSol: 0.000032,
+  });
+  assert.deepEqual(JSON.parse(JSON.stringify(quoteExtractor()(row, A))), {
+    mint: A,
+    pair: PAIR,
+    priceSol: 0.000032,
+    priceUsd: null,
+    mcapUsd: null,
+    supply: null,
+  });
+});
+
+test('an explicit token address wins over an unrelated generic address', () => {
+  const row = makeRow({
+    tokenAddress: A,
+    address: B,
+    pairAddress: PAIR,
+    priceSol: 0.000032,
+  });
+  assert.deepEqual(JSON.parse(JSON.stringify(quoteExtractor()(row, A))), {
+    mint: A,
+    pair: PAIR,
+    priceSol: 0.000032,
+    priceUsd: null,
+    mcapUsd: null,
+    supply: null,
+  });
+});
+
 test('a GMGN bare price without its USD cap is rejected', () => {
   assert.equal(quoteExtractor()(makeRow({
     address: A,

--- a/extension/test/rowprops.test.js
+++ b/extension/test/rowprops.test.js
@@ -130,6 +130,51 @@ test('unitless prices and percentage changes never become row quotes', () => {
   }), A), null);
 });
 
+test('a GMGN row proves its bare price is USD from supply and market cap', () => {
+  const row = makeRow({
+    data: {
+      address: A,
+      pool_address: PAIR,
+      price: 0.0000028749178,
+      usd_market_cap: 2874.92,
+      total_supply: 1_000_000_000,
+    },
+  });
+  assert.deepEqual(JSON.parse(JSON.stringify(quoteExtractor()(row, A))), {
+    mint: A,
+    pair: PAIR,
+    priceSol: null,
+    priceUsd: 0.0000028749178,
+    mcapUsd: 2874.92,
+    supply: 1_000_000_000,
+  });
+});
+
+test('a GMGN bare price without its USD cap is rejected', () => {
+  assert.equal(quoteExtractor()(makeRow({
+    address: A,
+    price: 0.0000028749178,
+    total_supply: 1_000_000_000,
+  }), A), null);
+});
+
+test('a GMGN bare price that disagrees with supply and cap is rejected', () => {
+  assert.equal(quoteExtractor()(makeRow({
+    address: A,
+    price: 0.00001,
+    usd_market_cap: 2874.92,
+    total_supply: 1_000_000_000,
+  }), A), null);
+});
+
+test('Padre dev funding amounts never become row prices', () => {
+  assert.equal(quoteExtractor()(makeRow({
+    tokenAddress: A,
+    marketAddress: PAIR,
+    devFundTxnSolAmount: 0.9,
+  }), A), null);
+});
+
 test('the row-buy bridge message carries the quote from the tapped row', () => {
   assert.match(
     BRIDGE,

--- a/extension/test/rowprops.test.js
+++ b/extension/test/rowprops.test.js
@@ -100,6 +100,18 @@ test('a richer neighboring fiber cannot replace the tapped row record', () => {
   assert.equal(quote.priceUsd, null);
 });
 
+test('a parent price is not inherited by a descendant identity record', () => {
+  const row = makeRow({
+    priceSol: 9,
+    child: { tokenAddress: A, pairAddress: PAIR },
+  });
+  assert.equal(
+    quoteExtractor()(row, A),
+    null,
+    'identity and price must come from the same coherent record',
+  );
+});
+
 test('unitless prices and percentage changes never become row quotes', () => {
   const extract = quoteExtractor();
   assert.equal(extract(makeRow({

--- a/extension/test/rowprops.test.js
+++ b/extension/test/rowprops.test.js
@@ -45,6 +45,7 @@ function makeRow(memoizedProps, memoizedState) {
 test('a tapped Axiom row yields its coherent mint, pair, SOL and USD quote', () => {
   const row = makeRow(
     {
+      tokenAddress: A,
       tokenPriceUsd: 0.003295168220388057,
       marketCapUsd: 3244624.7223963863,
       row: {
@@ -102,7 +103,8 @@ test('a richer neighboring fiber cannot replace the tapped row record', () => {
 
 test('a parent price is not inherited by a descendant identity record', () => {
   const row = makeRow({
-    priceSol: 9,
+    tokenPriceUsd: 900,
+    marketCapUsd: 900_000,
     child: { tokenAddress: A, pairAddress: PAIR },
   });
   assert.equal(

--- a/extension/test/rowprops.test.js
+++ b/extension/test/rowprops.test.js
@@ -1,0 +1,124 @@
+/* Axiom row-props quotes must come from one coherent, tapped row record.
+ *
+ * The bridge walks the tapped row's React fiber only at click time. These
+ * tests drive the shipped extractor against the record shape captured from
+ * the logged-in Axiom board, including its separate USD props candidate.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const BRIDGE = fs.readFileSync(path.join(ROOT, 'price-bridge.js'), 'utf8');
+const A = 'A'.repeat(32);
+const B = 'B'.repeat(32);
+const PAIR = 'P'.repeat(32);
+
+function quoteExtractor() {
+  const start = BRIDGE.indexOf('function rowQuoteFromFiber(');
+  const end = BRIDGE.indexOf('function findRowContainer(', start);
+  assert.ok(start !== -1 && end > start, 'rowQuoteFromFiber must ship in the bridge');
+  const context = {
+    BASE58_RE: /^[1-9A-HJ-NP-Za-km-z]{32,44}$/,
+    numberValue(value) {
+      if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+      if (typeof value === 'string' && value.length <= 64) {
+        const number = Number(value.replace(/[$,\s]/g, ''));
+        return Number.isFinite(number) ? number : null;
+      }
+      return null;
+    },
+  };
+  vm.createContext(context);
+  vm.runInContext(BRIDGE.slice(start, end), context, { filename: 'price-bridge.js' });
+  return context.rowQuoteFromFiber;
+}
+
+function makeRow(memoizedProps, memoizedState) {
+  const row = {};
+  row.__reactFiber$test = { memoizedProps, memoizedState };
+  return row;
+}
+
+test('a tapped Axiom row yields its coherent mint, pair, SOL and USD quote', () => {
+  const row = makeRow(
+    {
+      tokenPriceUsd: 0.003295168220388057,
+      marketCapUsd: 3244624.7223963863,
+      row: {
+        tokenAddress: A,
+        pairAddress: PAIR,
+        priceSol: 0.00003229290690305818,
+        marketCapSol: 31797.576660097864,
+        supply: 984661329.98038,
+      },
+    },
+    {},
+  );
+  const quote = quoteExtractor()(row, A);
+
+  assert.deepEqual(JSON.parse(JSON.stringify(quote)), {
+    mint: A,
+    pair: PAIR,
+    priceSol: 0.00003229290690305818,
+    priceUsd: 0.003295168220388057,
+    mcapUsd: 3244624.7223963863,
+    supply: 984661329.98038,
+  });
+});
+
+test('a record for another token is discarded by the tapped identity guard', () => {
+  const row = makeRow({
+    tokenAddress: B,
+    pairAddress: PAIR,
+    priceSol: 1,
+    tokenPriceUsd: 100,
+  });
+  assert.equal(quoteExtractor()(row, A), null);
+});
+
+test('a richer neighboring fiber cannot replace the tapped row record', () => {
+  const row = {};
+  row.__reactFiber$test = {
+    memoizedProps: { tokenAddress: A, priceSol: 0.1 },
+    sibling: {
+      memoizedProps: {
+        tokenAddress: B,
+        pairAddress: PAIR,
+        priceSol: 9,
+        tokenPriceUsd: 900,
+        marketCapUsd: 900_000,
+        supply: 100_000,
+      },
+    },
+  };
+  const quote = quoteExtractor()(row, A);
+  assert.equal(quote.mint, A);
+  assert.equal(quote.priceSol, 0.1);
+  assert.equal(quote.priceUsd, null);
+});
+
+test('unitless prices and percentage changes never become row quotes', () => {
+  const extract = quoteExtractor();
+  assert.equal(extract(makeRow({
+    tokenAddress: A,
+    pairAddress: PAIR,
+    price: 1,
+    price1minChange: 2,
+    price24h: 3,
+  }), A), null);
+  assert.equal(extract(makeRow({
+    tokenAddress: A,
+    price1minChange: 1,
+    price24hChange: 2,
+  }), A), null);
+});
+
+test('the row-buy bridge message carries the quote from the tapped row', () => {
+  assert.match(
+    BRIDGE,
+    /emit\('row-buy',\s*\{\s*address: entry\.address,\s*quote: rowQuoteFromFiber\(entry\.row, entry\.address\),/s,
+  );
+});

--- a/extension/test/rowprops.test.js
+++ b/extension/test/rowprops.test.js
@@ -314,6 +314,6 @@ test('Padre dev funding amounts never become row prices', () => {
 test('the row-buy bridge message carries the quote from the tapped row', () => {
   assert.match(
     BRIDGE,
-    /emit\('row-buy',\s*\{\s*address: entry\.address,\s*quote: rowQuoteFromFiber\(entry\.row, entry\.address\),/s,
+    /emit\('row-buy',\s*\{\s*address: decision\.address,\s*quote: typeof rowQuoteFromFiber/s,
   );
 });

--- a/extension/test/rowprops.test.js
+++ b/extension/test/rowprops.test.js
@@ -42,6 +42,18 @@ function makeRow(memoizedProps, memoizedState) {
   return row;
 }
 
+function makeFiberChain(length, targetIndex, targetProps) {
+  const start = { memoizedProps: {} };
+  let fiber = start;
+  for (let index = 1; index <= length; index += 1) {
+    fiber.sibling = { memoizedProps: index === targetIndex ? targetProps : {} };
+    fiber = fiber.sibling;
+  }
+  const row = {};
+  row.__reactFiber$test = start;
+  return row;
+}
+
 test('a tapped Axiom row yields its coherent mint, pair, SOL and USD quote', () => {
   const row = makeRow(
     {
@@ -199,6 +211,96 @@ test('a GMGN bare price that disagrees with supply and cap is rejected', () => {
     usd_market_cap: 2874.92,
     total_supply: 1_000_000_000,
   }), A), null);
+});
+
+test('an Axiom row can combine bounded ancestor records for the tapped token', () => {
+  const start = {
+    tokenAddress: A,
+    pairAddress: PAIR,
+    priceSol: 0.000032,
+    tokenPriceUsd: 0.000032,
+    supply: 1_000_000_000,
+    tokenTicker: 'crap',
+    tokenName: 'dinosaur crap',
+  };
+  const row = makeRow(start);
+  let fiber = row.__reactFiber$test;
+  for (let up = 1; up <= 7; up += 1) {
+    fiber.return = { memoizedProps: up === 7
+      ? { row: { tokenAddress: A, marketCapUsd: 32_000 } }
+      : { row: { tokenAddress: A } } };
+    fiber = fiber.return;
+  }
+  assert.deepEqual(JSON.parse(JSON.stringify(quoteExtractor()(row, A))), {
+    mint: A,
+    pair: PAIR,
+    priceSol: 0.000032,
+    priceUsd: 0.000032,
+    mcapUsd: 32_000,
+    supply: 1_000_000_000,
+    symbol: 'crap',
+    name: 'dinosaur crap',
+  });
+});
+
+test('an ancestor record for another token cannot leak into the tapped row quote', () => {
+  const row = makeRow({ tokenAddress: A, priceSol: 0.1 });
+  row.__reactFiber$test.return = {
+    memoizedProps: {
+      row: { tokenAddress: B, priceSol: 9, marketCapUsd: 900_000, supply: 100_000 },
+    },
+  };
+  const quote = quoteExtractor()(row, A);
+  assert.equal(quote.mint, A);
+  assert.equal(quote.priceSol, 0.1);
+  assert.equal(quote.mcapUsd, null);
+});
+
+test('a GMGN record beyond 80 fibers is found within the 400-step bound', () => {
+  const row = makeFiberChain(220, 211, {
+    address: A,
+    pool_address: PAIR,
+    price: 0.000002,
+    usd_market_cap: 2_000,
+    total_supply: 1_000_000_000,
+  });
+  const quote = quoteExtractor()(row, A);
+  assert.equal(quote.mint, A);
+  assert.equal(quote.priceUsd, 0.000002);
+});
+
+test('a GMGN record beyond 400 fibers remains out of bounds', () => {
+  const row = makeFiberChain(420, 411, {
+    address: A,
+    pool_address: PAIR,
+    price: 0.000002,
+    usd_market_cap: 2_000,
+    total_supply: 1_000_000_000,
+  });
+  assert.equal(quoteExtractor()(row, A), null);
+});
+
+test('an incoherent USD cap is dropped while the coherent price remains', () => {
+  const quote = quoteExtractor()(makeRow({
+    tokenAddress: A,
+    priceSol: 0.000032,
+    tokenPriceUsd: 0.0032,
+    marketCapUsd: 6_400,
+    supply: 1_000_000,
+  }), A);
+  assert.equal(quote.priceUsd, 0.0032);
+  assert.equal(quote.mcapUsd, null);
+});
+
+test('symbol and name values that look like addresses are rejected', () => {
+  const quote = quoteExtractor()(makeRow({
+    tokenAddress: A,
+    priceSol: 0.000032,
+    symbol: B,
+    name: B,
+  }), A);
+  assert.equal(quote.symbol, undefined);
+  assert.equal(quote.name, undefined);
 });
 
 test('Padre dev funding amounts never become row prices', () => {

--- a/extension/test/rowprops.test.js
+++ b/extension/test/rowprops.test.js
@@ -218,7 +218,6 @@ test('an Axiom row can combine bounded ancestor records for the tapped token', (
     tokenAddress: A,
     pairAddress: PAIR,
     priceSol: 0.000032,
-    tokenPriceUsd: 0.000032,
     supply: 1_000_000_000,
     tokenTicker: 'crap',
     tokenName: 'dinosaur crap',
@@ -227,10 +226,11 @@ test('an Axiom row can combine bounded ancestor records for the tapped token', (
   let fiber = row.__reactFiber$test;
   for (let up = 1; up <= 7; up += 1) {
     fiber.return = { memoizedProps: up === 7
-      ? { row: { tokenAddress: A, marketCapUsd: 32_000 } }
+      ? { action: { props: { tokenAddress: A, tokenPriceUsd: 0.000032 } } }
       : { row: { tokenAddress: A } } };
     fiber = fiber.return;
   }
+  fiber.return = { memoizedProps: { row: { tokenAddress: A, marketCapUsd: 32_000 } } };
   assert.deepEqual(JSON.parse(JSON.stringify(quoteExtractor()(row, A))), {
     mint: A,
     pair: PAIR,

--- a/site/index.html
+++ b/site/index.html
@@ -117,7 +117,7 @@
   <span class="home-credits-kicker">proof</span>
   <span class="home-credits-item"><span class="home-credits-role">terminals</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="sites">15</b></span>
   <span class="home-credits-item"><span class="home-credits-role">invented prices</span><span class="home-credits-rule" aria-hidden="true"></span><b>0</b></span>
-  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2519</b></span>
+  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2524</b></span>
   <span class="home-credits-item"><span class="home-credits-role">local</span><span class="home-credits-rule" aria-hidden="true"></span><b>100%</b></span>
 </p>
 

--- a/site/index.html
+++ b/site/index.html
@@ -117,7 +117,7 @@
   <span class="home-credits-kicker">proof</span>
   <span class="home-credits-item"><span class="home-credits-role">terminals</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="sites">15</b></span>
   <span class="home-credits-item"><span class="home-credits-role">invented prices</span><span class="home-credits-rule" aria-hidden="true"></span><b>0</b></span>
-  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2513</b></span>
+  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2519</b></span>
   <span class="home-credits-item"><span class="home-credits-role">local</span><span class="home-credits-rule" aria-hidden="true"></span><b>100%</b></span>
 </p>
 

--- a/site/index.html
+++ b/site/index.html
@@ -117,7 +117,7 @@
   <span class="home-credits-kicker">proof</span>
   <span class="home-credits-item"><span class="home-credits-role">terminals</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="sites">15</b></span>
   <span class="home-credits-item"><span class="home-credits-role">invented prices</span><span class="home-credits-rule" aria-hidden="true"></span><b>0</b></span>
-  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2524</b></span>
+  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2527</b></span>
   <span class="home-credits-item"><span class="home-credits-role">local</span><span class="home-credits-rule" aria-hidden="true"></span><b>100%</b></span>
 </p>
 

--- a/site/index.html
+++ b/site/index.html
@@ -117,7 +117,7 @@
   <span class="home-credits-kicker">proof</span>
   <span class="home-credits-item"><span class="home-credits-role">terminals</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="sites">15</b></span>
   <span class="home-credits-item"><span class="home-credits-role">invented prices</span><span class="home-credits-rule" aria-hidden="true"></span><b>0</b></span>
-  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2457</b></span>
+  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2513</b></span>
   <span class="home-credits-item"><span class="home-credits-role">local</span><span class="home-credits-rule" aria-hidden="true"></span><b>100%</b></span>
 </p>
 

--- a/site/index.html
+++ b/site/index.html
@@ -117,7 +117,7 @@
   <span class="home-credits-kicker">proof</span>
   <span class="home-credits-item"><span class="home-credits-role">terminals</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="sites">15</b></span>
   <span class="home-credits-item"><span class="home-credits-role">invented prices</span><span class="home-credits-rule" aria-hidden="true"></span><b>0</b></span>
-  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2527</b></span>
+  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2531</b></span>
   <span class="home-credits-item"><span class="home-credits-role">local</span><span class="home-credits-rule" aria-hidden="true"></span><b>100%</b></span>
 </p>
 

--- a/site/news.html
+++ b/site/news.html
@@ -57,7 +57,7 @@
       <!-- 2299 = 2072 extension + 211 server + 16 bot. Preflight recomputes
            data-check="tests" and data-check="defects" and fails the release
            if either disagrees. Update them together with that check. -->
-      <span><b data-check="tests">2527</b> tests passing</span>
+      <span><b data-check="tests">2531</b> tests passing</span>
       <span><b data-check="defects">195</b> defects closed</span>
       <span><b>0</b> numbers invented</span>
     </div>

--- a/site/news.html
+++ b/site/news.html
@@ -57,7 +57,7 @@
       <!-- 2299 = 2072 extension + 211 server + 16 bot. Preflight recomputes
            data-check="tests" and data-check="defects" and fails the release
            if either disagrees. Update them together with that check. -->
-      <span><b data-check="tests">2513</b> tests passing</span>
+      <span><b data-check="tests">2519</b> tests passing</span>
       <span><b data-check="defects">195</b> defects closed</span>
       <span><b>0</b> numbers invented</span>
     </div>

--- a/site/news.html
+++ b/site/news.html
@@ -57,7 +57,7 @@
       <!-- 2299 = 2072 extension + 211 server + 16 bot. Preflight recomputes
            data-check="tests" and data-check="defects" and fails the release
            if either disagrees. Update them together with that check. -->
-      <span><b data-check="tests">2457</b> tests passing</span>
+      <span><b data-check="tests">2513</b> tests passing</span>
       <span><b data-check="defects">195</b> defects closed</span>
       <span><b>0</b> numbers invented</span>
     </div>

--- a/site/news.html
+++ b/site/news.html
@@ -57,7 +57,7 @@
       <!-- 2299 = 2072 extension + 211 server + 16 bot. Preflight recomputes
            data-check="tests" and data-check="defects" and fails the release
            if either disagrees. Update them together with that check. -->
-      <span><b data-check="tests">2519</b> tests passing</span>
+      <span><b data-check="tests">2524</b> tests passing</span>
       <span><b data-check="defects">195</b> defects closed</span>
       <span><b>0</b> numbers invented</span>
     </div>

--- a/site/news.html
+++ b/site/news.html
@@ -57,7 +57,7 @@
       <!-- 2299 = 2072 extension + 211 server + 16 bot. Preflight recomputes
            data-check="tests" and data-check="defects" and fails the release
            if either disagrees. Update them together with that check. -->
-      <span><b data-check="tests">2524</b> tests passing</span>
+      <span><b data-check="tests">2527</b> tests passing</span>
       <span><b data-check="defects">195</b> defects closed</span>
       <span><b>0</b> numbers invented</span>
     </div>


### PR DESCRIPTION
## Summary

Two taps, two fills. In the live run I tapped two Axiom rows 267 ms apart: two `row-buy` events fired, one trade was booked, and the second tap produced nothing on screen — `doRowBuy` opened with `if (rowBuyInFlight) return toast('Row buy already in progress…')`, and a toast that says "already in progress" reads as "your tap did nothing". Both taps were deliberate intents, so both must fill.

A tap arriving while a fill is in flight now queues instead of being thrown away:

```js
if (rowBuyInFlight || (!fromQueue && rowBuyQueue.length)) {
  if (!fromQueue && rowBuyQueue.length >= 3) return toast('Row buy queue full — tap again after current buys finish');
  const entry = { address, button, quote: rowQuote, amount, at: fromQueue ? queuedAt : Date.now() };
  fromQueue ? rowBuyQueue.unshift(entry) : rowBuyQueue.push(entry);
  toast('Queued — filling after the current buy');
  return scheduleRowBuyDrain();
}
```

Each entry carries **the quote and the preset amount captured at its own tap time**, so a queued fill books what that row printed when the user tapped it, at the size that was selected then, and can never inherit the identity of the row that filled ahead of it. A fresh tap landing in the window between a latch release and the zero-delay drain callback joins the back of the queue rather than jumping it, and an already-accepted entry that finds the latch retaken goes back to the *front* and is never refused by the capacity check (`!fromQueue`), which is the difference between "your tap is queued" and "your tap vanished". The queue drains after every latch release — normal, armed flush, stuck-latch watchdog — asynchronously, never recursively; an entry that ages past 5 s is dropped with `Queued row buy expired — no fill at the tapped price` rather than filling at a price the user looked at 10 seconds ago; and the queue clears both on context teardown and on `disableOverlay()`, so a queued tap can't fire into a disabled overlay.

The exactly-once guarantees are untouched: each drained entry runs the ordinary `doRowBuy` path and takes its own latch generation, so the ownership check at the mutation boundary still blocks a superseded operation.

**A tap that commits nothing no longer reports success.** From the live log:

```
PaperTrench: row-buy source=row-props outcome=done quote=1ms guard+state=-ms commit=-ms total=56134ms
```

No journal entry, no toast, no position: the stuck-latch watchdog released the latch at its 20 s bound, a later tap bumped `rowBuyOwner`, and the original operation then failed its ownership check inside `withState` and returned `null` in silence. The protection is right, the silence isn't — that path now toasts `That tap was released after taking too long — nothing was filled` and logs `outcome=superseded`.

**An accepted tap can no longer be discarded by the next one, and a chip no longer goes idle while work is pending.** Two review findings that are the same class of defect as the one above. The no-price arm branch wrote a *single* global slot, so two queued taps that both failed to price meant the second silently overwrote the first intent and its service-worker mirror; armed intents are now a bounded FIFO of 3 with per-entry timestamps and TTLs, deduped by address, refused with a toast at the bound, expiring individually, and mirrored into the SW as a list that clears one address at a time (a legacy single-object mirror still reads). Separately, `doRowBuy(...).finally(() => sendPadreMarker('row-buy-done'))` treated *admission* to the queue as completion, so the chip stopped looking busy while two fills were still outstanding — the done-signal is now sent only when nothing is in flight, queued or armed, from every terminal path including the watchdog (DEFECT F-08's stuck-forever chip is revert-proved).

**Padre books the row's ticker.** A Padre row-feed fill showed `ASEo…pump` as its symbol because the tick payload carried no ticker at all. The Padre branch of the bridge now forwards `tokenTicker`/`tokenName` taken **from the same decoded object that carried the accepted price** (same validation as the row-props path: length bounds, Base58-shaped values rejected), which `noteRowPrice` and `rowLivePrice` already knew how to pass through.

**Timing instrumentation, because I still don't know where the fill time goes.** The live run measured a ~3.4 s tap-to-fill on a first fill per site and 19–56 s under multi-tab load, all of it inside one bucket that spans the mutation-chain wait, `reloadState`, the honesty gates, the engine mutation and up to five `pt_state_commit` rounds. The buckets are now non-overlapping and name the CAS cost:

```
PaperTrench: row-buy source=row-props outcome=done quote=41ms guard+state=180ms commit=12ms total=3251ms fill->state=2890ms persist=169ms attempts=2
```

Local only, one `console.debug` line per tap, no settings, no telemetry.

## Testing

`cd extension && node --test`: 2,214 passed. `scripts/preflight.sh`: 2,513 across extension/server/bot. New coverage in rowbuyrace.test.js: a second tap fills too and in order, each at its own quote and its own tap-time amount; the fourth tap is refused while three are pending, but a re-queued accepted entry is not; a TTL-expired entry is dropped and the queue continues; a drain attempted while the latch is held keeps the entry; the watchdog release does not strand a queued tap; `disableOverlay()` cancels queued taps; an owner-token bump mid-flight toasts once and writes nothing. padrebridge.test.js covers ticker/name forwarded from the price-bearing object, a ticker on another mint's record not leaking, and an address-shaped ticker rejected. Cap and drain guards revert-proved.

Stacked on #104. Live evidence for the whole stack, including the three defects it exposed, is in the run report on this PR; the queue and timing fixes above postdate that build and still need their own live pass.

## Follow-up: the 5 s queue TTL is now real time

A queued tap only discovered it had expired inside `drainRowBuyQueue()`, and a drain only runs when `!rowBuyInFlight` — so behind a slow fill the live run reported expiry **7–21 s** after the tap while claiming a 5 s TTL, and the chip looked live for that whole stretch. A `rowBuyExpiryTimer` armed at `min(entry.at) + TTL` and rescheduled on every queue mutation now sweeps expired entries in tap order, emitting one `outcome=expired` line each whose `total` reads ~5000 ms. `sendRowBuyDoneIfIdle()` still gates on `rowBuyWorkOutstanding()`, so an expiry while a fill is genuinely in flight does not release the chip. Cleared with the queue on teardown and overlay disable.

`bash scripts/preflight.sh`: 2,531 passed.


Link to Devin session: https://app.devin.ai/sessions/b676704d774f4aa099ba7f31381b036f
Open in Devin Desktop: https://app.devin.ai/desktop/session/b676704d774f4aa099ba7f31381b036f?variant=devin
Requested by: @OnlyTerp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/papertrench/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->