### PR TITLE
feat(admin): add a streamer to the roster from /admin

### DIFF
--- a/docs/STREAMS.md
+++ b/docs/STREAMS.md
@@ -27,6 +27,7 @@ Routes on the Worker:
 | `POST /api/streamer/apply` | Anyone. Rate-limited to 5/hour per IP. |
 | `GET /api/streamer/applications?status=` | Moderators only (403 otherwise). |
 | `POST /api/streamer/review` | Moderators only (403 otherwise). |
+| `POST /api/streamer/add` | Moderators only (403 otherwise). Lands the row **approved**, attributed to the calling moderator — the direct door from the `/admin` form, replacing the add-a-streamer-by-GitHub-issue ritual. |
 | `GET /api/streamer/roster` | Anyone. Approved rows, public columns only. |
 
 ### One-time setup

--- a/server/core/streamer.js
+++ b/server/core/streamer.js
@@ -239,6 +239,38 @@ function normalizeApplication(fields) {
   };
 }
 
+/**
+ * Why a moderator's DIRECT add cannot be accepted, or null when it can.
+ *
+ * The add form is the apply form minus the contact block: a mod-added row
+ * skips the queue entirely, so the checks that protect the PUBLIC card are
+ * precisely the ones that stay — name and blurb against the content rule,
+ * the channel against the URL rule. Discord/viewers have no public surface
+ * (the roster SELECT never serves them), so a direct add carries none.
+ */
+function addProblem(fields) {
+  const f = fields || {};
+  const name = clean(f.name, LIMITS.name);
+  if (name.length < 2) return 'name-required';
+  if (blockedContent(name)) return 'name-blocked';
+  if (!safeUrl(f.channelUrl, LIMITS.channelUrl)) return 'channel-url-invalid';
+  if (blockedContent(clean(f.blurb, LIMITS.blurb))) return 'blurb-blocked';
+  return null;
+}
+
+/** The approved row for a direct add. Call only after addProblem() is null. */
+function normalizeAdd(fields) {
+  const f = fields || {};
+  const channelUrl = safeUrl(f.channelUrl, LIMITS.channelUrl);
+  return {
+    name: clean(f.name, LIMITS.name),
+    channelUrl,
+    platform: platformOf(channelUrl),
+    twitchLogin: twitchLogin(channelUrl),
+    blurb: clean(f.blurb, LIMITS.blurb),
+  };
+}
+
 const STATUSES = ['pending', 'approved', 'rejected'];
 const isStatus = (s) => STATUSES.includes(trim(s));
 
@@ -273,6 +305,8 @@ module.exports = {
   twitchLogin,
   applyProblem,
   normalizeApplication,
+  addProblem,
+  normalizeAdd,
   isStatus,
   isAdmin,
 };

--- a/server/test/streamer.test.js
+++ b/server/test/streamer.test.js
@@ -304,3 +304,31 @@ test('an over-long URL is rejected whole, never stored as a broken prefix', () =
   // is stripped before judging, so this is still over.
   assert.equal(S.safeUrl('  ' + over + '  ', 200), null);
 });
+
+/* -------------------------------------------------- the moderator's direct add */
+
+test('addProblem is applyProblem minus the contact block', () => {
+  // A mod-added row skips the queue, so the checks that survive are exactly
+  // the ones that protect the PUBLIC card: name, channel, blurb. Discord and
+  // viewers have no public surface (the roster SELECT never serves them), so
+  // demanding them here would just be a second form nobody reads.
+  const base = { name: 'Zurp52', channelUrl: 'https://twitch.tv/zurp52' };
+  assert.equal(S.addProblem(base), null);
+  assert.equal(S.addProblem({}), 'name-required');
+  assert.equal(S.addProblem({ name: 'x', channelUrl: 'https://kick.com/x' }), 'name-required');
+  assert.equal(S.addProblem({ name: `Stream ${HATE_CODE}`, channelUrl: 'https://kick.com/x' }), 'name-blocked');
+  assert.equal(S.addProblem({ name: 'Ok', channelUrl: 'javascript:alert(1)' }), 'channel-url-invalid');
+  assert.equal(S.addProblem({ name: 'Ok', channelUrl: 'https://kick.com/x', blurb: `gm ${HATE_CODE}` }), 'blurb-blocked');
+});
+
+test('normalizeAdd derives platform and Twitch login from the URL alone', () => {
+  const kick = S.normalizeAdd({ name: 'Ark1317', channelUrl: 'https://kick.com/ark1317', blurb: 'Night runs.' });
+  assert.equal(kick.platform, 'kick');
+  assert.equal(kick.twitchLogin, null, 'no invented login for a platform we cannot embed');
+  assert.equal(kick.blurb, 'Night runs.');
+
+  const twitch = S.normalizeAdd({ name: 'Zurp52', channelUrl: 'twitch.tv/Zurp52', blurb: '' });
+  assert.equal(twitch.platform, 'twitch');
+  assert.equal(twitch.twitchLogin, 'zurp52', 'lowercased, embeddable, same rules as apply');
+  assert.equal(twitch.blurb, '', 'an absent blurb is stored absent, not as a placeholder lie');
+});

--- a/server/test/streameradd.test.js
+++ b/server/test/streameradd.test.js
@@ -1,0 +1,163 @@
+/* POST /api/streamer/add — the moderator's direct door onto the roster.
+ *
+ * The owner used to add a streamer by filing a GitHub issue against this very
+ * repo and waiting for someone to translate it into an INSERT. These tests
+ * pin the endpoint that replaces that round trip: mod-gated like every other
+ * write on the queue page, landing rows APPROVED and attributed, refused when
+ * the channel is already spoken for, and held to the same content rules the
+ * public form faces — because an approved row is a public card either way.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { HATE_CODE } = require('../core/clan.js');
+
+const ORIGIN = 'https://papertrench.com';
+const SECRET = 'test-secret';
+const MOD = { id: 7, x_id: 'mod-x-id-900', handle: 'terp', session_epoch: 1, banned_at: null };
+
+/** A scripted D1: `route(sql, args)` decides every answer. */
+function fakeDB(route) {
+  const log = [];
+  const statement = (sql) => {
+    let bound = [];
+    const stmt = {
+      sql,
+      get args() { return bound; },
+      bind(...args) { bound = args; return stmt; },
+      async first() { log.push({ sql, args: bound, via: 'first' }); return route(sql, bound) || null; },
+      async all() { log.push({ sql, args: bound, via: 'all' }); const rows = route(sql, bound); return { results: Array.isArray(rows) ? rows : [] }; },
+      async run() { log.push({ sql, args: bound, via: 'run' }); const out = route(sql, bound); return out && out.meta ? out : { meta: { changes: 1 } }; },
+    };
+    return stmt;
+  };
+  return { log, prepare: statement, batch: async () => [] };
+}
+
+function makeEnv(db) {
+  // ADMIN_X_IDS carries the fixture moderator's x_id — this is the whole gate.
+  return { DB: db, SESSION_SECRET: SECRET, SITE_ORIGIN: ORIGIN, ADMIN_X_IDS: MOD.x_id };
+}
+
+async function loadWorker() {
+  globalThis.caches = globalThis.caches || {
+    default: { match: async () => undefined, put: async () => {} },
+  };
+  return (await import('../worker/index.js')).default;
+}
+
+/** A session token signed exactly the way auth.js signs them. */
+async function sessionToken(uid) {
+  const enc = (s) => new TextEncoder().encode(s);
+  const b64 = (bytes) => Buffer.from(bytes).toString('base64url');
+  const body = b64(enc(JSON.stringify({ uid, epoch: 1, exp: Date.now() + 3600000 })));
+  const key = await crypto.subtle.importKey(
+    'raw', enc(SECRET), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const sig = b64(await crypto.subtle.sign('HMAC', key, enc(body)));
+  return body + '.' + sig;
+}
+
+/** The users row lookup every session check performs. */
+const usersRoute = (sql) => {
+  if (sql.includes('FROM users WHERE id = ?')) {
+    return { id: MOD.id, x_id: MOD.x_id, handle: MOD.handle, display_name: 'Terp', avatar_url: null, session_epoch: 1, banned_at: null };
+  }
+  return null;
+};
+
+async function postAdd(worker, env, payload, { auth = true } = {}) {
+  const headers = { Origin: ORIGIN, 'Content-Type': 'application/json' };
+  if (auth) headers.Authorization = 'Bearer ' + await sessionToken(MOD.id);
+  const res = await worker.fetch(new Request('https://api.test/api/streamer/add', {
+    method: 'POST', headers, body: JSON.stringify(payload),
+  }), env, { waitUntil: () => {} });
+  return { status: res.status, body: await res.json() };
+}
+
+const VALID = Object.freeze({
+  name: 'Ark1317',
+  channelUrl: 'https://kick.com/ark1317',
+  blurb: 'Fresh eyes on the trenches.',
+});
+
+test('the door is locked: no session, no add', async () => {
+  const worker = await loadWorker();
+  const db = fakeDB(usersRoute);
+  const { status, body } = await postAdd(worker, makeEnv(db), VALID, { auth: false });
+  assert.equal(status, 403);
+  assert.equal(body.reason, 'not-a-moderator');
+  assert.equal(db.log.filter((l) => l.sql.includes('INSERT INTO streamer_applications')).length, 0,
+    'a refused caller must not have written a row');
+});
+
+test('a signed-in non-moderator is refused too', async () => {
+  const worker = await loadWorker();
+  // The session resolves to a real user whose x_id is NOT on the allowlist.
+  const db = fakeDB(() => null);
+  const env = makeEnv(db);
+  env.ADMIN_X_IDS = 'someone-else';
+  const { status } = await postAdd(worker, env, VALID);
+  assert.equal(status, 403);
+});
+
+test('a direct add lands APPROVED, attributed, and platform-derived', async () => {
+  const worker = await loadWorker();
+  const db = fakeDB(usersRoute);
+  const { status, body } = await postAdd(worker, makeEnv(db), VALID);
+  assert.equal(status, 200);
+  assert.equal(body.ok, true);
+
+  const insert = db.log.find((l) => l.sql.includes('INSERT INTO streamer_applications'));
+  assert.ok(insert, 'the handler must insert, not update its way in');
+  assert.ok(insert.sql.includes("'approved'"), 'the row lands approved — that is the point of the door');
+  // Bind order: name, channelUrl, platform, twitchLogin, blurb, reviewed_by, reviewed_at, created_at.
+  assert.equal(insert.args[0], 'Ark1317');
+  assert.equal(insert.args[1], 'https://kick.com/ark1317');
+  assert.equal(insert.args[2], 'kick', 'the platform is read from the URL, never chosen by the caller');
+  assert.equal(insert.args[3], null, 'a Kick channel gets no invented Twitch login');
+  assert.equal(insert.args[5], MOD.id, 'the add is attributed to the moderator who made it');
+  assert.equal(insert.args[6], insert.args[7], 'reviewed_at and created_at are the same moment');
+});
+
+test('a Twitch add extracts the embeddable login', async () => {
+  const worker = await loadWorker();
+  const db = fakeDB(usersRoute);
+  await postAdd(worker, makeEnv(db), { name: 'Zurp52', channelUrl: 'twitch.tv/zurp52' });
+  const insert = db.log.find((l) => l.sql.includes('INSERT INTO streamer_applications'));
+  assert.equal(insert.args[2], 'twitch');
+  assert.equal(insert.args[3], 'zurp52', 'the login is what the streams page embeds by');
+});
+
+test('a channel already pending or approved is a 409, not a double row', async () => {
+  const worker = await loadWorker();
+  // The partial unique index on channel_url rejects the INSERT — the index is
+  // what decides, so the fake reproduces exactly that and nothing else.
+  const db = fakeDB((sql) => {
+    if (sql.includes('INSERT INTO streamer_applications')) {
+      throw new Error('UNIQUE constraint failed: index idx_streamer_applications_open_channel');
+    }
+    return usersRoute(sql);
+  });
+  const { status, body } = await postAdd(worker, makeEnv(db), VALID);
+  assert.equal(status, 409);
+  assert.equal(body.reason, 'already-listed');
+});
+
+test('the public card rules hold for moderators too', async () => {
+  const worker = await loadWorker();
+  const db = fakeDB(usersRoute);
+  const env = makeEnv(db);
+  for (const [payload, reason] of [
+    [{ channelUrl: 'https://kick.com/x' }, 'name-required'],
+    [{ name: 'x', channelUrl: 'https://kick.com/x' }, 'name-required'],
+    [{ name: `Stream ${HATE_CODE}`, channelUrl: 'https://kick.com/x' }, 'name-blocked'],
+    [{ name: 'Ok Name', channelUrl: 'javascript:alert(1)' }, 'channel-url-invalid'],
+    [{ name: 'Ok Name', channelUrl: 'https://kick.com/x', blurb: `gm ${HATE_CODE}` }, 'blurb-blocked'],
+  ]) {
+    const { status, body } = await postAdd(worker, env, payload);
+    assert.equal(status, 422, JSON.stringify(payload));
+    assert.equal(body.reason, reason, JSON.stringify(payload));
+  }
+  assert.equal(db.log.filter((l) => l.sql.includes('INSERT INTO streamer_applications')).length, 0,
+    'none of the refused payloads may have written a row');
+});

--- a/server/worker/index.js
+++ b/server/worker/index.js
@@ -1753,6 +1753,59 @@ async function handleStreamerApply(request, env) {
 }
 
 /**
+ * POST /api/streamer/add — a moderator puts a channel straight onto the roster.
+ *
+ * The public apply endpoint exists so strangers can ask; this one exists so
+ * the owner never has to file a GitHub issue against their own project to add
+ * a streamer they have already decided on. The row lands approved, attributed
+ * to the moderator who added it (reviewed_by/reviewed_at — the audit fields
+ * the review path fills, filled here too), and through the same machine gate
+ * the public form faces: an approved row becomes a public card either way, so
+ * the name/blurb content rule and the channel-URL rule hold for mods too.
+ *
+ * discord/viewers are NOT NULL columns of the shared table with no public
+ * surface — the roster SELECT serves only name/login/blurb/platform/url — so
+ * a direct add stores empty strings rather than pretending to know them.
+ */
+async function handleStreamerAdd(request, env) {
+  const mod = await moderator(request, env);
+  if (!mod) return json({ ok: false, reason: 'not-a-moderator' }, 403);
+
+  let body = {};
+  try { body = await request.json(); } catch {}
+
+  const problem = streamer.addProblem(body);
+  if (problem) return json({ ok: false, reason: problem }, 422);
+
+  const added = streamer.normalizeAdd(body);
+  try {
+    await env.DB.prepare(`
+      INSERT INTO streamer_applications
+        (name, channel_url, platform, twitch_login, discord, viewers, blurb,
+         notes, contact_method, contact_link, best_time, status,
+         reviewed_by, reviewed_at, created_at)
+      VALUES (?, ?, ?, ?, '', '', ?, NULL, NULL, NULL, NULL, 'approved', ?, ?, ?)`)
+      .bind(added.name, added.channelUrl, added.platform, added.twitchLogin,
+        added.blurb || null, mod.id, Date.now(), Date.now())
+      .run();
+  } catch {
+    // The partial unique index on channel_url is what decides: a channel
+    // already pending or approved is a duplicate, not a server fault.
+    return json({ ok: false, reason: 'already-listed' }, 409);
+  }
+  return json({
+    ok: true,
+    streamer: {
+      name: added.name,
+      channelUrl: added.channelUrl,
+      platform: added.platform,
+      twitchLogin: added.twitchLogin,
+      blurb: added.blurb,
+    },
+  });
+}
+
+/**
  * The mod queue. Every column, including contact details — which is exactly
  * why it is behind moderator() and why nothing else selects from this table.
  */
@@ -2454,6 +2507,9 @@ export default {
       }
       else if (path === '/api/streamer/review' && request.method === 'POST') {
         response = await handleStreamerReview(request, env);
+      }
+      else if (path === '/api/streamer/add' && request.method === 'POST') {
+        response = await handleStreamerAdd(request, env);
       }
       else if (path === '/api/streamer/roster') {
         response = await edgeCached(request, ctx, BOARD_CACHE_SEC, () => handleStreamerRoster(env));

--- a/site/admin.html
+++ b/site/admin.html
@@ -149,6 +149,31 @@
   .state { text-align: center; padding: 60px 20px; color: var(--muted); font-size: 14px; }
   .state .big { font-size: 38px; margin-bottom: 12px; opacity: 0.8; }
 
+  /* ---------- direct add ----------
+     The owner's own door onto the roster: no GitHub issue, no round trip.
+     Collapsed by default so the queue stays the first thing on the page. */
+  .add-panel { background: var(--panel); border: 1px solid var(--line);
+    border-radius: var(--radius); margin-bottom: 22px; overflow: hidden; }
+  .add-sum { display: flex; align-items: center; gap: 10px; padding: 15px 20px;
+    cursor: pointer; list-style: none; font-size: 14px; font-weight: 800;
+    color: var(--orange2); transition: background .15s; }
+  .add-sum::-webkit-details-marker { display: none; }
+  .add-sum:hover { background: rgba(255,255,255,0.025); }
+  .add-sum .plus { font-family: var(--mono); font-size: 17px; font-weight: 800; }
+  .add-form { padding: 4px 20px 18px; border-top: 1px solid var(--line); }
+  .add-note { font-size: 12.5px; color: var(--muted); line-height: 1.6; margin: 12px 0 14px; }
+  .add-grid { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 12px 14px; }
+  @media (max-width: 620px) { .add-grid { grid-template-columns: 1fr; } }
+  .add-grid label { display: flex; flex-direction: column; gap: 6px;
+    font-size: 11.5px; font-weight: 750; letter-spacing: 0.5px;
+    text-transform: uppercase; color: var(--dim); }
+  .add-grid .opt { text-transform: none; letter-spacing: 0; font-weight: 600; opacity: 0.8; }
+  .add-grid input { font: inherit; font-size: 14px; color: var(--text);
+    background: rgba(0,0,0,0.3); border: 1px solid var(--line2); border-radius: 8px;
+    padding: 10px 12px; }
+  .add-grid input:focus { outline: none; border-color: rgba(255,157,69,0.5); }
+  .add-acts { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-top: 14px; }
+
   .who { display: flex; align-items: center; gap: 10px; font-size: 13px; color: var(--muted); margin-bottom: 20px; }
   .who img { width: 26px; height: 26px; border-radius: 50%; }
   .who b { color: var(--text); font-weight: 750; }
@@ -221,6 +246,28 @@
         <span>Signed in as <b id="whoHandle"></b> · moderator</span>
         <button class="ar-btn" type="button" id="refreshBtn">Refresh</button>
       </div>
+
+      <details class="add-panel" id="addPanel">
+        <summary class="add-sum"><span class="plus" aria-hidden="true">+</span> Add a streamer to the roster</summary>
+        <form id="addForm" class="add-form">
+          <p class="add-note">Lands on the public roster immediately, credited to you in the audit trail. Twitch, Kick and YouTube all work — the platform is read from the link, not chosen. Twitch plays inline; the others get a card that links out.</p>
+          <div class="add-grid">
+            <label>Channel URL
+              <input id="addUrl" type="text" inputmode="url" placeholder="https://kick.com/name" autocomplete="off" required>
+            </label>
+            <label>Card name
+              <input id="addName" type="text" maxlength="40" placeholder="Shown as the card title" autocomplete="off" required>
+            </label>
+            <label class="add-wide" style="grid-column:1/-1">Card blurb <span class="opt">(optional — one line under the name)</span>
+              <input id="addBlurb" type="text" maxlength="160" placeholder="Weekend challenge runs — fresh eyes on the trenches." autocomplete="off">
+            </label>
+          </div>
+          <div class="add-acts">
+            <button class="ar-btn good" type="submit" id="addSubmit">Add to roster</button>
+            <span class="act-msg" id="addMsg" role="status" aria-live="polite"></span>
+          </div>
+        </form>
+      </details>
 
       <div class="tabs" id="tabs">
         <button class="tab on" type="button" data-status="pending">Pending<span class="n" id="nPending"></span></button>

--- a/site/admin.js
+++ b/site/admin.js
@@ -302,6 +302,74 @@
 
   $('refreshBtn').addEventListener('click', loadQueue);
 
+  /* ---------------- direct add ----------------
+   * POST /api/streamer/add — the owner's own door onto the roster, so adding a
+   * streamer is a form here rather than a GitHub issue against this repo. The
+   * server gates it on moderator() exactly like every other write on this
+   * page; this form is a courtesy, not the control.
+   */
+
+  // Reason codes come from core/streamer.js addProblem() — assert on the map,
+  // never on the server's exact sentence.
+  const ADD_REASON = {
+    'name-required': 'A card name is needed — at least two characters.',
+    'name-blocked': 'That name was refused by the content filter.',
+    'channel-url-invalid': "That channel URL didn't parse as a web link.",
+    'blurb-blocked': 'That blurb was refused by the content filter.',
+    'already-listed': 'That channel is already on the roster or waiting in the queue.',
+    'not-a-moderator': 'Your moderator access changed — refresh the page.',
+  };
+
+  /** twitch.tv/name -> name, for prefilling the card-name field. Same shape
+   * the server accepts; anything else leaves the field alone. */
+  function slugFromUrlText(text) {
+    const raw = String(text || '').trim();
+    if (!raw) return '';
+    const withScheme = /^[a-z][a-z0-9+.-]*:/i.test(raw) ? raw : 'https://' + raw;
+    try {
+      const first = new URL(withScheme).pathname.split('/').filter(Boolean)[0] || '';
+      return /^[a-z0-9_]{3,25}$/i.test(first) ? first : '';
+    } catch { return ''; }
+  }
+
+  $('addUrl').addEventListener('change', () => {
+    if ($('addName').value.trim()) return; // never overwrite a typed name
+    const slug = slugFromUrlText($('addUrl').value);
+    if (slug) $('addName').value = slug;
+  });
+
+  $('addForm').addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const msg = $('addMsg');
+    const say = (text, err) => { msg.textContent = text; msg.className = 'act-msg' + (err ? ' err' : ''); };
+    const button = $('addSubmit');
+    button.disabled = true;
+    say('Adding…');
+
+    const { status, body } = await api('/api/streamer/add', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: $('addName').value,
+        channelUrl: $('addUrl').value,
+        blurb: $('addBlurb').value,
+      }),
+    });
+
+    button.disabled = false;
+    if (status >= 200 && status < 300 && body && body.ok) {
+      const added = body.streamer || {};
+      say('Added — ' + (added.name || 'streamer') + ' is on the roster'
+        + (added.twitchLogin ? ', and plays inline on the streams page.' : ', with a card that links out.'), false);
+      $('addForm').reset();
+      // Counts and the current tab's list catch up; the roster itself is
+      // edge-cached for 60s, so the streams page may take a minute to show it.
+      loadQueue();
+      return;
+    }
+    say(ADD_REASON[(body && body.reason)] || 'That didn’t save — try again.', true);
+  });
+
   /* ---------------- boot ---------------- */
 
   async function boot() {


### PR DESCRIPTION
## The problem

The roster has no owner UI. Adding Twitch/Kick/YouTube accounts to the streams roster meant **filing a GitHub issue against this repo** (#64-style) and waiting for someone with a shell to turn it into an approved row in D1. The moderator queue can approve *applications* — but there was no way to add a channel nobody applied through.

## What this adds

**A collapsed "Add a streamer to the roster" panel above the queue on `/admin`**, visible only past the existing moderator gate (the page is a view; the server is the control):

- Three fields: **Channel URL** (required), **Card name** (required, auto-prefilled from the URL slug — `twitch.tv/zurp52` → `Zurp52` — and never overwriting a typed name), and an optional one-line **Card blurb**, which is exactly what the public card shows.
- The platform is **read from the link, not chosen** — no dropdown to get wrong. Twitch adds land embeddable (login extracted); Kick/YouTube land as link-out cards; anything else links to its URL. The page says which is which.

**`POST /api/streamer/add`** (server):

- Gated by `moderator()` exactly like every other write on the page — "the routing table is not the gate, the handler is."
- The row lands **`approved` and attributed**: `reviewed_by`/`reviewed_at` filled with the calling moderator and now, so the audit trail of the review path holds for direct adds too.
- **The public-card rules hold for mods too** — name and blurb go through the same blocked-content filter and the channel through the same `safeUrl` the public form faces, because an approved row is a public card either way. Reason codes (`name-required`, `channel-url-invalid`, `blurb-blocked`, …) are shared with apply, and the page renders them as sentences.
- A channel already **pending or approved comes back `409 already-listed`** — the partial unique index decides, not a check-then-act SELECT.
- `discord`/`viewers` are NOT NULL columns of the shared table with **no public surface** (the roster SELECT serves only name/login/blurb/platform/url), so a direct add stores empty strings rather than pretending to know them. `notes` stays NULL — nothing was privately messaged.

**No D1 migration** — the feature reuses `streamer_applications` as-is (the roster *is* `status = 'approved'`).

## Deploy note

**Deploy the Worker before using the /admin form.** The endpoint without the UI is harmless; the UI without the endpoint would just report a failure.

## Tests

- New `server/test/streameradd.test.js` (6 tests, following the scripted-D1 harness): no session → 403 with **no row written**; signed-in non-moderator → 403; happy path inserts **approved + attributed**, platform derived from the URL, no invented Twitch login for Kick, `reviewed_by` = the mod; Twitch login extraction; duplicate channel → 409 via the unique index; the full validation matrix refused with **zero INSERTs attempted**.
- `core/streamer.js` gains `addProblem`/`normalizeAdd` (pure, exported, tested in `streamer.test.js`): apply's rules minus the contact block.
- Full server suite: **308 passed, 0 failed**. `scripts/preflight.sh`: **PREFLIGHT OK**.

Closes the "add streamers via /admin instead of issues" request (Twitch, Kick, and YouTube all handled).