### PR TITLE
fix(panel): the BUY label was green text on its own green background

### DIFF
--- a/extension/content.js
+++ b/extension/content.js
@@ -4919,10 +4919,17 @@
     .pt-box.pt-micro .pt-led .k { font-size: 7.5px; }
     .pt-box.pt-micro .pt-led .v { font-size: 10px; }
     .pt-box.pt-focus .pt-ledger { gap: 3px; }
-    /* Direction is colour before it is text: the buy chips read green, the
-       sell ladder red, so a mis-click is visible before it is a fill. */
+    /* Direction is colour before it is text: the preset chips read green, the
+       sell ladder red, so a mis-click is visible before it is a fill.
+       .pt-buy is deliberately NOT in this list. Its own rule above already
+       sets high-contrast dark text (#032B1B) against its solid green
+       gradient — a bare .pt-buy here overrode that with --pt-green (#34D399)
+       text on the SAME green gradient, which is green-on-green: "BUY" went
+       to near-zero contrast, reported from the field as the label being
+       invisible on the main panel's buy button. The preset chips and the
+       sell button do not have this collision — their backgrounds are
+       transparent/dark, not drawn from the same swatch as their text. */
     .pt-preset { color: var(--pt-green); }
-    .pt-buy { color: var(--pt-green); }
     .pt-sell { color: var(--pt-red); }
     .pt-sell:disabled, .pt-preset:disabled { opacity: 0.4; cursor: not-allowed; }
 

--- a/extension/test/d67_buycontrast.test.js
+++ b/extension/test/d67_buycontrast.test.js
@@ -1,0 +1,84 @@
+/* D-67: the main BUY button's label went invisible — green text on its own
+ * green gradient.
+ *
+ * Reported from the field (screenshot, Padre "Terminal" view): the panel's
+ * primary buy button rendered as a solid green pill with no legible "BUY".
+ *
+ * Root cause, found by reading the two .pt-buy rules in order:
+ *
+ *   .pt-buy {                                    // the base rule
+ *     background: linear-gradient(180deg, #3FE49B, #22B573);
+ *     color: #032B1B;                             // dark, deliberately
+ *   }
+ *   ...
+ *   .pt-buy { color: var(--pt-green); }           // --pt-green: #34D399
+ *
+ * Both selectors have equal specificity (one class each), so the LATER rule
+ * wins by cascade order regardless of what the first one intended. The
+ * override was written for the small preset chips and the sell ladder —
+ * "the buy chips read green, the sell ladder red" — where it is legible
+ * because those elements have a transparent or dark background, not one
+ * drawn from the same swatch as the text sitting on it. .pt-buy was caught
+ * in the same bare selector by accident and inherited a background it was
+ * never designed against: #34D399 text on a #3FE49B→#22B573 background is
+ * green-on-green, near-zero contrast.
+ *
+ * git blame: introduced by 92d11baf ("the panel keeps its shape, held or
+ * not"), which added the direction-colour block without checking it against
+ * .pt-buy's own earlier rule.
+ *
+ * Fix: .pt-buy is no longer in the override list. Locked here at the source
+ * level so a future edit to that block cannot silently re-add it.
+ */
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'content.js'), 'utf8');
+
+/** Every bare `.SELECTOR { ... }` rule, in source order, most-specific-last
+ *  matching the exact class (not `.pt-buy-armed`, not `.pt-box .pt-buy`). */
+function bareRules(selector) {
+  const re = new RegExp(
+    '(?<![.\\w-])' + selector.replace('.', '\\.') + '\\s*\\{([^}]*)\\}', 'g');
+  return [...src.matchAll(re)].map((m) => m[1]);
+}
+
+test('D-67/1: no rule ever sets .pt-buy\'s text to --pt-green again', () => {
+  const rules = bareRules('.pt-buy');
+  assert.ok(rules.length >= 1, '.pt-buy must still exist');
+  for (const body of rules) {
+    assert.doesNotMatch(body, /color:\s*var\(--pt-green\)/,
+      'green text on the button\'s own green gradient is the exact bug '
+      + '(field report: the BUY label unreadable in Padre Terminal)');
+  }
+});
+
+test('D-67/2: the base .pt-buy rule keeps its deliberate dark, high-contrast text', () => {
+  const rules = bareRules('.pt-buy');
+  const base = rules.find((body) => /background:\s*linear-gradient/.test(body));
+  assert.ok(base, 'the base rule (the one with the green gradient) must exist');
+  assert.match(base, /color:\s*#032B1B/,
+    'dark text against the light green gradient is what makes the label legible');
+});
+
+test('D-67/3: the direction-colour block still colours what it can safely colour', () => {
+  // The fix must be surgical: .pt-preset and .pt-sell keep their intended
+  // colouring, only .pt-buy is excluded. Losing the other two would be
+  // trading one regression for another.
+  assert.match(src, /\.pt-preset\s*\{\s*color:\s*var\(--pt-green\)/,
+    'preset chips must still read green — they have no background collision');
+  assert.match(src, /\.pt-sell\s*\{\s*color:\s*var\(--pt-red\)/,
+    'the sell ladder must still read red');
+});
+
+test('D-67/4: the armed state (a different class) is untouched by any of this', () => {
+  // .pt-buy-armed is not `.pt-buy` and was never part of the bug — confirm
+  // the fix did not accidentally touch it.
+  const armed = bareRules('.pt-buy-armed');
+  assert.ok(armed.length >= 1, '.pt-buy-armed must still exist');
+  assert.match(armed[0], /color:\s*#2A1400/, 'armed keeps its own dark text');
+});

--- a/extension/test/positionledger.test.js
+++ b/extension/test/positionledger.test.js
@@ -143,8 +143,18 @@ test('a live position re-arms everything the empty state switched off', () => {
 
 test('direction is colour-coded before it is read', () => {
   assert.match(content, /\.pt-preset \{ color: var\(--pt-green\); \}/, 'buy chips are green');
-  assert.match(content, /\.pt-buy \{ color: var\(--pt-green\); \}/, 'so is the BUY button');
   assert.match(content, /\.pt-sell \{ color: var\(--pt-red\); \}/, 'the sell ladder is red');
+  // D-67: the BUY button is deliberately NOT in this list. It already
+  // carries its own colour-as-direction cue through its solid green
+  // gradient background — text on top of that has to be the high-contrast
+  // dark colour its own rule sets, not the same green the background is
+  // drawn from. Asserting `.pt-buy { color: var(--pt-green) }` here is
+  // exactly the assertion that pinned the bug: a field report found the
+  // BUY label unreadable (green-on-green) because a later bare `.pt-buy`
+  // rule overrode the base one by cascade order. See
+  // test/d67_buycontrast.test.js for the regression coverage.
+  assert.doesNotMatch(content, /\.pt-buy \{ color: var\(--pt-green\); \}/,
+    'the BUY label must not be set to the same green as its own background');
 });
 
 test('each ledger figure gets its own box', () => {


### PR DESCRIPTION
Field report (screenshot, Padre "Terminal" view): the main panel's BUY button renders as a solid green pill with **no legible label**. This is not scoped to Terminal or to Padre — it hits every site, every panel size.

## Root cause

Two rules set `.pt-buy`'s text colour, equal specificity, later one wins:

```css
.pt-buy {                                    /* the base rule */
  background: linear-gradient(180deg, #3FE49B, #22B573);
  color: #032B1B;                            /* dark, deliberately */
}
...
.pt-buy { color: var(--pt-green); }          /* --pt-green: #34D399 */
```

`#34D399` text on a `#3FE49B → #22B573` background is green-on-green — near-zero contrast, exactly the screenshot.

**git blame:** the override was added by `92d11baf` ("the panel keeps its shape, held or not") for the preset chips and sell ladder — *"the buy chips read green, the sell ladder red"* — and it's correct there, because those elements have transparent/dark backgrounds, not ones drawn from the same swatch as their text. `.pt-buy` was caught in the same bare selector by accident and inherited a background it was never designed against.

## Fix

`.pt-buy` is removed from the override list. Preset chips and the sell ladder keep their colouring exactly as before — this is a one-line, surgical fix, not a redesign.

## The existing test asserted the bug

`positionledger.test.js` had:

```js
assert.match(content, /\.pt-buy \{ color: var\(--pt-green\); \}/, 'so is the BUY button');
```

That's the bug, written down as the passing contract — it could never have caught this. Corrected to assert the rule's *absence* instead.

## Verification

New `test/d67_buycontrast.test.js` (4 tests): no rule may ever set `.pt-buy`'s text back to `--pt-green`; the base rule keeps its dark colour; preset/sell colouring is untouched; `.pt-buy-armed` (a different class, never part of this) is confirmed unaffected.

**Negative control** — reintroducing the one deleted line:
```
✖ D-67/1: no rule ever sets .pt-buy's text to --pt-green again
```
Removed again: all 4 pass.

Extension **2396/2396**, server **300/300**, all site guards pass.