### PR TITLE
feat(quickbuy): remember the list buy chip's size and position per site

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -536,6 +536,23 @@
     window.postMessage({ source: 'papertrench-content', type, payload: payload || null }, '*');
   }
 
+  function listQuickBuyPrefs(source, siteId) {
+    const siteOverride = source.listQuickBuyBySite
+      && typeof source.listQuickBuyBySite === 'object'
+      && source.listQuickBuyBySite[siteId]
+      && typeof source.listQuickBuyBySite[siteId] === 'object'
+      ? source.listQuickBuyBySite[siteId] : {};
+    const siteSize = Number(siteOverride.size);
+    const globalSize = Number(source.listQuickBuySize);
+    const size = Number.isFinite(siteSize) ? siteSize
+      : (globalSize || 1);
+    const globalPlacement = source.listQuickBuyPlacement === 'bottom' ? 'bottom'
+      : source.listQuickBuyPlacement === 'auto' ? 'auto' : null;
+    const placementPref = siteOverride.placement === 'bottom' ? 'bottom'
+      : siteOverride.placement === 'auto' ? 'auto' : globalPlacement;
+    return { size, placementPref };
+  }
+
   /**
    * Value model for the generic SVG overlay. GMGN is not a price chart:
    * its live iframe symbol is `sol/<mint>/USD/MCAP` and its candle endpoint
@@ -6660,17 +6677,17 @@
     if (now - rowBuyScanAt < 350) return;
     rowBuyScanAt = now;
 
+    const listPrefs = listQuickBuyPrefs(settings, site.id);
     sendPadreMarker('row-scan', {
       amount: (settings.presetsBuy || [0.1])[0],
-      size: Math.max(0.6, Math.min(1.5, Number(settings.listQuickBuySize) || 1)),
+      size: Math.max(0.6, Math.min(1.5, listPrefs.size)),
       linkSelectors: site.rowBuy.linkSelectors,
       placement: site.rowBuy.placement,
       // F-53 (jb): 'auto' probes the default anchor and drops to the row's
       // bottom-right gutter when it lands on row content (Axiom/Padre
       // "ultra" compact format puts the MC exactly there); 'bottom' pins
       // the gutter everywhere. Null keeps the per-site default untouched.
-      placementPref: settings.listQuickBuyPlacement === 'bottom' ? 'bottom'
-        : settings.listQuickBuyPlacement === 'auto' ? 'auto' : null,
+      placementPref: listPrefs.placementPref,
       buyButtonPattern: site.rowBuy.buyButtonPattern || null,
       containerMode: site.rowBuy.containerMode || 'heuristic',
     });

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -1070,6 +1070,7 @@
   <script src="trench-grid.js"></script>
   <script src="spark.js"></script>
   <script src="wrapped.js"></script>
+  <script src="sites.js"></script>
   <!-- The modal must exist before dashboard.js runs (D-53): bindShareCard
        silently disables the composer if #card-modal is missing, and the old
        order was safe only by accident of init() being async. -->

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -4480,8 +4480,21 @@ function renderListQuickBuySiteFields() {
   }).join('');
 }
 
-function listQuickBuyOverridesFromForm(adapters, readValue) {
+function listQuickBuyOverridesFromForm(adapters, readValue, baseOverrides) {
   const overrides = {};
+  if (baseOverrides && typeof baseOverrides === 'object' && !Array.isArray(baseOverrides)) {
+    for (const [siteId, raw] of Object.entries(baseOverrides)) {
+      if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
+      const override = {};
+      if (typeof raw.size === 'number' && Number.isFinite(raw.size)) {
+        override.size = Math.max(0.6, Math.min(1.5, raw.size));
+      }
+      if (raw.placement === 'auto' || raw.placement === 'bottom') {
+        override.placement = raw.placement;
+      }
+      if (Object.keys(override).length) overrides[siteId] = override;
+    }
+  }
   for (const adapter of adapters) {
     const placement = readValue(`set-list-quick-buy-placement-${adapter.id}`);
     const sizeRaw = readValue(`set-list-quick-buy-size-${adapter.id}`);
@@ -4492,6 +4505,7 @@ function listQuickBuyOverridesFromForm(adapters, readValue) {
       override.size = Math.max(0.6, Math.min(1.5, size));
     }
     if (Object.keys(override).length) overrides[adapter.id] = override;
+    else delete overrides[adapter.id];
   }
   return overrides;
 }
@@ -5102,6 +5116,7 @@ function gatherSettingsFromForm(notes = [], base = settings) {
   const listQuickBuyBySite = listQuickBuyOverridesFromForm(
     listQuickBuyAdapters(),
     (id) => document.getElementById(id)?.value,
+    base.listQuickBuyBySite,
   );
 
   return {

--- a/extension/dashboard.js
+++ b/extension/dashboard.js
@@ -4440,6 +4440,62 @@ function renderPresetBoxes(id, values, { max, step, unit, addLabel }) {
     <input type="hidden" id="${id}" value="${esc(values.join(', '))}">`;
 }
 
+const LIST_QUICK_BUY_SIZE_OPTIONS = [0.7, 0.85, 1, 1.15, 1.3, 1.5];
+
+function listQuickBuyAdapters() {
+  const adapters = window.PaperTrenchSites && window.PaperTrenchSites.ADAPTERS;
+  return Array.isArray(adapters)
+    ? adapters.filter((adapter) => adapter && adapter.id && adapter.rowBuy)
+    : [];
+}
+
+function renderListQuickBuySiteFields() {
+  const overrides = settings.listQuickBuyBySite
+    && typeof settings.listQuickBuyBySite === 'object'
+    ? settings.listQuickBuyBySite : {};
+  return listQuickBuyAdapters().map((adapter) => {
+    const override = overrides[adapter.id] || {};
+    const size = Number(override.size);
+    const placement = override.placement === 'auto' || override.placement === 'bottom'
+      ? override.placement : '';
+    const sizeOptions = [
+      '<option value="">Use the default</option>',
+      ...LIST_QUICK_BUY_SIZE_OPTIONS.map((value) =>
+        `<option value="${value}" ${size === value ? 'selected' : ''}>${value}x</option>`),
+    ].join('');
+    return `
+      <div class="field">
+        <label>${esc(adapter.name)}</label>
+        <div style="display:flex;gap:8px;flex-wrap:wrap">
+          <select id="set-list-quick-buy-placement-${esc(adapter.id)}" data-list-quick-buy-site="${esc(adapter.id)}" aria-label="${esc(adapter.name)} chip position">
+            <option value="" ${placement === '' ? 'selected' : ''}>Use the default</option>
+            <option value="auto" ${placement === 'auto' ? 'selected' : ''}>Auto</option>
+            <option value="bottom" ${placement === 'bottom' ? 'selected' : ''}>Corner</option>
+          </select>
+          <select id="set-list-quick-buy-size-${esc(adapter.id)}" data-list-quick-buy-site="${esc(adapter.id)}" aria-label="${esc(adapter.name)} chip size">
+            ${sizeOptions}
+          </select>
+        </div>
+      </div>`;
+  }).join('');
+}
+
+function listQuickBuyOverridesFromForm(adapters, readValue) {
+  const overrides = {};
+  for (const adapter of adapters) {
+    const placement = readValue(`set-list-quick-buy-placement-${adapter.id}`);
+    const sizeRaw = readValue(`set-list-quick-buy-size-${adapter.id}`);
+    const size = Number(sizeRaw);
+    const override = {};
+    if (placement === 'auto' || placement === 'bottom') override.placement = placement;
+    if (sizeRaw !== '' && sizeRaw !== null && sizeRaw !== undefined && Number.isFinite(size)) {
+      override.size = Math.max(0.6, Math.min(1.5, size));
+    }
+    if (Object.keys(override).length) overrides[adapter.id] = override;
+  }
+  return overrides;
+}
+
 function renderSettings(el) {
   // D-24: a corrupt backup can leave presetsBuy/sellPcts as non-arrays. An
   // unguarded .join() threw mid-render, leaving Settings blank AND unbound —
@@ -4503,8 +4559,10 @@ function renderSettings(el) {
           <div class="field field-check"><label><input type="checkbox" id="set-list-quick-buy" ${settings.listQuickBuyEnabled !== false ? 'checked' : ''}> One-tap buy buttons on token lists</label><small>A "P" button on every token row of Axiom Pulse, Padre Trenches and GMGN Trenches — buys the first preset amount without opening the chart.</small></div>
           <div class="field field-check"><label><input type="checkbox" id="set-list-quick-open" ${settings.listQuickOpen !== false ? 'checked' : ''}> Open the chart tab after a list buy</label><small>When a one-tap list buy opens a NEW position, its chart opens in a background tab so the position is one click away. Turn off for list-only trading.</small></div>
       <div class="field"><label for="set-panel-theme">Panel theme</label><select id="set-panel-theme"><option value="trench" ${!settings.panelTheme || settings.panelTheme === 'trench' ? 'selected' : ''}>Trench — PaperTrench default (amber on slate)</option><option value="axiom" ${settings.panelTheme === 'axiom' ? 'selected' : ''}>Axiom — dark slate, cyan accents</option><option value="padre" ${settings.panelTheme === 'padre' ? 'selected' : ''}>Padre — warm near-black, amber accents</option><option value="lute" ${settings.panelTheme === 'lute' ? 'selected' : ''}>Lute — deep indigo, violet accents</option><option value="solana" ${settings.panelTheme === 'solana' ? 'selected' : ''}>Solana — void green, terminal phosphor</option></select><small>Skins the PaperTrench overlay to match your dex. The site's own page is never touched — only the panel's colors. Or cycle them live with the ◍ button on the panel header.</small></div>
-      <div class="field"><label for="set-list-quick-buy-size">Buy-button size on lists <span id="val-list-quick-buy-size">${(settings.listQuickBuySize || 1).toFixed(2)}</span>x</label><input id="set-list-quick-buy-size" type="range" min="0.6" max="1.5" step="0.05" value="${Number(settings.listQuickBuySize || 1).toFixed(2)}"><small>Make the list buy buttons larger or smaller to fit your screen density.</small></div>
-      <div class="field"><label for="set-list-quick-buy-placement">Buy-button position on lists</label><select id="set-list-quick-buy-placement"><option value="auto" ${settings.listQuickBuyPlacement !== 'bottom' ? 'selected' : ''}>Auto — next to each row (moves if it covers something)</option><option value="bottom" ${settings.listQuickBuyPlacement === 'bottom' ? 'selected' : ''}>Corner — always bottom-right of the row</option></select><small>Corner pins the P button to the row's bottom-right, clear of the market-cap readout on compact/ultra list formats.</small></div>
+      <div class="field"><label for="set-list-quick-buy-size">Default buy-button size on all sites <span id="val-list-quick-buy-size">${(settings.listQuickBuySize || 1).toFixed(2)}</span>x</label><input id="set-list-quick-buy-size" type="range" min="0.6" max="1.5" step="0.05" value="${Number(settings.listQuickBuySize || 1).toFixed(2)}"><small>Default for sites without their own override. Make list buy buttons larger or smaller to fit your screen density.</small></div>
+      <div class="field"><label for="set-list-quick-buy-placement">Default buy-button position on all sites</label><select id="set-list-quick-buy-placement"><option value="auto" ${settings.listQuickBuyPlacement !== 'bottom' ? 'selected' : ''}>Auto — next to each row (moves if it covers something)</option><option value="bottom" ${settings.listQuickBuyPlacement === 'bottom' ? 'selected' : ''}>Corner — always bottom-right of the row</option></select><small>Default for sites without their own override. Corner pins the P button to the row's bottom-right, clear of the market-cap readout on compact/ultra list formats.</small></div>
+      <div class="field"><label>Per-site list buy buttons</label><small>Override the defaults above only where a site's rows need different sizing or placement. Use the default keeps this map sparse.</small></div>
+      ${renderListQuickBuySiteFields()}
           <div class="field field-check"><label><input type="checkbox" id="set-panel-buy" ${settings.panelBuyEnabled !== false ? 'checked' : ''}> Buy section in the trade tab</label><small>Shows the quick-buy presets, custom amount and BUY button in the overlay. Off makes the trade tab view-only.</small></div>
           <div class="field field-check"><label><input type="checkbox" id="set-panel-presets" ${settings.panelPresetsEnabled !== false ? 'checked' : ''}> Quick-buy preset buttons</label><small>The one-tap SOL amount buttons. Off keeps the custom amount and BUY button.</small></div>
         <div class="field field-check"><label><input type="checkbox" id="set-panel-custom" ${settings.panelCustomAmount === true ? 'checked' : ''}> Custom amount box</label><small>A free-text SOL amount under the presets. Off by default — the preset row is eight boxes you configure above, so an arbitrary size is rarely needed and the field costs three lines of panel on every token. BUY and limit orders use the selected preset when it is off.</small></div>
@@ -5041,6 +5099,11 @@ function gatherSettingsFromForm(notes = [], base = settings) {
   if (!presets.length) notes.push('quick-buy presets were empty — defaults restored');
   if (!sellPcts.length) notes.push('quick-sell presets were empty — defaults restored');
 
+  const listQuickBuyBySite = listQuickBuyOverridesFromForm(
+    listQuickBuyAdapters(),
+    (id) => document.getElementById(id)?.value,
+  );
+
   return {
     balanceStartSol,
     // D-11: integers 0..1000 only — a negative fee inverts the arithmetic.
@@ -5062,6 +5125,7 @@ function gatherSettingsFromForm(notes = [], base = settings) {
     panelTheme: document.getElementById('set-panel-theme').value,
     listQuickBuySize: Math.max(0.6, Math.min(1.5, Number(document.getElementById('set-list-quick-buy-size').value) || 1)),
     listQuickBuyPlacement: document.getElementById('set-list-quick-buy-placement').value === 'bottom' ? 'bottom' : 'auto',
+    listQuickBuyBySite,
     chartOrderLineThickness: Math.max(1, Math.min(4, Math.round(Number(document.getElementById('set-chart-line-thickness').value) || 2))),
     panelBuyEnabled: document.getElementById('set-panel-buy').checked,
     panelPresetsEnabled: document.getElementById('set-panel-presets').checked,

--- a/extension/engine.js
+++ b/extension/engine.js
@@ -59,6 +59,9 @@
     // 'bottom' pins the gutter anchor everywhere. The maintainer default is
     // auto: the collision is the exception, not the rule.
     listQuickBuyPlacement: 'auto',
+    // Sparse per-site overrides for list quick-buy chip size and placement.
+    // An absent site or field follows the global setting above.
+    listQuickBuyBySite: {},
     // TradingView order/level line width for TP/SL and average-entry lines.
     // 1 = hairline (old hard-coded look), 2 = default, 3 = thick, easier to
     // read on dense charts and small screens. Same knob for both line
@@ -227,6 +230,24 @@
     return JSON.parse(JSON.stringify(DEFAULT_SETTINGS));
   }
 
+  function normalizeListQuickBuyBySite(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+    const entries = [];
+    for (const [siteId, raw] of Object.entries(value)) {
+      if (!raw || typeof raw !== 'object' || Array.isArray(raw)) continue;
+      const override = {};
+      const size = raw.size;
+      if (typeof size === 'number' && Number.isFinite(size)) {
+        override.size = Math.max(0.6, Math.min(1.5, size));
+      }
+      if (raw.placement === 'auto' || raw.placement === 'bottom') {
+        override.placement = raw.placement;
+      }
+      if (Object.keys(override).length) entries.push([siteId, override]);
+    }
+    return Object.fromEntries(entries);
+  }
+
   /**
    * Merge stored settings over defaults, applying one-time migrations.
    *
@@ -255,6 +276,7 @@
   const OLD_LOCAL_AI_ENDPOINT = 'http://127.0.0.1:8765/v1';
   function mergeSettings(stored) {
     const merged = Object.assign(defaultSettings(), stored || {});
+    merged.listQuickBuyBySite = normalizeListQuickBuyBySite(merged.listQuickBuyBySite);
     if (!stored) return merged;
 
     const revision = Number(stored.settingsRevision) || 0;
@@ -2447,6 +2469,7 @@
     STORAGE_KEYS,
     DEFAULT_SETTINGS,
     defaultSettings,
+    normalizeListQuickBuyBySite,
     mergeSettings,
     SETTINGS_REVISION,
     defaultState,

--- a/extension/price-bridge.js
+++ b/extension/price-bridge.js
@@ -3387,9 +3387,12 @@
         anchor = { x: rect.right - 6, y: rect.bottom - 6, align: 'right-bottom' };
       }
     } else if (place.mode === 'badge') {
-      // Straddling the card's top-right edge: half in the row gutter, half
-      // over the card's own top padding — clear of the MC/stat text.
-      anchor = { x: rect.right - 8, y: rect.top, align: 'right-center' };
+      // Auto/unset deliberately straddles the card's top-right edge; unlike
+      // float mode, it is not a layout guess to probe. Corner still pins the
+      // chip to the same clear bottom-right gutter as the other modes.
+      anchor = entry.placementPref === 'bottom'
+        ? { x: rect.right - 6, y: rect.bottom - 6, align: 'right-bottom' }
+        : { x: rect.right - 8, y: rect.top, align: 'right-center' };
     } else {
       anchor = { x: rect.right - 6, y: rect.top + 6, align: 'right-top' };
       // F-53 (jb, Axiom "ultra" format): compact rows put the market cap

--- a/extension/test/chartlinesettings.test.js
+++ b/extension/test/chartlinesettings.test.js
@@ -43,9 +43,11 @@ test('the paper-orders payload carries the clamped lineWidth', () => {
 });
 
 test('the row-scan payload carries placementPref only for explicit choices', () => {
-  assert.match(content, /placementPref: settings\.listQuickBuyPlacement === 'bottom' \? 'bottom'/,
+  assert.match(content, /const globalPlacement = source\.listQuickBuyPlacement === 'bottom' \? 'bottom'/,
     "'bottom' must reach the bridge as a pin");
-  assert.match(content, /: settings\.listQuickBuyPlacement === 'auto' \? 'auto' : null,/,
+  assert.match(content, /const placementPref = siteOverride\.placement === 'bottom' \? 'bottom'/,
+    'a valid per-site pin must take precedence over the global setting');
+  assert.match(content, /: siteOverride\.placement === 'auto' \? 'auto' : globalPlacement;/,
     "anything unset must send null so per-site defaults survive");
 });
 

--- a/extension/test/nativecharts.test.js
+++ b/extension/test/nativecharts.test.js
@@ -204,6 +204,7 @@ function runBridge(opts = {}) {
   // ---- optional screener-row DOM for the chip occlusion tests (O-22) ----
   let panelOverChip = false;
   let rowDomNodes = null;
+  const chipNodes = [];
   function makeChipNode(tag) {
     return {
       tag, style: {}, isConnected: true, children: [],
@@ -250,6 +251,7 @@ function runBridge(opts = {}) {
     node.style = new Proxy(plain, {
       set(target, prop, value) { styleWrites += 1; target[prop] = value; return true; },
     });
+    chipNodes.push(node);
     return node;
   }
   if (rowDomNodes) {
@@ -341,6 +343,9 @@ function runBridge(opts = {}) {
     enableAxiom: () => { axiomVisible = true; },
     setPanelOverChip: (on) => { panelOverChip = Boolean(on); },
     rowDebug: () => (typeof win.__ptRowChipDebug === 'function' ? win.__ptRowChipDebug() : []),
+    rowChipStyles: () => chipNodes
+      .filter((node) => node.className === 'pt-rowbuy')
+      .map((node) => ({ ...node.style })),
     styleWrites: () => styleWrites,
     resetStyleWrites: () => { styleWrites = 0; },
     axiomRealtime: () => axiomRealtime,
@@ -1961,6 +1966,38 @@ test('Turbo: a steady-state chip sweep performs zero style writes', () => {
   env.runTimers();
   assert.equal(env.styleWrites(), 0,
     'an unmoved chip must cost zero style writes — writes are what dirty layout for the next read');
+});
+
+test('GMGN badge chips honor Corner while preserving Auto and unset placement', () => {
+  const env = runBridge({ rowDom: true, href: 'https://gmgn.ai/trenches' });
+  const scan = {
+    amount: 0.1, size: 1,
+    linkSelectors: ['a.testrow'],
+    placement: 'badge',
+    buyButtonPattern: null,
+    containerMode: 'heuristic',
+  };
+
+  env.send('row-scan', { ...scan, placementPref: 'bottom' });
+  assert.deepEqual(env.rowChipStyles()[0] && {
+    left: env.rowChipStyles()[0].left,
+    top: env.rowChipStyles()[0].top,
+  }, { left: '504px', top: '174px' },
+  'Corner must use the row bottom-right gutter');
+
+  env.send('row-scan', { ...scan, placementPref: 'auto' });
+  assert.deepEqual(env.rowChipStyles()[0] && {
+    left: env.rowChipStyles()[0].left,
+    top: env.rowChipStyles()[0].top,
+  }, { left: '502px', top: '100px' },
+  'Auto must retain the existing badge anchor');
+
+  env.send('row-scan', scan);
+  assert.deepEqual(env.rowChipStyles()[0] && {
+    left: env.rowChipStyles()[0].left,
+    top: env.rowChipStyles()[0].top,
+  }, { left: '502px', top: '100px' },
+  'Unset placement must retain the existing badge anchor');
 });
 
 test('Turbo source contract: the chip sweep separates reads from writes', () => {

--- a/extension/test/persitequickbuy.test.js
+++ b/extension/test/persitequickbuy.test.js
@@ -1,0 +1,121 @@
+/* Per-site list quick-buy settings stay sparse, bounded and live. */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const ROOT = path.join(__dirname, '..');
+const E = require(path.join(ROOT, 'engine.js'));
+const content = fs.readFileSync(path.join(ROOT, 'content.js'), 'utf8');
+const dashboard = fs.readFileSync(path.join(ROOT, 'dashboard.js'), 'utf8');
+const dashboardHtml = fs.readFileSync(path.join(ROOT, 'dashboard.html'), 'utf8');
+
+function fnBlock(source, signature) {
+  const start = source.indexOf(signature);
+  assert.ok(start !== -1, `missing ${signature}`);
+  const brace = source.indexOf('{', start);
+  let depth = 0;
+  for (let i = brace; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (!depth) return source.slice(start, i + 1);
+    }
+  }
+  throw new Error(`unterminated ${signature}`);
+}
+
+test('per-site list chip overrides sanitize on settings read', () => {
+  assert.deepEqual(E.DEFAULT_SETTINGS.listQuickBuyBySite, {});
+  const merged = E.mergeSettings({
+    listQuickBuySize: 1.2,
+    listQuickBuyPlacement: 'bottom',
+    listQuickBuyBySite: {
+      axiom: { size: 2, placement: 'auto' },
+      padre: { size: 0.4, placement: 'corner' },
+      gmgn: { size: 'not-a-number', placement: 'bottom' },
+      empty: { placement: 'junk' },
+      malformed: 'ignore me',
+      stringSize: { size: '1.15', placement: 'auto' },
+    },
+  });
+  assert.deepEqual(merged.listQuickBuyBySite, {
+    axiom: { size: 1.5, placement: 'auto' },
+    padre: { size: 0.6 },
+    gmgn: { placement: 'bottom' },
+    stringSize: { placement: 'auto' },
+  });
+});
+
+test('list scan preferences use per-site fields, then global fields, then defaults', () => {
+  const helper = fnBlock(content, 'function listQuickBuyPrefs(');
+  const prefs = vm.runInNewContext(`(${helper})`);
+  assert.deepEqual(JSON.parse(JSON.stringify(prefs({
+    listQuickBuySize: 1.2, listQuickBuyPlacement: 'bottom',
+    listQuickBuyBySite: { axiom: { size: 0.7, placement: 'auto' } },
+  }, 'axiom'))), { size: 0.7, placementPref: 'auto' });
+  assert.deepEqual(JSON.parse(JSON.stringify(prefs({
+    listQuickBuySize: 1.2, listQuickBuyPlacement: 'bottom',
+    listQuickBuyBySite: {},
+  }, 'padre'))), { size: 1.2, placementPref: 'bottom' });
+  assert.deepEqual(JSON.parse(JSON.stringify(prefs({
+    listQuickBuySize: 1.2, listQuickBuyPlacement: 'bottom',
+    listQuickBuyBySite: { gmgn: { placement: 'auto' } },
+  }, 'gmgn'))), { size: 1.2, placementPref: 'auto' });
+  assert.deepEqual(JSON.parse(JSON.stringify(prefs({
+    listQuickBuySize: 0, listQuickBuyPlacement: 'invalid',
+    listQuickBuyBySite: { gmgn: { size: 99, placement: 'invalid' } },
+  }, 'gmgn'))), { size: 99, placementPref: null });
+  const scan = fnBlock(content, 'function scanRowBuys()');
+  assert.match(scan, /Math\.max\(0\.6, Math\.min\(1\.5, listPrefs\.size\)\)/,
+    'the bridge payload retains the outgoing size clamp');
+});
+
+test('dashboard renders row-buy adapters dynamically and saves a sparse map', () => {
+  assert.match(dashboard, /window\.PaperTrenchSites\.ADAPTERS|window\.PaperTrenchSites && window\.PaperTrenchSites\.ADAPTERS/);
+  assert.match(dashboard, /\.filter\(\(adapter\) => adapter && adapter\.id && adapter\.rowBuy\)/,
+    'site controls must derive from adapters that have rowBuy');
+  assert.match(dashboard, /Use the default/);
+  assert.match(dashboard, />Auto<\/option>/);
+  assert.match(dashboard, />Corner<\/option>/);
+  assert.match(dashboard, /LIST_QUICK_BUY_SIZE_OPTIONS = \[0\.7, 0\.85, 1, 1\.15, 1\.3, 1\.5\]/,
+    'the size selector offers the specified choices');
+  const overridesHelper = fnBlock(dashboard, 'function listQuickBuyOverridesFromForm(');
+  const overridesFromForm = vm.runInNewContext(`(${overridesHelper})`);
+  const values = {
+    'set-list-quick-buy-placement-axiom': 'auto',
+    'set-list-quick-buy-size-axiom': '0.7',
+    'set-list-quick-buy-placement-padre': '',
+    'set-list-quick-buy-size-padre': '',
+    'set-list-quick-buy-placement-gmgn': 'bottom',
+    'set-list-quick-buy-size-gmgn': '',
+  };
+  const sparse = overridesFromForm(
+    [{ id: 'axiom' }, { id: 'padre' }, { id: 'gmgn' }],
+    (id) => values[id],
+  );
+  assert.deepEqual(JSON.parse(JSON.stringify(sparse)), {
+    axiom: { placement: 'auto', size: 0.7 },
+    gmgn: { placement: 'bottom' },
+  }, 'default/default sites are omitted so old overrides are deleted');
+  const gather = fnBlock(dashboard, 'function gatherSettingsFromForm(');
+  const overrideHelper = fnBlock(dashboard, 'function listQuickBuyOverridesFromForm(');
+  assert.match(overrideHelper, /const overrides = \{\};/);
+  assert.match(overrideHelper, /if \(Object\.keys\(override\)\.length\) overrides\[adapter\.id\] = override;/,
+    'both default selects omit the site and delete an old override on save');
+  assert.match(gather, /listQuickBuyBySite,/);
+  assert.ok(dashboardHtml.indexOf('<script src="sites.js"></script>')
+    < dashboardHtml.indexOf('<script src="dashboard.js"></script>'),
+  'sites.js must load before the dashboard');
+});
+
+test('settings changes merge live before the next throttled row scan', () => {
+  const listener = fnBlock(content, 'function watchStorage(');
+  assert.match(listener, /settings = E\.mergeSettings\(settingsChange\.newValue\)/,
+    'storage changes replace content settings with the sanitized merged map');
+  assert.match(listener, /publishPageState\(\)/,
+    'the existing live settings publication path remains active');
+  assert.match(content, /if \(now - rowBuyScanAt < 350\) return;/,
+    'the next eligible scan, without reload, forwards the refreshed settings');
+});

--- a/extension/test/persitequickbuy.test.js
+++ b/extension/test/persitequickbuy.test.js
@@ -99,12 +99,29 @@ test('dashboard renders row-buy adapters dynamically and saves a sparse map', ()
     axiom: { placement: 'auto', size: 0.7 },
     gmgn: { placement: 'bottom' },
   }, 'default/default sites are omitted so old overrides are deleted');
+  const stored = {
+    axiom: { size: 1.3, placement: 'bottom' },
+    padre: { size: 0.85 },
+  };
+  assert.deepEqual(JSON.parse(JSON.stringify(overridesFromForm(
+    [], () => { throw new Error('no controls should be read'); }, stored,
+  ))), stored, 'an empty adapter list must preserve stored overrides');
+  const absentSite = overridesFromForm(
+    [{ id: 'axiom' }],
+    () => '',
+    stored,
+  );
+  assert.deepEqual(JSON.parse(JSON.stringify(absentSite)), {
+    padre: { size: 0.85 },
+  }, 'defaulting a rendered site deletes it while an absent site survives');
   const gather = fnBlock(dashboard, 'function gatherSettingsFromForm(');
   const overrideHelper = fnBlock(dashboard, 'function listQuickBuyOverridesFromForm(');
   assert.match(overrideHelper, /const overrides = \{\};/);
   assert.match(overrideHelper, /if \(Object\.keys\(override\)\.length\) overrides\[adapter\.id\] = override;/,
     'both default selects omit the site and delete an old override on save');
   assert.match(gather, /listQuickBuyBySite,/);
+  assert.match(gather, /base\.listQuickBuyBySite/,
+    'saves must patch the fresh base map rather than rebuilding from rendered rows');
   assert.ok(dashboardHtml.indexOf('<script src="sites.js"></script>')
     < dashboardHtml.indexOf('<script src="dashboard.js"></script>'),
   'sites.js must load before the dashboard');

--- a/site/index.html
+++ b/site/index.html
@@ -117,7 +117,7 @@
   <span class="home-credits-kicker">proof</span>
   <span class="home-credits-item"><span class="home-credits-role">terminals</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="sites">15</b></span>
   <span class="home-credits-item"><span class="home-credits-role">invented prices</span><span class="home-credits-rule" aria-hidden="true"></span><b>0</b></span>
-  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2451</b></span>
+  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2452</b></span>
   <span class="home-credits-item"><span class="home-credits-role">local</span><span class="home-credits-rule" aria-hidden="true"></span><b>100%</b></span>
 </p>
 

--- a/site/index.html
+++ b/site/index.html
@@ -117,7 +117,7 @@
   <span class="home-credits-kicker">proof</span>
   <span class="home-credits-item"><span class="home-credits-role">terminals</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="sites">15</b></span>
   <span class="home-credits-item"><span class="home-credits-role">invented prices</span><span class="home-credits-rule" aria-hidden="true"></span><b>0</b></span>
-  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2457</b></span>
+  <span class="home-credits-item"><span class="home-credits-role">tests</span><span class="home-credits-rule" aria-hidden="true"></span><b data-check="tests">2451</b></span>
   <span class="home-credits-item"><span class="home-credits-role">local</span><span class="home-credits-rule" aria-hidden="true"></span><b>100%</b></span>
 </p>
 

--- a/site/news.html
+++ b/site/news.html
@@ -57,7 +57,7 @@
       <!-- 2299 = 2072 extension + 211 server + 16 bot. Preflight recomputes
            data-check="tests" and data-check="defects" and fails the release
            if either disagrees. Update them together with that check. -->
-      <span><b data-check="tests">2451</b> tests passing</span>
+      <span><b data-check="tests">2452</b> tests passing</span>
       <span><b data-check="defects">195</b> defects closed</span>
       <span><b>0</b> numbers invented</span>
     </div>

--- a/site/news.html
+++ b/site/news.html
@@ -57,7 +57,7 @@
       <!-- 2299 = 2072 extension + 211 server + 16 bot. Preflight recomputes
            data-check="tests" and data-check="defects" and fails the release
            if either disagrees. Update them together with that check. -->
-      <span><b data-check="tests">2457</b> tests passing</span>
+      <span><b data-check="tests">2451</b> tests passing</span>
       <span><b data-check="defects">195</b> defects closed</span>
       <span><b>0</b> numbers invented</span>
     </div>


### PR DESCRIPTION
## Summary

The list buy-chip's size and position were **one global pair of settings**, so tuning them for one board broke the others: Axiom Pulse rows are dense and re-sort every second, Padre's Trenches cards are tall with their own SOL pill at the bottom, and GMGN's Trenches is a narrow table. A chip that sits clear of everything on one of them covers the market cap on another. The complaint was that the placement has to be remembered per site, and it now is.

The mechanism is untouched — the bridge still anchors, collision-probes and scales each chip exactly as before. Only the source of the two values changes:

```js
// content.js — scanRowBuys()
-size:         clamp(settings.listQuickBuySize)
-placementPref: settings.listQuickBuyPlacement
+const prefs = listQuickBuyPrefs(settings, site.id);   // per-site → global → default
+size:         clamp(prefs.size)
+placementPref: prefs.placementPref
```

`settings.listQuickBuyBySite` is a **sparse** map `siteId -> { size?, placement? }` keyed by the adapter `id` in `sites.js`. Sparse is the point: an absent site — or an absent field on a present site — keeps following the existing global setting, so no existing layout moves on upgrade, and returning a site's controls to *Use the default* actually deletes its entry rather than freezing today's global into it. `mergeSettings` sanitizes the map on read (clamped `size`, `placement` only `'auto'`/`'bottom'`, junk entries dropped), because a settings map is user-editable through backup import.

The dashboard's per-site controls are **derived from the adapters themselves** — `ADAPTERS.filter((a) => a.rowBuy)` — so a future row-buy site appears here on its own instead of waiting for someone to remember this file. Both controls are selects rather than sliders: a select can say *Use the default*, and a slider has no position that honestly means "unset".

The one non-obvious hazard, caught in review of the first commit: the save originally rebuilt the map from the rendered rows alone, so an empty adapter list (`sites.js` failing to load, or `window.PaperTrenchSites` absent) would have written `{}` and wiped every override the user had — and the settings form saves on every edit, so an unrelated toggle would have done it. The save is now a patch over the stored map: rendered sites are set or deleted, sites with no rendered controls keep what they had.

## Testing

`cd extension && node --test`: 2,152 passed. `bash scripts/preflight.sh`: 2,451 across extension/server/bot. New `extension/test/persitequickbuy.test.js` covers the precedence chain (per-site wins, absent site and absent field fall back to the global), read-time clamping of an out-of-range size and rejection of a junk placement, the dashboard list being derived from the adapters with a `rowBuy` spec, `sites.js` loading before `dashboard.js`, and the save's sparseness in both directions — a defaulted site is deleted, while an empty adapter list and a site absent from the form preserve their overrides.

Not yet exercised in a browser; the next live pass on the logged-in terminals will confirm the chip actually moves and resizes per site.

Based on `main`, independent of the #101→#106 work.

## Review follow-up: Corner did nothing on GMGN

GMGN's `rowBuy.placement` is `'badge'`, and that branch of `positionRowChip` set its anchor unconditionally while `before-buy-button` and the float branch both honour `entry.placementPref === 'bottom'`. Dormant while the setting was global; with a GMGN-labelled Corner control in the dashboard it would have been a control that visibly does nothing, so badge mode now drops to the same bottom-right gutter anchor (`62dff96`).

Deliberately not done: adding the `rowAnchorHitsContent` probe to badge mode for `'auto'`. The float anchor's probe exists because top-right is a *guess* about the row's layout; the badge anchor straddles the card's top edge on purpose, so changing GMGN's default placement on an unproven probe belongs in its own change, verified on the live board.

`bash scripts/preflight.sh`: 2,452 passed. The new coverage drives the real bridge sweep and asserts the applied anchor, rather than matching source.


Link to Devin session: https://app.devin.ai/sessions/b676704d774f4aa099ba7f31381b036f
Open in Devin Desktop: https://app.devin.ai/desktop/session/b676704d774f4aa099ba7f31381b036f?variant=devin
Requested by: @OnlyTerp
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/onlyterp/papertrench/pull/107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->