### PR TITLE
fix(streams): the player stops pointing a live embed at an offline channel

### DIFF
--- a/site/streams.js
+++ b/site/streams.js
@@ -519,7 +519,13 @@
     // player — needs the parent domain.
     const wantChat = spec.chat && !!PARENT;
     chatShell.style.display = wantChat ? '' : 'none';
-    if (!wantChat) $('chatFrame').innerHTML = '';
+    if (wantChat) {
+      $('chatFrame').innerHTML = `<iframe
+        src="${esc(spec.chatUrl(handle))}"
+        title="${esc(spec.label)} chat: ${who}"></iframe>`;
+    } else {
+      $('chatFrame').innerHTML = '';
+    }
 
     // Twitch refuses embeds without a parent domain, which file:// has no way
     // to supply. Kick and YouTube do not take a parent, so they still play.
@@ -549,16 +555,33 @@
       return;
     }
 
+    // THE LIVE GATE. The probes already answer whether this channel is live;
+    // mounting the player anyway is what produced Kick's "This embed seems to
+    // be misconfigured" — its player's answer to being pointed at a channel
+    // that is not broadcasting. Only a DEFINITIVE offline answer blocks the
+    // mount: an unknown state (probe failed, or the first poll has not
+    // landed) mounts as before and lets the player self-report, so a flaky
+    // probe can never black out a channel that is actually live.
+    // Signal-less platforms are exempt entirely: nobody reports YouTube's
+    // state, so its own player is the honest one (see the boot note below).
+    if (hasLiveSignal(s) && live.get(keyOf(s)) === false) {
+      frame.innerHTML = `
+        <div class="player-empty">
+          <div class="inner">
+            ${MARK_EXTERNAL}
+            <h3>${who} is offline</h3>
+            <p>Nobody is behind the mic right now. When ${who} goes live it plays
+            right here${href ? ` — meanwhile, the channel lives at <a href="${esc(href)}" target="_blank" rel="noopener">${label}</a>` : ''}.
+            Pick a LIVE card below to watch someone who is.</p>
+          </div>
+        </div>`;
+      return;
+    }
+
     frame.innerHTML = `<iframe
       src="${esc(spec.player(handle))}"
       allowfullscreen allow="autoplay; fullscreen"
       title="${esc(spec.label)} stream: ${who}"></iframe>`;
-
-    if (wantChat) {
-      $('chatFrame').innerHTML = `<iframe
-        src="${esc(spec.chatUrl(handle))}"
-        title="${esc(spec.label)} chat: ${who}"></iframe>`;
-    }
   }
 
   function setFeatured(key, { pinned = false, scroll = false } = {}) {
@@ -709,6 +732,15 @@
     if (!userPinned) {
       const firstLive = orderedRoster().find((s) => live.get(keyOf(s)) === true);
       if (firstLive && live.get(featured) !== true) setFeatured(keyOf(firstLive));
+    }
+    // When the FEATURED channel's own state flips, the gate in renderFeatured
+    // must re-judge it: offline → live mounts the stream, live → offline
+    // swaps the player for the honest card. Only a flip re-renders — a poll
+    // that rebuilt the iframe every 60s would restart the stream mid-watch.
+    const current = featured && entryFor(featured);
+    if (current && hasLiveSignal(current)) {
+      const wantsIframe = live.get(keyOf(current)) !== false;
+      if (wantsIframe !== !!document.querySelector('#playerFrame iframe')) renderFeatured();
     }
     renderGrid();
   }


### PR DESCRIPTION
## The bug

The screenshot that came with the report: the featured player showing Kick's own red error — **"This embed seems to be misconfigured"** — where a stream should be.

That message is Kick's player answering a question it was never supposed to be asked: `renderFeatured()` mounted the `player.kick.com` iframe **unconditionally** (streams.js:552-555), both before any live probe had answered and regardless of what the probe then said. Point an embeddable player at a channel that isn't broadcasting and each platform improvises: Twitch shows a graceful offline slate; Kick shows the misconfigured error. Same mistake, kinder costume.

The live probes (Kick's public channel API, Twitch's preview-CDN heuristic) already run at boot and every 60s — the player just never listened to them.

## The fix

A **live gate in the featured player**, driven by the probes that already exist:

- A **definitive offline** verdict (`probe → false`) swaps the player for an honest card: the name, what happened, the channel link, and the way out — "Pick a LIVE card below." No iframe, no platform error text.
- An **unknown** state (probe failed, or the first poll hasn't landed) **still mounts the player**. A failed probe must never black out a channel that is actually live — the player self-reports until the next poll, exactly as before. Only certainty suppresses the embed.
- **Signal-less platforms are exempt** (YouTube keeps mounting its `live_stream` embed — nobody reports its state, so its own player is the honest one; the boot-pick comment already documents this doctrine).
- **Pinning goes through the same gate**: clicking an OFFLINE roster card features that channel with the same honest card, not an error iframe.
- **The poll re-judges the featured channel only when its state flips** (offline → live mounts the stream; live → offline swaps the card). Naively re-rendering each poll would rebuild the iframe every 60 seconds and restart the stream mid-watch.

While nothing on the roster is live, the page now opens on the offline card instead of a red error — and the moment a channel goes live, the existing auto-promotion puts it in the player as before.

## Verification

- `node --check`, `scripts/preflight.sh` → **PREFLIGHT OK**.
- Clicked through in a real browser against the live roster (all channels currently offline): featured Kick channel shows the offline card (screenshot-verified) — no `player.kick.com` iframe in the DOM; pinning an offline Twitch card behaves the same; desktop nav/grid unaffected.

Site-only, static, no server change — ships on merge.