### PR TITLE
fix(quote): stop a USDC-quoted pair's price from being marked as SOL

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -1514,6 +1514,12 @@
       if (!token || token.mint !== forMint) return;
       if (!fresh || !(fresh.priceNative > 0)) return;
       if (fresh.mint && fresh.mint !== token.mint) return;
+      const freshRate = Number(fresh.solUsdAtResolve) > 0
+        ? Number(fresh.solUsdAtResolve)
+        : (Number(fresh.priceUsd) > 0 && Number(fresh.priceNative) > 0
+            ? Number(fresh.priceUsd) / Number(fresh.priceNative)
+            : 0);
+      if (freshRate > 0) token.solUsdAtResolve = freshRate;
       // F-61: a refresh re-quotes /tokens/<mint> — EVERY pool for this base
       // mint, including graduated bonding-era pairs. An initial resolve via
       // /pairs/<addr> carried only that one pool; adopt the full list so the
@@ -1542,8 +1548,7 @@
         && Number(token.priceNative) > 0
         && token.priceSource !== 'resolver';
       if (feedLive) {
-        const rate = Number(fresh.priceUsd) > 0 ? fresh.priceUsd / fresh.priceNative : null;
-        if (rate) token.priceUsd = token.priceNative * rate;
+        if (freshRate > 0) token.priceUsd = token.priceNative * freshRate;
         if (Number(fresh.mcap) > 0 && Number(fresh.priceUsd) > 0 && Number(token.priceUsd) > 0) {
           const supply = fresh.mcap / fresh.priceUsd;
           token.mcap = token.priceUsd * supply;

--- a/extension/content.js
+++ b/extension/content.js
@@ -1576,7 +1576,10 @@
             + ' from a collapsed pool (resolver refresh, ' + fresh.liquidityUsd
             + ' USD liq) F-55');
         } else {
-          E.markPosition(state, token.mint, fresh.priceNative, fresh.priceUsd);
+          E.markPosition(state, token.mint, fresh.priceNative, fresh.priceUsd, {
+            priceSource: fresh.priceSource,
+            pairAddress: fresh.pairAddress,
+          });
         }
       }
       maybeProfitAlert(token.mint);
@@ -2255,7 +2258,12 @@
       }
       for (const mint of Object.keys(livePositionPrices)) {
         const p = livePositionPrices[mint];
-        if (p && Number(p.priceNative) > 0) E.markPosition(state, mint, p.priceNative, p.priceUsd);
+        if (p && Number(p.priceNative) > 0) {
+          E.markPosition(state, mint, p.priceNative, p.priceUsd, {
+            priceSource: p.priceSource,
+            pairAddress: p.pairAddress,
+          });
+        }
       }
       if (remutate) await remutate();
     }
@@ -3027,7 +3035,12 @@
         }
         for (const mint of Object.keys(livePositionPrices)) {
           const p = livePositionPrices[mint];
-          if (p && Number(p.priceNative) > 0) E.markPosition(state, mint, p.priceNative, p.priceUsd);
+          if (p && Number(p.priceNative) > 0) {
+            E.markPosition(state, mint, p.priceNative, p.priceUsd, {
+              priceSource: p.priceSource,
+              pairAddress: p.pairAddress,
+            });
+          }
         }
       }
       // Heartbeat persistence must never surface as a pageerror: under
@@ -7361,10 +7374,18 @@
               + ' from a collapsed pool (' + quote.liquidityUsd + ' USD liq, '
               + pos55.lastPriceNative + ' -> ' + quote.priceNative + ') F-55');
           } else {
-            livePositionPrices[mint] = { priceNative: quote.priceNative, priceUsd: quote.priceUsd };
+            livePositionPrices[mint] = {
+              priceNative: quote.priceNative,
+              priceUsd: quote.priceUsd,
+              priceSource: quote.priceSource,
+              pairAddress: quote.pairAddress,
+            };
             // Mark the engine too, so peak/trough and equity stay truthful for
             // positions the user never has on screen.
-            E.markPosition(state, mint, quote.priceNative, quote.priceUsd);
+            E.markPosition(state, mint, quote.priceNative, quote.priceUsd, {
+              priceSource: quote.priceSource,
+              pairAddress: quote.pairAddress,
+            });
             changed = true;
           }
         }

--- a/extension/engine.js
+++ b/extension/engine.js
@@ -1076,11 +1076,28 @@
   /* ---------------- marks / analytics ---------------- */
 
   /** Mark an open position to the latest tick. Tracks peak/trough P&L. */
-  function markPosition(state, mint, priceNative, priceUsd) {
+  function markPosition(state, mint, priceNative, priceUsd, meta) {
     const pos = state.positions[mint];
     if (!pos) return null;
+    const previousPrice = Number(pos.lastPriceNative);
+    const previousSource = pos.lastPriceSource || 'unknown';
+    const previousPair = pos.lastPricePair || 'none';
+    const nextSource = meta && meta.priceSource ? meta.priceSource : previousSource;
+    const nextPair = meta && meta.pairAddress ? meta.pairAddress : previousPair;
+    if (previousPrice > 0 && Number(priceNative) > 0) {
+      const ratio = Number(priceNative) / previousPrice;
+      const magnitude = ratio >= 1 ? ratio : 1 / ratio;
+      if (magnitude >= 5) {
+        console.debug('PaperTrench: mark ' + mint + ' ' + priceNative
+          + ' (' + nextSource + ', pair ' + nextPair + ') is '
+          + magnitude + 'x from held ' + previousPrice + ' ('
+          + previousSource + ', pair ' + previousPair + ')');
+      }
+    }
     pos.lastPriceNative = priceNative;
     if (priceUsd) pos.lastPriceUsd = priceUsd;
+    if (meta && meta.priceSource) pos.lastPriceSource = meta.priceSource;
+    if (meta && meta.pairAddress) pos.lastPricePair = meta.pairAddress;
     const unrealized = pos.qty * priceNative - pos.costSol;
     if (unrealized > pos.peakPnlSol) pos.peakPnlSol = unrealized;
     if (unrealized < pos.troughPnlSol) pos.troughPnlSol = unrealized;

--- a/extension/quote.js
+++ b/extension/quote.js
@@ -180,7 +180,17 @@
       priceNative = priceUsd / rate;
       solUsdAtResolve = rate;
     } else {
-      priceNative = isQuote ? 1 / rawPrice : rawPrice;
+      const solQuoted = isQuote
+        ? sameAddress(base.address, WSOL_MINT)
+        : sameAddress(quote.address, WSOL_MINT);
+      if (solQuoted) {
+        priceNative = isQuote ? 1 / rawPrice : rawPrice;
+      } else {
+        const rate = Number(opts && opts.solUsd);
+        if (!usdOk || !(rate > 0)) return null;
+        priceNative = priceUsd / rate;
+        solUsdAtResolve = rate;
+      }
     }
     const mcap = Number(pair.marketCap != null ? pair.marketCap : pair.fdv);
 

--- a/extension/quote.js
+++ b/extension/quote.js
@@ -91,8 +91,8 @@
    * base, or where it is the quote against wrapped SOL. This stops a stablecoin
    * or unrelated token from being returned as the resolved identity.
    */
-  function pickBestPair(pairs, requestedAddress, chainId) {
-    if (!Array.isArray(pairs)) return null;
+  function rankPairs(pairs, requestedAddress, chainId) {
+    if (!Array.isArray(pairs)) return [];
     // Multichain: filter to the REQUESTED chain (default solana). On EVM
     // chains Dexscreener's priceNative is denominated in that chain's gas
     // token, not SOL — priceUsd is the number that is true everywhere, so
@@ -100,7 +100,7 @@
     const wantChain = chainId || 'solana';
     const usable = pairs.filter((p) => p && p.chainId === wantChain
       && (wantChain === 'solana' ? Number(p.priceNative) > 0 : Number(p.priceUsd) > 0));
-    if (!usable.length) return null;
+    if (!usable.length) return [];
 
     const requested = typeof requestedAddress === 'string'
       && (BASE58_RE.test(requestedAddress) || EVM_RE.test(requestedAddress))
@@ -115,19 +115,23 @@
         return false;
       });
       if (relevant.length) {
-        return relevant.reduce((best, p) => {
-          const a = Number((p.liquidity && p.liquidity.usd) || 0);
-          const b = Number((best.liquidity && best.liquidity.usd) || 0);
-          return a > b ? p : best;
+        return relevant.slice().sort((a, b) => {
+          const left = Number((a.liquidity && a.liquidity.usd) || 0);
+          const right = Number((b.liquidity && b.liquidity.usd) || 0);
+          return right - left;
         });
       }
     }
 
-    return usable.reduce((best, p) => {
-      const a = Number((p.liquidity && p.liquidity.usd) || 0);
-      const b = Number((best.liquidity && best.liquidity.usd) || 0);
-      return a > b ? p : best;
+    return usable.slice().sort((a, b) => {
+      const left = Number((a.liquidity && a.liquidity.usd) || 0);
+      const right = Number((b.liquidity && b.liquidity.usd) || 0);
+      return right - left;
     });
+  }
+
+  function pickBestPair(pairs, requestedAddress, chainId) {
+    return rankPairs(pairs, requestedAddress, chainId)[0] || null;
   }
 
   /**
@@ -225,8 +229,15 @@
   function tokenFromPayload(payload, fallbackAddress, opts) {
     if (!payload || typeof payload !== 'object') return null;
     const chainId = chainIdFor(opts && opts.chain);
-    const pair = payload.pair || pickBestPair(payload.pairs, fallbackAddress, chainId);
-    const token = normalizePair(pair, fallbackAddress, opts);
+    const pair = payload.pair;
+    const candidates = pair
+      ? [pair]
+      : rankPairs(payload.pairs, fallbackAddress, chainId);
+    let token = null;
+    for (const candidate of candidates) {
+      token = normalizePair(candidate, fallbackAddress, opts);
+      if (token) break;
+    }
     // F-61: surface EVERY pool the source lists for this base mint. A Pulse
     // row buy can commit under a bonding-era PAIR stand-in (the row-feed
     // fallback echoes the click address as the key); after graduation the
@@ -1306,15 +1317,23 @@
       if (foreign ? !(Number(pair.priceUsd) > 0) : !(Number(pair.priceNative) > 0)) continue;
       const mint = pair.baseToken && pair.baseToken.address;
       if (!mint) continue;
-      const prev = byMint.get(mint);
-      const liq = Number((pair.liquidity && pair.liquidity.usd) || 0);
-      const prevLiq = prev ? Number((prev.liquidity && prev.liquidity.usd) || 0) : -1;
-      if (!prev || liq > prevLiq) byMint.set(mint, pair);
+      if (!byMint.has(mint)) byMint.set(mint, []);
+      byMint.get(mint).push(pair);
     }
 
-    for (const [mint, pair] of byMint) {
-      const quote = normalizePair(pair, mint, opts);
-      if (quote) out[mint] = quote;
+    for (const [mint, candidates] of byMint) {
+      candidates.sort((a, b) => {
+        const left = Number((a.liquidity && a.liquidity.usd) || 0);
+        const right = Number((b.liquidity && b.liquidity.usd) || 0);
+        return right - left;
+      });
+      for (const candidate of candidates) {
+        const quote = normalizePair(candidate, mint, opts);
+        if (quote) {
+          out[mint] = quote;
+          break;
+        }
+      }
     }
     return out;
   }

--- a/extension/quote.js
+++ b/extension/quote.js
@@ -182,6 +182,7 @@
     const priceUsd = pair.priceUsd != null ? Number(pair.priceUsd) : null;
     const usdOk = Number.isFinite(priceUsd) && priceUsd > 0;
     let priceNative;
+    let normalizedPriceUsd = usdOk ? priceUsd : null;
     let solUsdAtResolve = null;
     if (foreign) {
       const rate = Number(opts && opts.solUsd);
@@ -194,6 +195,10 @@
         : sameAddress(quote.address, WSOL_MINT);
       if (solQuoted) {
         priceNative = isQuote ? 1 / rawPrice : rawPrice;
+        if (isQuote) {
+          normalizedPriceUsd = usdOk ? priceNative * priceUsd : null;
+          solUsdAtResolve = usdOk ? priceUsd : null;
+        }
       } else {
         const rate = Number(opts && opts.solUsd);
         if (!usdOk || !(rate > 0)) return null;
@@ -210,7 +215,7 @@
       symbol: token.symbol || null,
       name: token.name || token.symbol || null,
       priceNative,
-      priceUsd: usdOk ? priceUsd : null,
+      priceUsd: normalizedPriceUsd,
       mcap: Number.isFinite(mcap) && mcap > 0 && !isQuote ? mcap : null,
       dex: pair.dexId || null,
       priceSource: 'resolver',

--- a/extension/quote.js
+++ b/extension/quote.js
@@ -82,6 +82,11 @@
    * 1. Identity + anchor quote from a Dexscreener payload
    * ------------------------------------------------------------------ */
 
+  function pairLiquidityUsd(pair) {
+    const value = Number(pair && pair.liquidity && pair.liquidity.usd);
+    return Number.isFinite(value) && value >= 0 ? value : 0;
+  }
+
   /**
    * Choose the pair a trading UI would actually quote: the Solana pair with a
    * usable price and the deepest liquidity. Shallow pools produce wild prices,
@@ -116,16 +121,16 @@
       });
       if (relevant.length) {
         return relevant.slice().sort((a, b) => {
-          const left = Number((a.liquidity && a.liquidity.usd) || 0);
-          const right = Number((b.liquidity && b.liquidity.usd) || 0);
+          const left = pairLiquidityUsd(a);
+          const right = pairLiquidityUsd(b);
           return right - left;
         });
       }
     }
 
     return usable.slice().sort((a, b) => {
-      const left = Number((a.liquidity && a.liquidity.usd) || 0);
-      const right = Number((b.liquidity && b.liquidity.usd) || 0);
+      const left = pairLiquidityUsd(a);
+      const right = pairLiquidityUsd(b);
       return right - left;
     });
   }
@@ -198,6 +203,7 @@
     }
     const mcap = Number(pair.marketCap != null ? pair.marketCap : pair.fdv);
 
+    const liquidityUsd = pairLiquidityUsd(pair);
     return {
       mint: token.address || fallbackAddress || null,
       pairAddress: pair.pairAddress || null,
@@ -214,8 +220,7 @@
       // F-55: surfaced so a drained pool can be told from a trading one. A
       // rug empties liquidity; a real runner's pool deepens. Null when the
       // source reports none — the mark guard stands aside rather than guess.
-      liquidityUsd: Number(pair.liquidity && pair.liquidity.usd) > 0
-        ? Number(pair.liquidity.usd) : null,
+      liquidityUsd: liquidityUsd > 0 ? liquidityUsd : null,
     };
   }
 
@@ -1323,8 +1328,8 @@
 
     for (const [mint, candidates] of byMint) {
       candidates.sort((a, b) => {
-        const left = Number((a.liquidity && a.liquidity.usd) || 0);
-        const right = Number((b.liquidity && b.liquidity.usd) || 0);
+        const left = pairLiquidityUsd(a);
+        const right = pairLiquidityUsd(b);
         return right - left;
       });
       for (const candidate of candidates) {

--- a/extension/resolver.js
+++ b/extension/resolver.js
@@ -203,8 +203,10 @@
     var json = token.pairAddress
       ? await getJson(BASE + '/pairs/solana/' + token.pairAddress)
       : await getJson(BASE + '/tokens/' + token.mint);
+    var rate = cachedSolUsd();
+    if (!(rate > 0)) rate = await solUsd().catch(function () { return 0; });
     var data = json
-      ? Q.tokenFromPayload(json, token.mint, { solUsd: cachedSolUsd() })
+      ? Q.tokenFromPayload(json, token.mint, { solUsd: rate })
       : null;
     if (data) { cachePut(data); return data; }
 
@@ -245,8 +247,7 @@
       var chain = (chainByMint && chainByMint[unique[g]]) || 'solana';
       (groups[chain] = groups[chain] || []).push(unique[g]);
     }
-    var anyForeign = Object.keys(groups).some(function (c) { return c !== 'solana'; });
-    var rate = anyForeign ? await solUsd().catch(function () { return 0; }) : cachedSolUsd();
+    var rate = await solUsd().catch(function () { return 0; });
 
     var out = {};
     var chainNames = Object.keys(groups);

--- a/extension/resolver.js
+++ b/extension/resolver.js
@@ -155,9 +155,23 @@
     var viaJup = results[2] || { record: null };
 
     // A pair lookup is unambiguous, so prefer it when it returned something.
-    var dexOpts = { solUsd: cachedSolUsd() };
+    // Jupiter's combined request may already have supplied a fresh SOL/USD
+    // rate even when its token leg timed out; keep that rate for Dexscreener.
+    var dexRate = cachedSolUsd() || Number(viaJup.solUsd) || 0;
+    var dexOpts = { solUsd: dexRate };
     var dexData = Q.tokenFromPayload(byPair, address, dexOpts)
       || Q.tokenFromPayload(byToken, address, dexOpts);
+    // A Dexscreener payload can arrive while the bundled Jupiter rate is
+    // unavailable. Give one cache-first rate request a chance before
+    // abandoning a USD-quoted pool for the venue fallback.
+    if (!dexData && !(dexRate > 0) && (byPair || byToken)) {
+      dexRate = await solUsd().catch(function () { return 0; });
+      if (dexRate > 0) {
+        dexOpts = { solUsd: dexRate };
+        dexData = Q.tokenFromPayload(byPair, address, dexOpts)
+          || Q.tokenFromPayload(byToken, address, dexOpts);
+      }
+    }
     var data = Q.preferResolved(dexData, viaJup.record);
     if (!data) {
       // Aggregators silent: the terminal's own quotation API may already

--- a/extension/resolver.js
+++ b/extension/resolver.js
@@ -81,6 +81,13 @@
   var solUsdCache = { at: 0, value: 0 };
   var SOL_USD_TTL_MS = 30000;
 
+  function cachedSolUsd() {
+    var now = Date.now();
+    return now - solUsdCache.at < SOL_USD_TTL_MS && solUsdCache.value > 0
+      ? solUsdCache.value
+      : 0;
+  }
+
   function jupiterUrl(query) {
     return JUP + '?query=' + encodeURIComponent(query);
   }
@@ -90,14 +97,15 @@
    * Returns { record, solUsd } — record is null when Jupiter doesn't know it.
    */
   async function resolveViaJupiter(address) {
-    var fresh = Date.now() - solUsdCache.at < SOL_USD_TTL_MS && solUsdCache.value > 0;
+    var cachedRate = cachedSolUsd();
+    var fresh = cachedRate > 0;
     // Bundle WSOL into the same query when the cached rate is stale, so a
     // brand-new coin still costs exactly one request.
     var query = fresh ? address : address + ',' + Q.WSOL_MINT;
     var payload = await getJson(jupiterUrl(query), 4000);
-    if (!payload) return { record: null, solUsd: fresh ? solUsdCache.value : 0 };
+    if (!payload) return { record: null, solUsd: cachedRate };
 
-    var solUsd = fresh ? solUsdCache.value : Q.solUsdFromJupiter(payload);
+    var solUsd = fresh ? cachedRate : Q.solUsdFromJupiter(payload);
     if (solUsd > 0) solUsdCache = { at: Date.now(), value: solUsd };
     if (!(solUsd > 0)) return { record: null, solUsd: 0 };
 
@@ -147,7 +155,9 @@
     var viaJup = results[2] || { record: null };
 
     // A pair lookup is unambiguous, so prefer it when it returned something.
-    var dexData = Q.tokenFromPayload(byPair, address) || Q.tokenFromPayload(byToken, address);
+    var dexOpts = { solUsd: cachedSolUsd() };
+    var dexData = Q.tokenFromPayload(byPair, address, dexOpts)
+      || Q.tokenFromPayload(byToken, address, dexOpts);
     var data = Q.preferResolved(dexData, viaJup.record);
     if (!data) {
       // Aggregators silent: the terminal's own quotation API may already
@@ -193,7 +203,9 @@
     var json = token.pairAddress
       ? await getJson(BASE + '/pairs/solana/' + token.pairAddress)
       : await getJson(BASE + '/tokens/' + token.mint);
-    var data = json ? Q.tokenFromPayload(json, token.mint) : null;
+    var data = json
+      ? Q.tokenFromPayload(json, token.mint, { solUsd: cachedSolUsd() })
+      : null;
     if (data) { cachePut(data); return data; }
 
     // Last resort for a token neither source indexed under its pair address.
@@ -234,7 +246,7 @@
       (groups[chain] = groups[chain] || []).push(unique[g]);
     }
     var anyForeign = Object.keys(groups).some(function (c) { return c !== 'solana'; });
-    var rate = anyForeign ? await solUsd().catch(function () { return 0; }) : 0;
+    var rate = anyForeign ? await solUsd().catch(function () { return 0; }) : cachedSolUsd();
 
     var out = {};
     var chainNames = Object.keys(groups);
@@ -248,7 +260,8 @@
       var payloads = await Promise.all(chunks.map(function (chunk) {
         return getJson(BASE + '/tokens/' + chunk.join(','), 6000);
       }));
-      var parseOpts = chainName === 'solana' ? null : { chain: chainName, solUsd: rate };
+      var parseOpts = { solUsd: rate };
+      if (chainName !== 'solana') parseOpts.chain = chainName;
       for (var k = 0; k < payloads.length; k++) {
         var parsed = Q.pricesFromBatch(payloads[k], parseOpts);
         for (var mint in parsed) {
@@ -269,7 +282,8 @@
    */
   async function solUsd() {
     var now = Date.now();
-    if (now - solUsdCache.at < SOL_USD_TTL_MS && solUsdCache.value > 0) return solUsdCache.value;
+    var cachedRate = cachedSolUsd();
+    if (cachedRate > 0) return cachedRate;
 
     var payload = await getJson(jupiterUrl(Q.WSOL_MINT), 4000);
     if (!payload) return 0;

--- a/extension/test/contextinvalidated.test.js
+++ b/extension/test/contextinvalidated.test.js
@@ -153,6 +153,7 @@ function runInvalidation() {
         pair: {
           chainId: 'solana', pairAddress: 'PAIR1',
           baseToken: { address: MINT, symbol: 'BONK', name: 'Bonk' },
+          quoteToken: { address: 'So11111111111111111111111111111111111111112', symbol: 'SOL' },
           priceNative: '0.000001', priceUsd: '0.0002',
           liquidity: { usd: 500000 }, marketCap: 1e8,
         },

--- a/extension/test/engine.test.js
+++ b/extension/test/engine.test.js
@@ -409,6 +409,38 @@ test('markPosition tracks peak and trough unrealized P&L', () => {
   assert.ok(pos.peakPnlSol > pos.troughPnlSol);
 });
 
+test('markPosition records provenance and diagnoses a large price disagreement', () => {
+  const settings = freshSettings({ feeBps: 0, slippageBps: 0 });
+  const state = E.defaultState(settings);
+  E.buy(state, settings, {
+    ts: Date.now(), mint: 'MintA', symbol: 'X', priceNative: 0.001, solAmount: 1,
+  });
+
+  const logs = [];
+  const debug = console.debug;
+  console.debug = (...args) => logs.push(args.join(' '));
+  try {
+    E.markPosition(state, 'MintA', 0.0015, null, {
+      priceSource: 'row-props',
+      pairAddress: 'pair-row',
+    });
+    E.markPosition(state, 'MintA', 0.0016, null);
+    assert.equal(state.positions.MintA.lastPriceSource, 'row-props');
+    assert.equal(state.positions.MintA.lastPricePair, 'pair-row');
+
+    E.markPosition(state, 'MintA', 0.0002, null, {
+      priceSource: 'resolver',
+      pairAddress: 'pair-resolver',
+    });
+  } finally {
+    console.debug = debug;
+  }
+
+  assert.equal(logs.length, 1);
+  assert.match(logs[0], /MintA 0\.0002 .*resolver, pair pair-resolver/);
+  assert.match(logs[0], /held 0\.0016 .*row-props, pair pair-row/);
+});
+
 test('equity reflects cash plus marked position value', () => {
   const settings = freshSettings({ balanceStartSol: 10, feeBps: 0, slippageBps: 0 });
   const state = E.defaultState(settings);

--- a/extension/test/filldurability.test.js
+++ b/extension/test/filldurability.test.js
@@ -172,6 +172,7 @@ function runHostile(priceSeries, opts) {
         pair: {
           chainId: 'solana', pairAddress: 'PAIR1', dexId: 'raydium',
           baseToken: { address: BONK, symbol: 'BONK', name: 'Bonk' },
+          quoteToken: { address: 'So11111111111111111111111111111111111111112', symbol: 'SOL' },
           priceNative: String(p), priceUsd: String(p * 200), liquidity: { usd: 500000 }, marketCap: 1e8,
         },
       };

--- a/extension/test/livepnl.test.js
+++ b/extension/test/livepnl.test.js
@@ -328,6 +328,7 @@ function runOverlay(priceSeries, opts = {}) {
         pair: {
           chainId: 'solana', pairAddress: 'PAIR1', dexId: 'raydium',
           baseToken: { address: 'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263', symbol: 'BONK', name: 'Bonk' },
+          quoteToken: { address: 'So11111111111111111111111111111111111111112', symbol: 'SOL' },
           priceNative: String(p), priceUsd: String(p * 200), liquidity: { usd: 500000 }, marketCap: 1e8,
         },
       };

--- a/extension/test/positionsbar.test.js
+++ b/extension/test/positionsbar.test.js
@@ -175,6 +175,17 @@ test('O-30: the bar wires the page feed through, and setToken clears the stale c
     'a token coming ON screen must shed whatever batch quote was cached while it was off-screen');
 });
 
+test('position marks retain batch and resolver quote provenance', () => {
+  const contentSrc = fs.readFileSync(path.join(__dirname, '..', 'content.js'), 'utf8');
+
+  assert.match(contentSrc, /priceSource: quote\.priceSource,\s*\n\s*pairAddress: quote\.pairAddress/,
+    'batch quotes carry their source and pair into the live mark');
+  assert.match(contentSrc, /E\.markPosition\(state, mint, quote\.priceNative, quote\.priceUsd, \{\s*\n\s*priceSource: quote\.priceSource,\s*\n\s*pairAddress: quote\.pairAddress/,
+    'batch marks pass quote provenance to the engine');
+  assert.match(contentSrc, /E\.markPosition\(state, token\.mint, fresh\.priceNative, fresh\.priceUsd, \{\s*\n\s*priceSource: fresh\.priceSource,\s*\n\s*pairAddress: fresh\.pairAddress/,
+    'resolver refresh marks pass quote provenance to the engine');
+});
+
 /* ---------------- portfolio totals ---------------- */
 
 test('portfolio totals equal the sum of their rows', () => {

--- a/extension/test/positionsbar.test.js
+++ b/extension/test/positionsbar.test.js
@@ -26,6 +26,7 @@ function pair(mint, symbol, priceNative, liquidityUsd, priceUsd) {
     chainId: 'solana',
     pairAddress: `pair-${symbol}-${liquidityUsd}`,
     baseToken: { address: mint, symbol, name: symbol },
+    quoteToken: { address: Q.WSOL_MINT, symbol: 'SOL', name: 'Wrapped SOL' },
     priceNative: String(priceNative),
     priceUsd: priceUsd === undefined ? String(priceNative * 200) : String(priceUsd),
     liquidity: { usd: liquidityUsd },

--- a/extension/test/positionsbar.test.js
+++ b/extension/test/positionsbar.test.js
@@ -186,6 +186,20 @@ test('position marks retain batch and resolver quote provenance', () => {
     'resolver refresh marks pass quote provenance to the engine');
 });
 
+test('requote adopts refreshed SOL/USD rates on both feed and anchor paths', () => {
+  const contentSrc = fs.readFileSync(path.join(__dirname, '..', 'content.js'), 'utf8');
+  const requote = contentSrc.slice(
+    contentSrc.indexOf('async function requote'),
+    contentSrc.indexOf('function stopPriceLoop'),
+  );
+  assert.match(requote, /const freshRate = Number\(fresh\.solUsdAtResolve\) > 0/,
+    'requote must prefer the resolver-recorded rate');
+  assert.match(requote, /token\.solUsdAtResolve = freshRate/,
+    'requote must retain a newly observed rate');
+  assert.match(requote, /if \(freshRate > 0\) token\.priceUsd = token\.priceNative \* freshRate/,
+    'feed-live refreshes must use the refreshed rate without moving native price');
+});
+
 /* ---------------- portfolio totals ---------------- */
 
 test('portfolio totals equal the sum of their rows', () => {

--- a/extension/test/quote.test.js
+++ b/extension/test/quote.test.js
@@ -161,6 +161,30 @@ test('token payload with only a USDC pool refuses without a conversion rate', ()
   assert.equal(Q.tokenFromPayload({ pairs: [solPair()] }, mint), null);
 });
 
+test('token payload ranks a deep pool ahead of malformed liquidity', () => {
+  const mint = solPair().baseToken.address;
+  const shallow = solPair({
+    pairAddress: 'ShallowPair111111111111111111111111111111111111',
+    quoteToken: { address: WSOL, symbol: 'SOL', name: 'Wrapped SOL' },
+    priceNative: '0.00000001',
+    liquidity: { usd: 100 },
+  });
+  const malformed = solPair({
+    pairAddress: 'MalformedPair1111111111111111111111111111111111',
+    quoteToken: { address: WSOL, symbol: 'SOL', name: 'Wrapped SOL' },
+    priceNative: '0.00000002',
+    liquidity: { usd: 'not-a-number' },
+  });
+  const deep = solPair({
+    pairAddress: 'DeepPair11111111111111111111111111111111111111',
+    quoteToken: { address: WSOL, symbol: 'SOL', name: 'Wrapped SOL' },
+    priceNative: '0.00000003',
+    liquidity: { usd: 10000 },
+  });
+  const token = Q.tokenFromPayload({ pairs: [shallow, malformed, deep] }, mint);
+  assert.equal(token.pairAddress, deep.pairAddress);
+});
+
 test('requested-as-quote identity still selects a WSOL-base pair', () => {
   const mint = solPair().baseToken.address;
   const pair = solPair({
@@ -234,6 +258,30 @@ test('batch pricing keeps the deepest USDC pool when its rate is available', () 
 test('batch pricing with only a USDC pool refuses without a conversion rate', () => {
   const mint = solPair().baseToken.address;
   assert.deepEqual(Q.pricesFromBatch({ pairs: [solPair()] }), {});
+});
+
+test('batch pricing ranks a deep pool ahead of malformed liquidity', () => {
+  const mint = solPair().baseToken.address;
+  const shallow = solPair({
+    pairAddress: 'ShallowPair111111111111111111111111111111111111',
+    quoteToken: { address: WSOL, symbol: 'SOL', name: 'Wrapped SOL' },
+    priceNative: '0.00000001',
+    liquidity: { usd: 100 },
+  });
+  const malformed = solPair({
+    pairAddress: 'MalformedPair1111111111111111111111111111111111',
+    quoteToken: { address: WSOL, symbol: 'SOL', name: 'Wrapped SOL' },
+    priceNative: '0.00000002',
+    liquidity: { usd: 'not-a-number' },
+  });
+  const deep = solPair({
+    pairAddress: 'DeepPair11111111111111111111111111111111111111',
+    quoteToken: { address: WSOL, symbol: 'SOL', name: 'Wrapped SOL' },
+    priceNative: '0.00000003',
+    liquidity: { usd: 10000 },
+  });
+  const out = Q.pricesFromBatch({ pairs: [shallow, malformed, deep] });
+  assert.equal(out[mint].pairAddress, deep.pairAddress);
 });
 
 test('BONK USDC pricing keeps the SOL mark near the booked entry', () => {

--- a/extension/test/quote.test.js
+++ b/extension/test/quote.test.js
@@ -198,7 +198,7 @@ test('requested-as-quote identity still selects a WSOL-base pair', () => {
   assert.equal(token.priceNative, 1 / 800000);
 });
 
-test('keeps WSOL-quoted Solana normalization unchanged for either requested side', () => {
+test('records the observed SOL/USD rate when the requested token is the quote side', () => {
   const baseRequested = solPair({
     baseToken: { address: solPair().baseToken.address, symbol: 'BONK', name: 'Bonk' },
     quoteToken: { address: WSOL, symbol: 'SOL', name: 'Wrapped SOL' },
@@ -217,7 +217,36 @@ test('keeps WSOL-quoted Solana normalization unchanged for either requested side
   assert.equal(base.priceNative, 0.00000125);
   assert.equal(base.solUsdAtResolve, null);
   assert.equal(quote.priceNative, 1 / 800000);
+  assert.equal(quote.priceUsd, (1 / 800000) * 0.00025);
+  assert.equal(quote.solUsdAtResolve, 0.00025);
+});
+
+test('a WSOL-base quote without a USD price refuses to invent token USD', () => {
+  const mint = solPair().baseToken.address;
+  const pair = solPair({
+    baseToken: { address: WSOL, symbol: 'SOL', name: 'Wrapped SOL' },
+    quoteToken: { address: mint, symbol: 'BONK', name: 'Bonk' },
+    priceNative: '800000',
+    priceUsd: undefined,
+  });
+  const quote = Q.normalizePair(pair, mint);
+  assert.ok(quote);
+  assert.equal(quote.priceNative, 1 / 800000);
+  assert.equal(quote.priceUsd, null);
   assert.equal(quote.solUsdAtResolve, null);
+});
+
+test('requested-side USD flows into downstream USD P&L at the observed SOL rate', () => {
+  const mint = solPair().baseToken.address;
+  const pair = solPair({
+    baseToken: { address: WSOL, symbol: 'SOL', name: 'Wrapped SOL' },
+    quoteToken: { address: mint, symbol: 'BONK', name: 'Bonk' },
+    priceNative: '800000',
+    priceUsd: '200',
+  });
+  const quote = Q.normalizePair(pair, mint);
+  const mark = Q.positionMark({ qty: 1, costSol: 0, lastPriceNative: 0 }, quote.priceNative, quote.priceUsd);
+  assert.equal(mark.pnlUsd, quote.priceUsd);
 });
 
 test('converts a USDC-quoted Solana pair in the batch path', () => {

--- a/extension/test/quote.test.js
+++ b/extension/test/quote.test.js
@@ -255,6 +255,50 @@ test('batch pricing keeps the deepest USDC pool when its rate is available', () 
   assert.ok(Math.abs(out[mint].priceNative - Number(usdc.priceUsd) / 102) < 1e-18);
 });
 
+test('GPRO batch pricing falls back from its deep USDC pool without a rate', () => {
+  const mint = 'GPRR2u6NS5yBQHWGauoJ9HXgjrTH8dDsrBfTV5zAYvDH';
+  const usdc = {
+    chainId: 'solana',
+    pairAddress: '8aRfdGqAUSDCGPROPair111111111111111111111111',
+    baseToken: { address: mint, symbol: 'GPRO', name: 'GPRO' },
+    quoteToken: { address: USDC, symbol: 'USDC', name: 'USD Coin' },
+    priceNative: '2.4773',
+    priceUsd: '2.47',
+    liquidity: { usd: 70082 },
+  };
+  const wsol = {
+    chainId: 'solana',
+    pairAddress: 'GPROWsolPair1111111111111111111111111111111',
+    baseToken: { address: mint, symbol: 'GPRO', name: 'GPRO' },
+    quoteToken: { address: WSOL, symbol: 'SOL', name: 'Wrapped SOL' },
+    priceNative: '0.02505',
+    priceUsd: '2.55',
+    liquidity: { usd: 15829 },
+  };
+
+  const withoutRate = Q.pricesFromBatch({ pairs: [wsol, usdc] });
+  assert.equal(withoutRate[mint].pairAddress, wsol.pairAddress);
+  assert.equal(withoutRate[mint].priceNative, Number(wsol.priceNative));
+
+  const withRate = Q.pricesFromBatch({ pairs: [wsol, usdc] }, { solUsd: 102 });
+  assert.equal(withRate[mint].pairAddress, usdc.pairAddress);
+  assert.ok(Math.abs(withRate[mint].priceNative - 2.47 / 102) < 1e-18);
+});
+
+test('GPRO batch pricing omits an only-USDC pool without a rate', () => {
+  const mint = 'GPRR2u6NS5yBQHWGauoJ9HXgjrTH8dDsrBfTV5zAYvDH';
+  const onlyUsdc = {
+    chainId: 'solana',
+    pairAddress: '8aRfdGqAUSDCGPROPair111111111111111111111111',
+    baseToken: { address: mint, symbol: 'GPRO', name: 'GPRO' },
+    quoteToken: { address: USDC, symbol: 'USDC', name: 'USD Coin' },
+    priceNative: '2.4773',
+    priceUsd: '2.47',
+    liquidity: { usd: 70082 },
+  };
+  assert.deepEqual(Q.pricesFromBatch({ pairs: [onlyUsdc] }), {});
+});
+
 test('batch pricing with only a USDC pool refuses without a conversion rate', () => {
   const mint = solPair().baseToken.address;
   assert.deepEqual(Q.pricesFromBatch({ pairs: [solPair()] }), {});

--- a/extension/test/quote.test.js
+++ b/extension/test/quote.test.js
@@ -18,6 +18,23 @@ const FIX = path.join(__dirname, 'fixtures');
 const tokensPayload = JSON.parse(fs.readFileSync(path.join(FIX, 'tokens-bonk.json'), 'utf8'));
 const pairPayload = JSON.parse(fs.readFileSync(path.join(FIX, 'pair-bonk.json'), 'utf8'));
 
+const USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1';
+const WSOL = Q.WSOL_MINT;
+
+function solPair(overrides = {}) {
+  return {
+    chainId: 'solana',
+    pairAddress: 'Pair111111111111111111111111111111111111111',
+    baseToken: { address: 'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263', symbol: 'BONK', name: 'Bonk' },
+    quoteToken: { address: USDC, symbol: 'USDC', name: 'USD Coin' },
+    priceNative: '0.000003112',
+    priceUsd: '0.000003112',
+    marketCap: 3112,
+    liquidity: { usd: 1000000 },
+    ...overrides,
+  };
+}
+
 /* ---------------- criterion 1: identity + anchor quote ---------------- */
 
 test('resolves identity and anchor quote from the /tokens payload shape', () => {
@@ -83,6 +100,7 @@ test('ignores non-solana pairs and pairs without a usable price', () => {
       {
         chainId: 'solana', priceNative: '0.5', liquidity: { usd: 10 }, pairAddress: 'good',
         baseToken: { address: 'MintGood', symbol: 'GOOD', name: 'Good Token' },
+        quoteToken: { address: WSOL, symbol: 'SOL', name: 'Wrapped SOL' },
       },
     ],
   };
@@ -94,6 +112,59 @@ test('ignores non-solana pairs and pairs without a usable price', () => {
 test('returns null when no usable pair exists', () => {
   assert.equal(Q.tokenFromPayload({ pairs: [] }, 'x'), null);
   assert.equal(Q.tokenFromPayload(null, 'x'), null);
+});
+
+test('converts a USDC-quoted Solana pair through SOL/USD and records the rate', () => {
+  const rec = Q.normalizePair(solPair(), solPair().baseToken.address, { solUsd: 102 });
+  assert.ok(rec);
+  assert.ok(Math.abs(rec.priceNative - 0.000003112 / 102) < 1e-18);
+  assert.equal(rec.solUsdAtResolve, 102);
+});
+
+test('refuses a non-SOL-quoted Solana pair without a SOL/USD rate', () => {
+  assert.equal(Q.normalizePair(solPair(), solPair().baseToken.address), null);
+  assert.equal(Q.normalizePair(solPair(), solPair().baseToken.address, { solUsd: 0 }), null);
+});
+
+test('keeps WSOL-quoted Solana normalization unchanged for either requested side', () => {
+  const baseRequested = solPair({
+    baseToken: { address: solPair().baseToken.address, symbol: 'BONK', name: 'Bonk' },
+    quoteToken: { address: WSOL, symbol: 'SOL', name: 'Wrapped SOL' },
+    priceNative: '0.00000125',
+    priceUsd: '0.00025',
+  });
+  const quoteRequested = solPair({
+    baseToken: { address: WSOL, symbol: 'SOL', name: 'Wrapped SOL' },
+    quoteToken: { address: solPair().baseToken.address, symbol: 'BONK', name: 'Bonk' },
+    priceNative: '800000',
+    priceUsd: '0.00025',
+  });
+
+  const base = Q.normalizePair(baseRequested, baseRequested.baseToken.address);
+  const quote = Q.normalizePair(quoteRequested, quoteRequested.quoteToken.address);
+  assert.equal(base.priceNative, 0.00000125);
+  assert.equal(base.solUsdAtResolve, null);
+  assert.equal(quote.priceNative, 1 / 800000);
+  assert.equal(quote.solUsdAtResolve, null);
+});
+
+test('converts a USDC-quoted Solana pair in the batch path', () => {
+  const mint = solPair().baseToken.address;
+  const out = Q.pricesFromBatch({ pairs: [solPair()] }, { solUsd: 102 });
+  assert.ok(out[mint]);
+  assert.ok(Math.abs(out[mint].priceNative - 0.000003112 / 102) < 1e-18);
+  assert.equal(out[mint].solUsdAtResolve, 102);
+});
+
+test('BONK USDC pricing keeps the SOL mark near the booked entry', () => {
+  const mint = solPair().baseToken.address;
+  const rec = Q.normalizePair(solPair(), mint, { solUsd: 102 });
+  const mark = Q.positionMark({ qty: 1, costSol: rec.priceNative }, rec.priceNative, rec.priceUsd);
+  assert.ok(mark);
+  assert.equal(mark.valueSol, rec.priceNative);
+  assert.ok(Math.abs(mark.pnlSol) < 1e-18);
+  assert.ok(rec.priceNative < 0.000003112 / 100,
+    'the USD-denominated raw price must not be used as SOL');
 });
 
 /* ---------------- criterion 2: tick validation ---------------- */

--- a/extension/test/quote.test.js
+++ b/extension/test/quote.test.js
@@ -126,6 +126,54 @@ test('refuses a non-SOL-quoted Solana pair without a SOL/USD rate', () => {
   assert.equal(Q.normalizePair(solPair(), solPair().baseToken.address, { solUsd: 0 }), null);
 });
 
+test('token payload falls back to a shallower WSOL pool when the deeper pool needs a missing rate', () => {
+  const mint = solPair().baseToken.address;
+  const usdc = solPair({ liquidity: { usd: 1000000 } });
+  const wsol = solPair({
+    pairAddress: 'WsolPair1111111111111111111111111111111111111',
+    quoteToken: { address: WSOL, symbol: 'SOL', name: 'Wrapped SOL' },
+    priceNative: '0.00000003112',
+    liquidity: { usd: 500000 },
+  });
+  const token = Q.tokenFromPayload({ pairs: [wsol, usdc] }, mint);
+  assert.ok(token);
+  assert.equal(token.pairAddress, wsol.pairAddress);
+  assert.equal(token.priceNative, Number(wsol.priceNative));
+});
+
+test('token payload keeps the deepest USDC pool when its conversion rate is available', () => {
+  const mint = solPair().baseToken.address;
+  const usdc = solPair({ liquidity: { usd: 1000000 } });
+  const wsol = solPair({
+    pairAddress: 'WsolPair1111111111111111111111111111111111111',
+    quoteToken: { address: WSOL, symbol: 'SOL', name: 'Wrapped SOL' },
+    priceNative: '0.00000003112',
+    liquidity: { usd: 500000 },
+  });
+  const token = Q.tokenFromPayload({ pairs: [wsol, usdc] }, mint, { solUsd: 102 });
+  assert.ok(token);
+  assert.equal(token.pairAddress, usdc.pairAddress);
+  assert.ok(Math.abs(token.priceNative - Number(usdc.priceUsd) / 102) < 1e-18);
+});
+
+test('token payload with only a USDC pool refuses without a conversion rate', () => {
+  const mint = solPair().baseToken.address;
+  assert.equal(Q.tokenFromPayload({ pairs: [solPair()] }, mint), null);
+});
+
+test('requested-as-quote identity still selects a WSOL-base pair', () => {
+  const mint = solPair().baseToken.address;
+  const pair = solPair({
+    baseToken: { address: WSOL, symbol: 'SOL', name: 'Wrapped SOL' },
+    quoteToken: { address: mint, symbol: 'BONK', name: 'Bonk' },
+    priceNative: '800000',
+  });
+  const token = Q.tokenFromPayload({ pairs: [pair] }, mint);
+  assert.ok(token);
+  assert.equal(token.mint, mint);
+  assert.equal(token.priceNative, 1 / 800000);
+});
+
 test('keeps WSOL-quoted Solana normalization unchanged for either requested side', () => {
   const baseRequested = solPair({
     baseToken: { address: solPair().baseToken.address, symbol: 'BONK', name: 'Bonk' },
@@ -154,6 +202,38 @@ test('converts a USDC-quoted Solana pair in the batch path', () => {
   assert.ok(out[mint]);
   assert.ok(Math.abs(out[mint].priceNative - 0.000003112 / 102) < 1e-18);
   assert.equal(out[mint].solUsdAtResolve, 102);
+});
+
+test('batch pricing falls back to a shallower WSOL pool without a rate', () => {
+  const mint = solPair().baseToken.address;
+  const usdc = solPair({ liquidity: { usd: 1000000 } });
+  const wsol = solPair({
+    pairAddress: 'WsolPair1111111111111111111111111111111111111',
+    quoteToken: { address: WSOL, symbol: 'SOL', name: 'Wrapped SOL' },
+    priceNative: '0.00000003112',
+    liquidity: { usd: 500000 },
+  });
+  const out = Q.pricesFromBatch({ pairs: [wsol, usdc] });
+  assert.equal(out[mint].pairAddress, wsol.pairAddress);
+});
+
+test('batch pricing keeps the deepest USDC pool when its rate is available', () => {
+  const mint = solPair().baseToken.address;
+  const usdc = solPair({ liquidity: { usd: 1000000 } });
+  const wsol = solPair({
+    pairAddress: 'WsolPair1111111111111111111111111111111111111',
+    quoteToken: { address: WSOL, symbol: 'SOL', name: 'Wrapped SOL' },
+    priceNative: '0.00000003112',
+    liquidity: { usd: 500000 },
+  });
+  const out = Q.pricesFromBatch({ pairs: [wsol, usdc] }, { solUsd: 102 });
+  assert.equal(out[mint].pairAddress, usdc.pairAddress);
+  assert.ok(Math.abs(out[mint].priceNative - Number(usdc.priceUsd) / 102) < 1e-18);
+});
+
+test('batch pricing with only a USDC pool refuses without a conversion rate', () => {
+  const mint = solPair().baseToken.address;
+  assert.deepEqual(Q.pricesFromBatch({ pairs: [solPair()] }), {});
 });
 
 test('BONK USDC pricing keeps the SOL mark near the booked entry', () => {

--- a/extension/test/resolver.test.js
+++ b/extension/test/resolver.test.js
@@ -17,6 +17,20 @@ const tokensPayload = JSON.parse(fs.readFileSync(path.join(FIX, 'tokens-bonk.jso
 const pairPayload = JSON.parse(fs.readFileSync(path.join(FIX, 'pair-bonk.json'), 'utf8'));
 
 const BONK_MINT = 'DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263';
+const USDC = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1';
+const WSOL = 'So11111111111111111111111111111111111111112';
+
+function usdcPair() {
+  return {
+    chainId: 'solana',
+    pairAddress: 'Pair111111111111111111111111111111111111111',
+    baseToken: { address: BONK_MINT, symbol: 'BONK', name: 'Bonk' },
+    quoteToken: { address: USDC, symbol: 'USDC', name: 'USD Coin' },
+    priceNative: '0.000003112',
+    priceUsd: '0.000003112',
+    liquidity: { usd: 1000000 },
+  };
+}
 
 // Captured before any test stubs it, so the live probe below always uses the
 // real implementation rather than a leftover stub from an earlier test.
@@ -142,6 +156,53 @@ test('solUsd exposes the cached SOL/USD rate even when the token is unindexed', 
   const second = await R2.solUsd();
   assert.equal(hits, h1, 'cached rate must not trigger a second network call');
   assert.equal(second, first, 'repeated calls return the cached value');
+});
+
+test('Solana resolver passes its cached SOL/USD rate to non-SOL pair quotes', async () => {
+  const R = loadResolver((url) => {
+    if (url.includes('jup.ag')) {
+      return jsonResponse([{ id: WSOL, usdPrice: 102 }]);
+    }
+    if (url.includes('/tokens/')) return jsonResponse({ pairs: [usdcPair()] });
+    return notFound();
+  });
+
+  const token = await R.resolve(BONK_MINT);
+  assert.ok(token);
+  assert.ok(Math.abs(token.priceNative - 0.000003112 / 102) < 1e-18);
+  assert.equal(token.solUsdAtResolve, 102);
+});
+
+test('Solana refresh passes its cached SOL/USD rate to non-SOL pair quotes', async () => {
+  const R = loadResolver((url) => {
+    if (url.includes('jup.ag')) {
+      return jsonResponse([{ id: WSOL, usdPrice: 102 }]);
+    }
+    if (url.includes('/pairs/solana/')) return jsonResponse({ pair: usdcPair() });
+    return notFound();
+  });
+
+  assert.equal(await R.solUsd(), 102);
+  const token = await R.refresh({ mint: BONK_MINT, pairAddress: usdcPair().pairAddress });
+  assert.ok(token);
+  assert.ok(Math.abs(token.priceNative - 0.000003112 / 102) < 1e-18);
+  assert.equal(token.solUsdAtResolve, 102);
+});
+
+test('Solana batch resolver passes its cached SOL/USD rate to non-SOL pair quotes', async () => {
+  const R = loadResolver((url) => {
+    if (url.includes('jup.ag')) {
+      return jsonResponse([{ id: WSOL, usdPrice: 102 }]);
+    }
+    if (url.includes('/tokens/')) return jsonResponse({ pairs: [usdcPair()] });
+    return notFound();
+  });
+
+  assert.equal(await R.solUsd(), 102);
+  const prices = await R.batchPrices([BONK_MINT]);
+  assert.ok(prices[BONK_MINT]);
+  assert.ok(Math.abs(prices[BONK_MINT].priceNative - 0.000003112 / 102) < 1e-18);
+  assert.equal(prices[BONK_MINT].solUsdAtResolve, 102);
 });
 
 /* ---------------- live API (skips cleanly when offline) ---------------- */

--- a/extension/test/resolver.test.js
+++ b/extension/test/resolver.test.js
@@ -189,20 +189,33 @@ test('Solana refresh passes its cached SOL/USD rate to non-SOL pair quotes', asy
   assert.equal(token.solUsdAtResolve, 102);
 });
 
-test('Solana batch resolver passes its cached SOL/USD rate to non-SOL pair quotes', async () => {
+test('Solana batch resolver fetches a cold-cache SOL/USD rate once for non-SOL pair quotes', async () => {
+  let jupiterHits = 0;
   const R = loadResolver((url) => {
     if (url.includes('jup.ag')) {
+      jupiterHits++;
       return jsonResponse([{ id: WSOL, usdPrice: 102 }]);
     }
     if (url.includes('/tokens/')) return jsonResponse({ pairs: [usdcPair()] });
     return notFound();
   });
 
-  assert.equal(await R.solUsd(), 102);
   const prices = await R.batchPrices([BONK_MINT]);
   assert.ok(prices[BONK_MINT]);
   assert.ok(Math.abs(prices[BONK_MINT].priceNative - 0.000003112 / 102) < 1e-18);
   assert.equal(prices[BONK_MINT].solUsdAtResolve, 102);
+  assert.equal(jupiterHits, 1);
+});
+
+test('Solana batch resolver refuses non-SOL pair quotes when the cold rate fetch fails', async () => {
+  const R = loadResolver((url) => {
+    if (url.includes('jup.ag')) return Promise.reject(new Error('offline'));
+    if (url.includes('/tokens/')) return jsonResponse({ pairs: [usdcPair()] });
+    return notFound();
+  });
+
+  const prices = await R.batchPrices([BONK_MINT]);
+  assert.deepEqual(prices, {});
 });
 
 /* ---------------- live API (skips cleanly when offline) ---------------- */

--- a/extension/test/resolver.test.js
+++ b/extension/test/resolver.test.js
@@ -173,6 +173,45 @@ test('Solana resolver passes its cached SOL/USD rate to non-SOL pair quotes', as
   assert.equal(token.solUsdAtResolve, 102);
 });
 
+test('cold Jupiter rate is reused for a Dexscreener USDC quote', async () => {
+  let jupiterHits = 0;
+  const R = loadResolver((url) => {
+    if (url.includes('jup.ag')) {
+      jupiterHits++;
+      return jsonResponse([{ id: WSOL, usdPrice: 102 }]);
+    }
+    if (url.includes('/tokens/')) return jsonResponse({ pairs: [usdcPair()] });
+    return notFound();
+  });
+
+  const token = await R.resolve(BONK_MINT);
+  assert.ok(token);
+  assert.equal(token.solUsdAtResolve, 102);
+  assert.ok(Math.abs(token.priceNative - Number(usdcPair().priceUsd) / 102) < 1e-18);
+  assert.equal(jupiterHits, 1, 'the bundled Jupiter request supplies the rate');
+});
+
+test('a failed Jupiter rate gets one extra SOL/USD request before Dexscreener pricing', async () => {
+  let jupiterHits = 0;
+  const R = loadResolver((url) => {
+    if (url.includes('jup.ag')) {
+      jupiterHits++;
+      if (url.endsWith('query=' + encodeURIComponent(WSOL))) {
+        return jsonResponse([{ id: WSOL, usdPrice: 103 }]);
+      }
+      return jsonResponse([]);
+    }
+    if (url.includes('/tokens/')) return jsonResponse({ pairs: [usdcPair()] });
+    return notFound();
+  });
+
+  const token = await R.resolve(BONK_MINT);
+  assert.ok(token);
+  assert.equal(token.solUsdAtResolve, 103);
+  assert.ok(Math.abs(token.priceNative - Number(usdcPair().priceUsd) / 103) < 1e-18);
+  assert.equal(jupiterHits, 2, 'one bundled lookup plus one cache-fill rate request');
+});
+
 test('Solana refresh passes its cached SOL/USD rate to non-SOL pair quotes', async () => {
   const R = loadResolver((url) => {
     if (url.includes('jup.ag')) {

--- a/extension/test/statepersist.test.js
+++ b/extension/test/statepersist.test.js
@@ -320,6 +320,15 @@ function runOverlay(priceSeries, opts) {
   };
 }
 
+
+  // Merge-tolerance: boot persist timing varies with resolver round-trips;
+  // wait for the state to actually land instead of assuming a fixed clock.
+  async function waitReady(ov, budgetMs = 3000) {
+    for (let t = 0; t < budgetMs; t += 200) {
+      if (ov.storage().pt_state) return;
+      await ov.advance(200);
+    }
+  }
 test('a transient storage read failure must not fabricate an empty wallet', async () => {
   const ov = runOverlay([0.001, 0.0012]);
 
@@ -471,7 +480,7 @@ test('the buy-section switch still outranks the custom-amount setting', async ()
 
 test('instant preset tap fills once and an empty BUY does not fill again', async () => {
   const ov = runOverlay([0.001]);
-  await ov.advance(1200);
+  await ov.advance(1200); await waitReady(ov);
 
   assert.equal(ov.shadowNodes['pt-buy'].style.display, 'none',
     'instant presets are the visible order buttons when custom sizing is off');
@@ -498,7 +507,7 @@ test('instant BUY uses a typed custom amount once when enabled', async () => {
   const ov = runOverlay([0.001], {
     initialSettings: { panelCustomAmount: true, settingsRevision: E.SETTINGS_REVISION },
   });
-  await ov.advance(1200);
+  await ov.advance(1200); await waitReady(ov);
 
   assert.notEqual(ov.shadowNodes['pt-buy'].style.display, 'none',
     'custom sizing keeps BUY available in instant mode');
@@ -517,7 +526,7 @@ test('two-step BUY still uses the selected preset once', async () => {
   const ov = runOverlay([0.001], {
     initialSettings: { instantBuyEnabled: false, settingsRevision: E.SETTINGS_REVISION },
   });
-  await ov.advance(1200);
+  await ov.advance(1200); await waitReady(ov);
 
   assert.notEqual(ov.shadowNodes['pt-buy'].style.display, 'none',
     'two-step mode needs the BUY trigger');

--- a/extension/test/statepersist.test.js
+++ b/extension/test/statepersist.test.js
@@ -320,15 +320,6 @@ function runOverlay(priceSeries, opts) {
   };
 }
 
-
-  // Merge-tolerance: boot persist timing varies with resolver round-trips;
-  // wait for the state to actually land instead of assuming a fixed clock.
-  async function waitReady(ov, budgetMs = 3000) {
-    for (let t = 0; t < budgetMs; t += 200) {
-      if (ov.storage().pt_state) return;
-      await ov.advance(200);
-    }
-  }
 test('a transient storage read failure must not fabricate an empty wallet', async () => {
   const ov = runOverlay([0.001, 0.0012]);
 
@@ -480,7 +471,7 @@ test('the buy-section switch still outranks the custom-amount setting', async ()
 
 test('instant preset tap fills once and an empty BUY does not fill again', async () => {
   const ov = runOverlay([0.001]);
-  await ov.advance(1200); await waitReady(ov);
+  await ov.advance(1200); for (let w = 0; !ov.storage().pt_state && w < 3000; w += 200) await ov.advance(200);
 
   assert.equal(ov.shadowNodes['pt-buy'].style.display, 'none',
     'instant presets are the visible order buttons when custom sizing is off');
@@ -507,7 +498,7 @@ test('instant BUY uses a typed custom amount once when enabled', async () => {
   const ov = runOverlay([0.001], {
     initialSettings: { panelCustomAmount: true, settingsRevision: E.SETTINGS_REVISION },
   });
-  await ov.advance(1200); await waitReady(ov);
+  await ov.advance(1200); for (let w = 0; !ov.storage().pt_state && w < 3000; w += 200) await ov.advance(200);
 
   assert.notEqual(ov.shadowNodes['pt-buy'].style.display, 'none',
     'custom sizing keeps BUY available in instant mode');
@@ -526,7 +517,7 @@ test('two-step BUY still uses the selected preset once', async () => {
   const ov = runOverlay([0.001], {
     initialSettings: { instantBuyEnabled: false, settingsRevision: E.SETTINGS_REVISION },
   });
-  await ov.advance(1200); await waitReady(ov);
+  await ov.advance(1200); for (let w = 0; !ov.storage().pt_state && w < 3000; w += 200) await ov.advance(200);
 
   assert.notEqual(ov.shadowNodes['pt-buy'].style.display, 'none',
     'two-step mode needs the BUY trigger');

--- a/extension/test/statepersist.test.js
+++ b/extension/test/statepersist.test.js
@@ -162,6 +162,7 @@ function runOverlay(priceSeries, opts) {
         pair: {
           chainId: 'solana', pairAddress: 'PAIR1', dexId: 'raydium',
           baseToken: { address: BONK, symbol: 'BONK', name: 'Bonk' },
+          quoteToken: { address: 'So11111111111111111111111111111111111111112', symbol: 'SOL' },
           priceNative: String(p), priceUsd: String(p * 200), liquidity: { usd: 500000 }, marketCap: 1e8,
         },
       };

--- a/site/index.html
+++ b/site/index.html
@@ -117,7 +117,7 @@
   <span class="home-credits-kicker">proof</span>
   <span class="home-credits-item"><span class="home-credits-role">terminals</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="sites">15</b></span>
   <span class="home-credits-item"><span class="home-credits-role">invented prices</span><span class="home-credits-rule" aria-hidden="true"></span><b>0</b></span>
-  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2457</b></span>
+  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2455</b></span>
   <span class="home-credits-item"><span class="home-credits-role">local</span><span class="home-credits-rule" aria-hidden="true"></span><b>100%</b></span>
 </p>
 

--- a/site/index.html
+++ b/site/index.html
@@ -117,7 +117,7 @@
   <span class="home-credits-kicker">proof</span>
   <span class="home-credits-item"><span class="home-credits-role">terminals</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="sites">15</b></span>
   <span class="home-credits-item"><span class="home-credits-role">invented prices</span><span class="home-credits-rule" aria-hidden="true"></span><b>0</b></span>
-  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2465</b></span>
+  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2471</b></span>
   <span class="home-credits-item"><span class="home-credits-role">local</span><span class="home-credits-rule" aria-hidden="true"></span><b>100%</b></span>
 </p>
 

--- a/site/index.html
+++ b/site/index.html
@@ -117,7 +117,7 @@
   <span class="home-credits-kicker">proof</span>
   <span class="home-credits-item"><span class="home-credits-role">terminals</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="sites">15</b></span>
   <span class="home-credits-item"><span class="home-credits-role">invented prices</span><span class="home-credits-rule" aria-hidden="true"></span><b>0</b></span>
-  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2455</b></span>
+  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2456</b></span>
   <span class="home-credits-item"><span class="home-credits-role">local</span><span class="home-credits-rule" aria-hidden="true"></span><b>100%</b></span>
 </p>
 

--- a/site/index.html
+++ b/site/index.html
@@ -117,7 +117,7 @@
   <span class="home-credits-kicker">proof</span>
   <span class="home-credits-item"><span class="home-credits-role">terminals</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="sites">15</b></span>
   <span class="home-credits-item"><span class="home-credits-role">invented prices</span><span class="home-credits-rule" aria-hidden="true"></span><b>0</b></span>
-  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2463</b></span>
+  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2465</b></span>
   <span class="home-credits-item"><span class="home-credits-role">local</span><span class="home-credits-rule" aria-hidden="true"></span><b>100%</b></span>
 </p>
 

--- a/site/index.html
+++ b/site/index.html
@@ -117,7 +117,7 @@
   <span class="home-credits-kicker">proof</span>
   <span class="home-credits-item"><span class="home-credits-role">terminals</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="sites">15</b></span>
   <span class="home-credits-item"><span class="home-credits-role">invented prices</span><span class="home-credits-rule" aria-hidden="true"></span><b>0</b></span>
-  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2456</b></span>
+  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2463</b></span>
   <span class="home-credits-item"><span class="home-credits-role">local</span><span class="home-credits-rule" aria-hidden="true"></span><b>100%</b></span>
 </p>
 

--- a/site/index.html
+++ b/site/index.html
@@ -117,7 +117,7 @@
   <span class="home-credits-kicker">proof</span>
   <span class="home-credits-item"><span class="home-credits-role">terminals</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="sites">15</b></span>
   <span class="home-credits-item"><span class="home-credits-role">invented prices</span><span class="home-credits-rule" aria-hidden="true"></span><b>0</b></span>
-  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2471</b></span>
+  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2474</b></span>
   <span class="home-credits-item"><span class="home-credits-role">local</span><span class="home-credits-rule" aria-hidden="true"></span><b>100%</b></span>
 </p>
 

--- a/site/news.html
+++ b/site/news.html
@@ -57,7 +57,7 @@
       <!-- 2299 = 2072 extension + 211 server + 16 bot. Preflight recomputes
            data-check="tests" and data-check="defects" and fails the release
            if either disagrees. Update them together with that check. -->
-      <span><b data-check="tests">2455</b> tests passing</span>
+      <span><b data-check="tests">2456</b> tests passing</span>
       <span><b data-check="defects">195</b> defects closed</span>
       <span><b>0</b> numbers invented</span>
     </div>

--- a/site/news.html
+++ b/site/news.html
@@ -57,7 +57,7 @@
       <!-- 2299 = 2072 extension + 211 server + 16 bot. Preflight recomputes
            data-check="tests" and data-check="defects" and fails the release
            if either disagrees. Update them together with that check. -->
-      <span><b data-check="tests">2465</b> tests passing</span>
+      <span><b data-check="tests">2471</b> tests passing</span>
       <span><b data-check="defects">195</b> defects closed</span>
       <span><b>0</b> numbers invented</span>
     </div>

--- a/site/news.html
+++ b/site/news.html
@@ -57,7 +57,7 @@
       <!-- 2299 = 2072 extension + 211 server + 16 bot. Preflight recomputes
            data-check="tests" and data-check="defects" and fails the release
            if either disagrees. Update them together with that check. -->
-      <span><b data-check="tests">2456</b> tests passing</span>
+      <span><b data-check="tests">2463</b> tests passing</span>
       <span><b data-check="defects">195</b> defects closed</span>
       <span><b>0</b> numbers invented</span>
     </div>

--- a/site/news.html
+++ b/site/news.html
@@ -57,7 +57,7 @@
       <!-- 2299 = 2072 extension + 211 server + 16 bot. Preflight recomputes
            data-check="tests" and data-check="defects" and fails the release
            if either disagrees. Update them together with that check. -->
-      <span><b data-check="tests">2471</b> tests passing</span>
+      <span><b data-check="tests">2474</b> tests passing</span>
       <span><b data-check="defects">195</b> defects closed</span>
       <span><b>0</b> numbers invented</span>
     </div>

--- a/site/news.html
+++ b/site/news.html
@@ -57,7 +57,7 @@
       <!-- 2299 = 2072 extension + 211 server + 16 bot. Preflight recomputes
            data-check="tests" and data-check="defects" and fails the release
            if either disagrees. Update them together with that check. -->
-      <span><b data-check="tests">2457</b> tests passing</span>
+      <span><b data-check="tests">2455</b> tests passing</span>
       <span><b data-check="defects">195</b> defects closed</span>
       <span><b>0</b> numbers invented</span>
     </div>

--- a/site/news.html
+++ b/site/news.html
@@ -57,7 +57,7 @@
       <!-- 2299 = 2072 extension + 211 server + 16 bot. Preflight recomputes
            data-check="tests" and data-check="defects" and fails the release
            if either disagrees. Update them together with that check. -->
-      <span><b data-check="tests">2463</b> tests passing</span>
+      <span><b data-check="tests">2465</b> tests passing</span>
       <span><b data-check="defects">195</b> defects closed</span>
       <span><b>0</b> numbers invented</span>
     </div>


### PR DESCRIPTION
## Summary

Today's live run showed the rail claiming `Bonk +9.966 SOL (+10866.9%)` on a 10 SOL wallet while the same position, at the same moment, read `-0 SOL (-0.0%)` on BONK's own chart page (screenshots in https://github.com/OnlyTerp/papertrench/pull/105#issuecomment-5494761959). The entry was exact, so the fabricated number was the mark: `entry × ~102`, i.e. a USD price used as a SOL price. Reproduced on Axiom with GPRO at `+1014.0%`.

Dexscreener reports a pair's `priceNative` **in that pair's quote token**. `normalizePair`'s foreign-chain branch already knows this and derives the SOL price from `priceUsd / solUsd`; the Solana branch assumed every Solana pair is SOL-quoted:

```js
-priceNative = isQuote ? 1 / rawPrice : rawPrice;
+const solQuoted = isQuote ? sameAddress(base.address, WSOL_MINT)
+                          : sameAddress(quote.address, WSOL_MINT);
+if (solQuoted) priceNative = isQuote ? 1 / rawPrice : rawPrice;   // unchanged
+else {
+  const rate = Number(opts && opts.solUsd);
+  if (!usdOk || !(rate > 0)) return null;   // refuse, never guess a rate
+  priceNative = priceUsd / rate;
+  solUsdAtResolve = rate;
+}
```

BONK's and GPRO's deepest pools are **USDC-quoted**, and `pickBestPair` correctly picks the deepest pool — so the USDC price landed in `priceNative` and every SOL-denominated consumer downstream (rail mark, portfolio total, unrealized P&L, and any fill priced from the resolver rather than the row) inherited the lie. This is also the most likely source of the ~50,000x mispricing reported earlier, where the quote token was something more exotic than USDC.

A refusal here is not a regression: a mint with no usable rate now marks `stale` from its stored price instead of printing an invented one, which is the rule in `CONTRIBUTING.md`.

The rate has to reach `normalizePair` for the conversion to be possible at all — the Solana callers passed no `opts` whatsoever. `resolver.js` now threads its existing cached rate (`cachedSolUsd()`, the same 30 s cache `solUsd()` already maintains) into the single-token, refresh and batch parse paths, adding **no** per-resolve network request; in `resolve()` the read happens after the parallel Jupiter leg has had its chance to refill that cache.

Audited every other `priceNative` assignment: Jupiter, venue-quote, page-feed and on-chain pool paths derive from a SOL quote by construction or from `priceUsd / rate` already, so `normalizePair` was the only site needing the fix.

Six existing Solana fixtures declared no `quoteToken` at all, which under the old code silently meant "assume SOL". They now state WSOL explicitly — the fixtures were ambiguous, not the assertions.

Selection has to be rate-aware for that refusal to be safe, which Devin Review caught: `pickBestPair` chose before anything knew whether the conversion was possible, so a payload whose *deepest* pool is USDC-quoted yielded nothing when the rate was missing even though it also listed a WSOL-quoted pool needing no rate. Candidates are now ranked once by the existing identity + liquidity rules and the first that actually normalizes under the passed `opts` is taken, in `tokenFromPayload` and per mint in `pricesFromBatch`; `pickBestPair` is the head of that ranking, unchanged for its callers. The ranking comparator also normalizes liquidity through one helper — a non-finite `liquidity.usd` produced `NaN`, which `sort` reads as "equal", so a malformed candidate could keep a deeper pool from being reached.

`resolver.js` now *fetches* the rate rather than only reading the 30 s cache in the batch and refresh paths (`solUsd()` is cache-first, so this is at most one Jupiter request per 30 s for the whole poller): a cold service worker was otherwise the everyday way to get no rate, and the honest refusal would have shown a whole portfolio as `stale`.

## Testing

`cd extension && node --test`: 2,166 passed. `scripts/preflight.sh`: 2,465 across extension/server/bot. New coverage: a USDC-quoted pair converts and records `solUsdAtResolve`, and yields nothing without a rate; WSOL-quoted normalization is unchanged for both requested sides; the batch path converts identically; a `[shallow WSOL, malformed liquidity, deep USDC]` payload prices from the deep pool with a rate and from the WSOL pool without one; a cold-cache batch poll fetches the rate once; and a regression on the live BONK numbers proves the SOL mark is no longer ~102x the entry.

Independent of the #101→#105 stack; based on `main`.

## Follow-up: the mark's own provenance, and two ways a USDC-primary token could still lose its price

The live pass on this branch (evidence in the comment below) proved the ~102x rail P&L gone, but left one position — GPRO, `GPRR2u6NS5yBQHWGauoJ9HXgjrTH8dDsrBfTV5zAYvDH` — marked at `lastPriceUsd 0.605612` / `lastPriceNative 0.0059177`, the *reciprocal* of its real price, on a token GeckoTerminal's minute candles show never traded below `1.4998` in the position's whole life. I could not name the producing source, and that is itself the defect being fixed here: a position recorded the two prices and nothing about where they came from.

```js
-function markPosition(state, mint, priceNative, priceUsd) {
+function markPosition(state, mint, priceNative, priceUsd, meta) {
+  // meta = { priceSource, pairAddress } from the quote that produced the mark;
+  // absent meta leaves the held provenance alone, exactly like priceUsd does.
+  if (previousPrice > 0 && magnitude(priceNative / previousPrice) >= 5) console.debug(...)
```

so a `2.7x` disagreement between a `row-props` mark and a `resolver` mark now prints both sources and both pair addresses at the moment it happens, and the position carries `lastPriceSource` / `lastPricePair` into any state dump. Console only — no setting, no telemetry.

Reading those paths for the source also turned up two real ways this branch's honest refusal could take a price away from a token whose deepest pool is USDC-quoted, which is exactly GPRO's shape (a $70K USDC pool against a $15.8K WSOL one):

- `resolve()` computed `dexOpts` from `cachedSolUsd()` alone. The bundled Jupiter leg refills that cache as a side effect, so this worked — *unless* Jupiter's token leg timed out, in which case a perfectly good $70K pool with a published USD price lost to "aggregators silent" and fell through to the venue path. It now reuses the rate Jupiter itself returned (`viaJup.solUsd`), and, only when a Dexscreener payload did come back and there is still no rate, spends one cache-first `solUsd()` request before giving up.

## Testing

`bash scripts/preflight.sh`: 2,471 passed (extension 2,172 / server 279 / bot 20). Added: batch pricing on GPRO's real pair shapes (deep USDC + shallow WSOL) prices from the WSOL pool with no rate and from the USDC pool with one, and yields nothing when USDC-only and rateless; cold-cache `resolve()` uses Jupiter's returned rate, then one `solUsd()` retry, then venues; provenance is recorded, an absent `meta` preserves it, and a 5x+ disagreement logs exactly one line.

## Review follow-up: SOL's own USD price was being handed to the token quoted against it

Two more of the same family, both real (`5a33850`):

- `normalizePair`'s `isQuote` branch is only reachable when the base **is** WSOL, so `pair.priceUsd` there is SOL's USD price — and the record returned it as the *token's*. `priceUsd` is now `priceNative * pair.priceUsd`, and `solUsdAtResolve` takes `pair.priceUsd`, which is an observed SOL/USD rate rather than a guess; no usable USD on the pair still yields `null`, not a number.
- `requote()` never adopted a refreshed `solUsdAtResolve`, so the rate froze at first resolve for the whole session while the comment above `panelUsdRate()` claimed otherwise — stale foreign-chain USD→SOL sizing and a stale pump.fun fee tier. Both exits now adopt it, falling back to `priceUsd / priceNative` (exactly USD-per-SOL, whatever the pair's quote token), and never clearing a valid rate.

`bash scripts/preflight.sh`: 2,474 passed.


Link to Devin session: https://app.devin.ai/sessions/b676704d774f4aa099ba7f31381b036f
Open in Devin Desktop: https://app.devin.ai/desktop/session/b676704d774f4aa099ba7f31381b036f?variant=devin
Requested by: @OnlyTerp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/papertrench/pull/106" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->