### PR TITLE
feat(site): a hamburger for the phone nav

### DIFF
--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -95,6 +95,22 @@ for page in site/*.html; do
 done
 [ -z "$A11Y_MISSING" ] || fail "pages missing accessibility landmarks —$A11Y_MISSING"
 echo "a11y OK (skip link, main landmark and named nav on $(grep -lc 'class="skip-link"' site/*.html | wc -l) pages)"
+
+# The hamburger is part of the nav contract. Below 860px the row hides every
+# page link, so a page that carries the standard nav but not the burger (or
+# not the toggle that opens it) ships a phone view with exactly two
+# destinations and no way to reach the rest of the site. Checked, not
+# remembered — same rule as the nav destinations above.
+MOBILE_NAV_MISSING=""
+for page in site/*.html; do
+  grep -q 'class="nav-links"' "$page" || continue
+  grep -q 'class="nav-burger"' "$page" || MOBILE_NAV_MISSING="$MOBILE_NAV_MISSING $(basename "$page"):burger"
+  grep -q 'id="nav-menu"'      "$page" || MOBILE_NAV_MISSING="$MOBILE_NAV_MISSING $(basename "$page"):menu-id"
+  grep -q 'nav-toggle.js'      "$page" || MOBILE_NAV_MISSING="$MOBILE_NAV_MISSING $(basename "$page"):toggle-script"
+done
+[ -z "$MOBILE_NAV_MISSING" ] || fail "mobile nav incomplete —$MOBILE_NAV_MISSING"
+echo "mobile nav OK (burger, menu id and toggle on $(grep -lc 'class="nav-burger"' site/*.html | wc -l) pages)"
+
 # The site links its pages extensionless. A "<page>.html" string left in JS
 # is not a broken link — .html still resolves — which is exactly why it
 # survives review: it works, it is just the wrong spelling, and it escapes

--- a/server/test/worker.test.js
+++ b/server/test/worker.test.js
@@ -810,9 +810,13 @@ test('layering: logged-out page empty falls through to the user token', async ()
 
 test('sealed OAuth tokens survive the round trip and refuse tampering', async () => {
   const xfeed = (await import('../worker/xfeed.js')).default;
-  const pair = { access: 'tok-abc', refresh: 'r1', exp: 123456789 };
+  // The refresh token must be long enough that a coincidental base64url
+  // substring match cannot happen: 'r1' collides with ~1.4% of random
+  // ciphertexts, flaking this test (and preflight with it) about one run
+  // in seventy through no fault of the cipher.
+  const pair = { access: 'tok-abc', refresh: 'refresh-token-material', exp: 123456789 };
   const sealed = await xfeed.sealTokens(SECRET, pair);
-  assert.ok(!sealed.includes('tok-abc') && !sealed.includes('r1'),
+  assert.ok(!sealed.includes('tok-abc') && !sealed.includes('refresh-token-material'),
     'ciphertext carries no plaintext token material');
   assert.deepEqual(await xfeed.openTokens(SECRET, sealed), pair);
   const mid = Math.floor(sealed.length / 2);

--- a/site/404.html
+++ b/site/404.html
@@ -136,7 +136,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="/assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -256,6 +259,7 @@
 <script src="/vendor/gsap.min.js"></script>
 <script src="/film-boot.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <script>
 (() => {

--- a/site/admin-mod.html
+++ b/site/admin-mod.html
@@ -166,7 +166,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -277,6 +280,7 @@
 
 <script src="admin-mod.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/admin.html
+++ b/site/admin.html
@@ -163,7 +163,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -269,6 +272,7 @@
 
 <script src="admin.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/clan.html
+++ b/site/clan.html
@@ -27,7 +27,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -527,6 +530,7 @@
 })();
 </script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/clans.html
+++ b/site/clans.html
@@ -27,7 +27,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -562,6 +565,7 @@
 })();
 </script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/duel.html
+++ b/site/duel.html
@@ -318,7 +318,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -1380,6 +1383,7 @@
 })();
 </script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/duels.html
+++ b/site/duels.html
@@ -469,7 +469,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -1440,6 +1443,7 @@
 })();
 </script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/events.html
+++ b/site/events.html
@@ -232,7 +232,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events" aria-current="page">Events</a>
@@ -406,6 +409,7 @@
 <script src="arena.js?v=trench2"></script>
 <script src="events.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 </body>
 </html>

--- a/site/index.html
+++ b/site/index.html
@@ -31,7 +31,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -483,6 +486,7 @@
 })();
 </script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/leaderboard.html
+++ b/site/leaderboard.html
@@ -27,7 +27,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard" aria-current="page">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -901,6 +904,7 @@
 })();
 </script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/nav-toggle.js
+++ b/site/nav-toggle.js
@@ -1,0 +1,69 @@
+/* PaperTrench site — mobile nav toggle.
+ *
+ * Below 860px the nav hides every page link (style.css) and shows the
+ * hamburger button this script breathes life into. One class on the <nav>
+ * element is the whole state machine; CSS turns .nav-open into the
+ * dropdown. The list itself is the same .nav-links markup every page
+ * already ships — the menu cannot drift from the desktop nav because it
+ * IS the desktop nav.
+ */
+(function () {
+  'use strict';
+
+  var nav = document.querySelector('nav[aria-label="Primary"]');
+  if (!nav) return;
+  var burger = nav.querySelector('.nav-burger');
+  var links = nav.querySelector('.nav-links');
+  if (!burger || !links) return;
+
+  function isOpen() {
+    return nav.classList.contains('nav-open');
+  }
+
+  function setOpen(open) {
+    nav.classList.toggle('nav-open', open);
+    burger.setAttribute('aria-expanded', open ? 'true' : 'false');
+    burger.setAttribute('aria-label', open ? 'Close menu' : 'Open menu');
+  }
+
+  burger.addEventListener('click', function () {
+    setOpen(!isOpen());
+  });
+
+  // Choosing a destination closes the menu — the page is navigating anyway,
+  // and an in-page anchor (#install) should not leave the sheet covering
+  // the page it just scrolled.
+  links.addEventListener('click', function (e) {
+    var target = e.target;
+    while (target && target !== links) {
+      if (target.tagName === 'A') {
+        setOpen(false);
+        return;
+      }
+      target = target.parentNode;
+    }
+  });
+
+  // Escape closes and hands focus back to the button, so keyboard users are
+  // not stranded where the menu left them.
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' && isOpen()) {
+      setOpen(false);
+      burger.focus();
+    }
+  });
+
+  // A tap anywhere outside the open menu dismisses it.
+  document.addEventListener('click', function (e) {
+    if (isOpen() && !nav.contains(e.target)) setOpen(false);
+  });
+
+  // Crossing back to desktop hides the sheet; its open state must not
+  // survive the media query that gave it a reason to exist.
+  var mq = window.matchMedia('(min-width: 861px)');
+  var onWide = function (m) {
+    if (m.matches) setOpen(false);
+  };
+  if (mq.addEventListener) mq.addEventListener('change', onWide);
+  else if (mq.addListener) mq.addListener(onWide);
+})();

--- a/site/news-chain.html
+++ b/site/news-chain.html
@@ -54,7 +54,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -279,6 +282,7 @@
 
 <script src="reveal.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/news-fees.html
+++ b/site/news-fees.html
@@ -42,7 +42,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -233,6 +236,7 @@
 
 <script src="reveal.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/news-fills.html
+++ b/site/news-fills.html
@@ -59,7 +59,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -285,6 +288,7 @@
 
 <script src="reveal.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/news-flex.html
+++ b/site/news-flex.html
@@ -68,7 +68,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -359,6 +362,7 @@
 
 <script src="reveal.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/news-instant-x.html
+++ b/site/news-instant-x.html
@@ -49,7 +49,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -331,6 +334,7 @@
 
 <script src="reveal.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/news-perps.html
+++ b/site/news-perps.html
@@ -36,7 +36,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -195,6 +198,7 @@
 
 <script src="reveal.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/news-quickedit.html
+++ b/site/news-quickedit.html
@@ -53,7 +53,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -256,6 +259,7 @@
 
 <script src="reveal.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/news-rugguard.html
+++ b/site/news-rugguard.html
@@ -53,7 +53,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -290,6 +293,7 @@
 
 <script src="reveal.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/news-the-after.html
+++ b/site/news-the-after.html
@@ -49,7 +49,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -291,6 +294,7 @@
 
 <script src="reveal.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/news-trench-rank.html
+++ b/site/news-trench-rank.html
@@ -45,7 +45,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -174,6 +177,7 @@
 
 <script src="reveal.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/news-turbo.html
+++ b/site/news-turbo.html
@@ -56,7 +56,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -332,6 +335,7 @@
 
 <script src="reveal.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/news-v2.html
+++ b/site/news-v2.html
@@ -42,7 +42,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -282,6 +285,7 @@
 
 <script src="reveal.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/news-xray.html
+++ b/site/news-xray.html
@@ -63,7 +63,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -393,6 +396,7 @@
 
 <script src="reveal.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/news.html
+++ b/site/news.html
@@ -23,7 +23,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -187,6 +190,7 @@
 <script src="news.js"></script>
 <script src="reveal.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <script>
 (() => {

--- a/site/privacy.html
+++ b/site/privacy.html
@@ -33,7 +33,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -161,6 +164,7 @@
 <script src="/film-boot.js"></script>
 <script src="reveal.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/profile.html
+++ b/site/profile.html
@@ -383,7 +383,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <!-- A profile has no nav entry of its own — it is a leaf under the
            leaderboard. aria-current="true" says "you are inside this section";
            aria-current="page" would claim this IS leaderboard.html. -->
@@ -1571,6 +1574,7 @@
 })();
 </script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/replay.html
+++ b/site/replay.html
@@ -25,7 +25,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -209,6 +212,7 @@
 </footer>
 
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <script src="/vendor/lwc.js"></script>
 <script src="/vendor/replay-core.js"></script>

--- a/site/sprint.html
+++ b/site/sprint.html
@@ -148,7 +148,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint" aria-current="page">Sprint</a>
       <a href="/events">Events</a>
@@ -639,6 +642,7 @@
 })();
 </script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/streamer-signup.html
+++ b/site/streamer-signup.html
@@ -202,7 +202,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -423,6 +426,7 @@
 <script src="/film-boot.js"></script>
 <script src="streamer-signup.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script src="/nav-profile.js"></script>
 <!-- Cloudflare Web Analytics --><script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "724df78b5f6d45c6968c0c30b1a332d9"}'></script><!-- End Cloudflare Web Analytics -->
 </body>

--- a/site/streams.html
+++ b/site/streams.html
@@ -270,7 +270,10 @@
 <nav aria-label="Primary">
   <div class="nav-inner">
     <a class="nav-logo" href="/"><img src="assets/icon128.png" alt="PaperTrench logo">PaperTrench</a>
-    <div class="nav-links">
+    <button class="nav-burger" type="button" aria-expanded="false" aria-controls="nav-menu" aria-label="Open menu">
+      <span class="nav-burger-box" aria-hidden="true"><i></i><i></i><i></i></span>
+    </button>
+    <div class="nav-links" id="nav-menu">
       <a href="/leaderboard">Leaderboard</a>
       <a href="/sprint">Sprint</a>
       <a href="/events">Events</a>
@@ -477,6 +480,7 @@
 <script src="/film-boot.js"></script>
 <script src="streams.js"></script>
 <script src="/nav-wallet.js"></script>
+<script src="/nav-toggle.js"></script>
 <script>
 (() => {
   'use strict';

--- a/site/style.css
+++ b/site/style.css
@@ -302,6 +302,56 @@ nav[aria-label="Primary"] {
     box-shadow: 0 18px 40px rgba(0,0,0,0.45);
   }
   nav.nav-open .nav-links { display: flex; }
+  /* Destinations are rows; an action is a button. Live and the profile chip
+     keep their identity (the red dot, the avatar) but drop the desktop pill
+     chrome — inside a stretched column a content-sized pill is a smudge,
+     not a control. */
+  nav[aria-label="Primary"] .nav-links .nav-live,
+  nav[aria-label="Primary"] .nav-links .nav-profile {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    margin: 0;
+    padding: 12px 6px;
+    border-radius: 0;
+    border: 0;
+    border-bottom: 1px solid rgba(255,255,255,0.05);
+    background: transparent;
+    box-shadow: none;
+    transform: none;
+    font-size: 15px;
+    white-space: normal;
+  }
+  nav[aria-label="Primary"] .nav-links .nav-live:hover,
+  nav[aria-label="Primary"] .nav-links .nav-profile:hover {
+    background: rgba(255,255,255,0.04);
+    transform: none;
+    box-shadow: none;
+  }
+  nav[aria-label="Primary"] .nav-links .nav-profile { gap: 10px; }
+  nav[aria-label="Primary"] .nav-links .nav-profile img,
+  nav[aria-label="Primary"] .nav-links .nav-profile-dot { width: 26px; height: 26px; }
+  nav[aria-label="Primary"] .nav-links #nav-profile,
+  nav[aria-label="Primary"] .nav-links #nav-wallet { display: block; }
+  nav[aria-label="Primary"] .nav-links .nav-wallet {
+    width: 100%;
+    margin: 0;
+    padding: 12px 6px;
+    border-radius: 0;
+    border: 0;
+    border-bottom: 1px solid rgba(255,255,255,0.05);
+  }
+  nav[aria-label="Primary"] .nav-links .nav-wallet-num { font-size: 14px; }
+  /* The one true button in the sheet: set apart from the rows it sits under,
+     full width, tall enough to land a thumb on. */
+  nav[aria-label="Primary"] .nav-links .nav-cta {
+    display: block;
+    text-align: center;
+    margin: 14px 0 2px;
+    padding: 14px;
+    border-radius: 10px;
+    font-size: 14.5px;
+  }
 }
 @media (max-width: 470px) {
   /* Icon-only mark: the wordmark plus Live plus Download overflowed 375,

--- a/site/style.css
+++ b/site/style.css
@@ -183,6 +183,7 @@ nav[aria-label="Primary"] {
 @keyframes nw-up { 0% { color: var(--green2); text-shadow: 0 0 12px rgba(52,211,153,.7); } 100% { color: var(--orange2); } }
 @keyframes nw-down { 0% { color: #ff8a80; text-shadow: 0 0 12px rgba(224,67,58,.6); } 100% { color: var(--orange2); } }
 @media (prefers-reduced-motion: reduce) { .nav-wallet-num.up, .nav-wallet-num.down { animation: none; } }
+@media (prefers-reduced-motion: reduce) { .nav-burger-box i { transition: none; } }
 
 #nav-wallet { position: relative; }
 .nav-wallet-panel {
@@ -245,8 +246,62 @@ nav[aria-label="Primary"] {
    the row stops fitting. (The break was already there before Clans was added —
    a seven-item nav wrapped at 780 too — it just had less headroom to lose.) */
 .nav-cta, .nav-live { flex: none; white-space: nowrap; }
+
+/* The hamburger. Below 860px the row hides the page links entirely (the
+   rule below), which left phones with exactly two destinations — Live and
+   Download — and no way to reach Leaderboard, Events, Duels, Clans, Replay,
+   News, Sprint or Links at all. The burger brings the SAME list back as a
+   dropdown sheet: nav-toggle.js only toggles one class, so the menu and the
+   desktop row can never disagree about where a page lives. */
+.nav-burger {
+  display: none;
+  margin-left: auto;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: rgba(255,255,255,0.04);
+  padding: 9px 10px;
+  cursor: pointer;
+}
+.nav-burger:hover { border-color: var(--accent, #FF9D45); }
+.nav-burger:focus-visible { outline: 2px solid var(--accent, #FF9D45); outline-offset: 2px; }
+.nav-burger-box { display: block; width: 18px; height: 12px; position: relative; }
+.nav-burger-box i {
+  position: absolute; left: 0; right: 0; height: 2px; border-radius: 1px;
+  background: var(--text);
+  transition: transform .2s, opacity .2s, top .2s;
+}
+.nav-burger-box i:nth-child(1) { top: 0; }
+.nav-burger-box i:nth-child(2) { top: 5px; }
+.nav-burger-box i:nth-child(3) { top: 10px; }
+/* Open: the bars fold into an X — the icon says "this closes it" without a word. */
+.nav-burger[aria-expanded="true"] .nav-burger-box i:nth-child(1) { top: 5px; transform: rotate(45deg); }
+.nav-burger[aria-expanded="true"] .nav-burger-box i:nth-child(2) { opacity: 0; }
+.nav-burger[aria-expanded="true"] .nav-burger-box i:nth-child(3) { top: 5px; transform: rotate(-45deg); }
+
 @media (max-width: 860px) {
-  .nav-links a:not(.nav-cta):not(.nav-live) { display: none; }
+  .nav-burger { display: inline-flex; align-items: center; }
+  /* The hidden page links become the dropdown's rows. Same specificity as
+     the old hiding rule, later in the file: presence wins. */
+  nav[aria-label="Primary"] .nav-links a:not(.nav-cta):not(.nav-live) {
+    display: block;
+    padding: 12px 6px;
+    font-size: 15px;
+    border-bottom: 1px solid rgba(255,255,255,0.05);
+  }
+  nav[aria-label="Primary"] .nav-links {
+    display: none;
+    position: absolute;
+    top: 64px; left: 0; right: 0;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    margin: 0;
+    padding: 6px 16px 14px;
+    background: rgba(7, 9, 14, 0.97);
+    border-bottom: 1px solid var(--line);
+    box-shadow: 0 18px 40px rgba(0,0,0,0.45);
+  }
+  nav.nav-open .nav-links { display: flex; }
 }
 @media (max-width: 470px) {
   /* Icon-only mark: the wordmark plus Live plus Download overflowed 375,


### PR DESCRIPTION
## The problem

Below **860px**, `style.css` hid every nav link except Live and Download:

```css
@media (max-width: 860px) {
  .nav-links a:not(.nav-cta):not(.nav-live) { display: none; }
}
```

On a phone, the site's own header could not reach Leaderboard, Sprint, Events, Duels, Clans, Replay, News, or Links — the two links it kept are precisely the two that aren't destinations. Every screen on the site was unreachable by navigation on mobile.

## The fix

A **hamburger button** in the nav (three bars, folding to an X while open) that opens the page's own `.nav-links` list as a full-width sheet under the bar:

- **Same markup, not a copy.** The sheet IS the desktop's `.nav-links` — the menu can never drift from the desktop nav about where a page lives (the drift preflight already guards for the desktop row now guards for the sheet too, same file).
- **Closes like it should**: tapping a destination navigates and the fresh page arrives closed; Escape closes and returns focus to the button; a tap outside closes; crossing back above 860px closes — an open state never survives its own media query.
- **Screen-reader honest**: `aria-expanded` and the button's label (`Open menu` ↔ `Close menu`) track the state; the button controls the list by id.
- Live, the wallet chip and the profile chip ride in the sheet as rows, so nothing that was reachable on desktop disappears on mobile.
- Thirty lines of dependency-free JS (`nav-toggle.js`); CSS does the rest.

## Scope

- 30 pages carry the button (the standard nav pages; `links.html` has its own bespoke page nav and is untouched, same as it's skipped by the existing nav checks).
- `scripts/preflight.sh` grows a **mobile-nav check**: any page carrying the standard nav must also carry the burger, the menu id, and the toggle script — a future page can't quietly ship a phone view with no navigation. Currently: 30/30 OK, `PREFLIGHT OK`.
- The codemod that inserted the markup ran once locally; it's not part of the repo (preflight is the lasting guard).

## Drive-by (separate commit, revertible on its own)

`worker.test.js`'s sealed-token test flaked during my preflight run: it asserted the base64url ciphertext doesn't contain `'r1'` — a 2-character string that appears in ~**1.4%** of random base64url strings (measured), so the test failed about one run in seventy with the cipher working perfectly. The fixture token is now long enough that a coincidental match cannot happen. Test-only; no product code.

## Verification

- `scripts/preflight.sh`: **OK** — nav 30 pages, a11y 30 pages, mobile nav 30 pages, server suite green.
- Clicked through in a real browser at 390×844: menu opens (screenshot-verified layout — sheet, rows, X icon), Leaderboard tap navigates and lands closed, Escape closes with focus returned, and at 1200px the burger is gone with the desktop row intact.