### PR TITLE
fix(spark): every pass graded D, and the puzzle did not look like a game

### DIFF
--- a/DEFECTS.md
+++ b/DEFECTS.md
@@ -2132,6 +2132,17 @@ ark_trades13, Discord debug exports on v3.18.0, 2026-08-30: the 12:39 export car
 
 **fixed v3.18.1** (refusal memory: a FIRST 403 on (endpoint, method) records a sliding 10-minute entry — any later 403 refreshes it, a 200 clears it — that ranks the endpoint behind the healthy hedge for that method WITHOUT the two-strike requirement and WITHOUT feeding methodBlockedEverywhere; when every pool endpoint carries live refusal memory for getMultipleAccounts, getAccountsResilient skips the doomed batch entirely and goes straight to getAccountsIndividually; fallback-transition noteFeedError is throttled to once per (fn, minute). D-62 chunking at GMA_MAX_KEYS=20 preserved; a decayed trial restores the batch lane. Locked by `test/d65_refusal_memory.test.js` — 8 tests; negative control: stashed fix = 3/8, restored = 8/8. Contract: `.contracts/validation-contract-d65.md`.)
 
+**D-69 · S1 · Every Daily Spark pass graded D — including the perfect one, while TRADING the same trap scored a B**
+`server/core/spark.js` gradePass
+
+Found in playtest: *"why is it always a bad grade — I get a D when I skip because I knew it was going down anyway."* It was not variance. `letterForScore` reads a THREE-axis sum and its table only awards above D from 5 up (`>=9 S | 8 A | 7 B | 6,5 C | else D`). `gradePass` judges ONE axis and handed that table `AXIS_SCORE[tone]` directly — 3, 2 or 1 — so green, yellow and red all fell into the `else` and returned the same letter. The tone and the story were computed correctly throughout, which is what made it unreadable to play: the card printed a green 🟩 "the pass dodged the bleed" beside a red **D**.
+
+Measured on a flat chart that dropped 40% after T: pass = **D**, buying that same dip and selling the bounce = **B**. The rubric therefore paid better for taking a trap than for avoiding it — inverting the product's own doctrine, since not taking the trade is the discipline Spark exists to teach and was the only call that could never be rewarded.
+
+The existing rubric test asserted the pass's axis emoji and story but never its letter, which is the gap this shipped through.
+
+**fixed** (a pass expresses on its single axis what a trade expresses on three, so it scales by three: `AXIS_SCORE[tone] * 3` → green 9 = S, yellow 6 = C, red 3 = D. Verdict shape, axis count and the no-PnL doctrine are untouched. Locked by `server/test/spark-passgrade.test.js` — 6 tests, including one pinning that the three tones produce three DIFFERENT letters and one pinning that a correct pass is never out-scored by trading the same trap; negative control: restored bug = 2/6, fix = 6/6.)
+
 ---
 
 ## V — Visual polish

--- a/extension/dashboard.html
+++ b/extension/dashboard.html
@@ -906,50 +906,160 @@
     .tg-legend .tg-cell { width: 12px; height: 12px; }
     .tg-sub { max-width: 720px; margin: 4px 0 10px; }
 
-    /* ---- Daily Spark (A2) ---- */
-    .spark-head { display: flex; align-items: baseline; gap: 12px; margin: 4px 0 10px; }
-    .spark-title { font-size: 13px; font-weight: 800; letter-spacing: 1.4px; color: var(--text); }
-    .spark-date { font-size: 12px; color: var(--dim); }
-    .spark-about { font-size: 12.5px; color: var(--muted, #8b93a7); line-height: 1.55;
-      margin: 0 0 12px; max-width: 640px; }
-    .spark-body { max-width: 720px; }
-    .spark-chart { position: relative; border: 1px solid rgba(255,255,255,0.10);
-      border-radius: 10px; padding: 10px; background: rgba(10,13,19,0.5); }
-    .spark-canvas { width: 100%; height: auto; display: block; cursor: crosshair; }
-    .spark-chart-legend { display: flex; gap: 14px; margin-top: 8px; font-size: 11px; color: var(--dim); }
-    .spark-legend-item { display: inline-flex; align-items: center; gap: 5px; }
-    .spark-legend-item i { width: 10px; height: 10px; border-radius: 2px; display: inline-block; }
+    /* ---- Daily Spark (A2) ----
+       A game, laid out like one: a centred stage with the board at the
+       middle of it. The first pass rendered into the section's normal
+       left-aligned prose column at 760x230, so on a wide dashboard it read
+       as a screenshot somebody had pasted in rather than a thing you play. */
+    .spark-stage { max-width: 980px; margin: 0 auto; padding: 4px 0 8px; }
+
+    /* The title carries the game, so it is sized like a title. */
+    .spark-head { text-align: center; margin: 0 0 6px; }
+    .spark-title {
+      font-size: clamp(30px, 4.4vw, 46px); font-weight: 800;
+      letter-spacing: -0.03em; line-height: 1.02; color: var(--text);
+    }
+    .spark-date {
+      display: inline-flex; align-items: center; gap: 7px; margin-top: 9px;
+      font-family: var(--mono); font-size: 11px; font-weight: 700;
+      letter-spacing: 1.1px; text-transform: uppercase; color: var(--dim);
+      background: var(--raised); border: 1px solid var(--line);
+      border-radius: 999px; padding: 5px 12px;
+    }
+    .spark-date .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--amber); }
+
+    /* One sentence, centred. The old three-line paragraph explained the
+       whole game before you were allowed to touch it — the steps below do
+       that job now, in the order you actually need them. */
+    .spark-about {
+      font-size: 14px; color: var(--dim); line-height: 1.6;
+      margin: 12px auto 0; max-width: 56ch; text-align: center;
+    }
+    .spark-about b { color: var(--text); font-weight: 700; }
+
+    /* The instant-result promise, stated where the wait would be feared.
+       The tape is history the server already holds; nothing is pending. */
+    .spark-instant {
+      display: inline-flex; align-items: center; gap: 7px; margin-top: 12px;
+      font-size: 12px; font-weight: 650; color: var(--green);
+      background: rgba(52,211,153,0.09); border: 1px solid rgba(52,211,153,0.28);
+      border-radius: 999px; padding: 5px 13px;
+    }
+
+    /* ---- the step rail: what to do, in order ---- */
+    .spark-steps {
+      display: flex; align-items: stretch; justify-content: center;
+      gap: 8px; margin: 20px auto 14px; flex-wrap: wrap;
+    }
+    .spark-step {
+      display: flex; align-items: center; gap: 9px;
+      padding: 9px 14px; border-radius: var(--r-md);
+      border: 1px solid var(--line); background: var(--raised);
+      font-size: 12.5px; font-weight: 650; color: var(--dim);
+      transition: color .18s, border-color .18s, background .18s;
+    }
+    .spark-step .n {
+      width: 20px; height: 20px; flex: none; border-radius: 50%;
+      display: grid; place-items: center;
+      font-family: var(--mono); font-size: 10.5px; font-weight: 700;
+      background: rgba(255,255,255,0.07); color: var(--faint);
+    }
+    /* Only the step you are ON lights up — a rail where everything glows
+       tells you nothing about where you are. */
+    .spark-step.on {
+      color: var(--text); border-color: rgba(255,157,69,0.45);
+      background: rgba(255,157,69,0.08);
+    }
+    .spark-step.on .n { background: var(--amber); color: #2A1400; }
+    .spark-step.done { color: var(--green); border-color: rgba(52,211,153,0.3); }
+    .spark-step.done .n { background: rgba(52,211,153,0.18); color: var(--green); }
+
+    /* ---- the board ---- */
+    .spark-chart {
+      position: relative; border: 1px solid var(--line-2);
+      border-radius: var(--r-lg); padding: 14px; background: rgba(6,8,12,0.6);
+      box-shadow: var(--shadow-md);
+    }
+    .spark-canvas { width: 100%; height: auto; display: block; cursor: crosshair; border-radius: var(--r-sm); }
+    .spark-chart-legend {
+      display: flex; gap: 16px; margin-top: 11px; flex-wrap: wrap;
+      font-size: 11.5px; color: var(--dim);
+    }
+    .spark-legend-item { display: inline-flex; align-items: center; gap: 6px; }
+    .spark-legend-item i { width: 11px; height: 11px; border-radius: 3px; display: inline-block; }
     .spark-lane-key { background: rgba(255,157,69,0.18);
-      border: 1px dashed rgba(255,157,69,0.55); border-radius: 2px; }
-    .spark-hint { font-size: 12.5px; color: var(--dim); margin: 10px 0 0; line-height: 1.5; min-height: 1.5em; }
-    .spark-picks { display: flex; flex-direction: column; gap: 6px; margin: 10px 0 0; }
-    .spark-pick { display: flex; align-items: center; gap: 10px; font-size: 12.5px;
-      border: 1px solid rgba(255,255,255,0.10); border-radius: 8px; padding: 6px 10px;
-      background: rgba(255,255,255,0.03); max-width: 480px; }
-    .spark-pick-name { display: inline-flex; align-items: center; gap: 6px; font-weight: 750; }
-    .spark-pick-name i { width: 9px; height: 9px; border-radius: 2px; display: inline-block; }
-    .spark-pick-min { color: var(--dim); }
-    .spark-pick-ctl { margin-left: auto; display: inline-flex; gap: 4px; }
-    .spark-pick-ctl button { border: 1px solid rgba(255,255,255,0.16); border-radius: 6px;
-      background: rgba(255,255,255,0.04); color: var(--text); cursor: pointer;
-      min-width: 26px; height: 24px; font-size: 13px; line-height: 1; }
-    .spark-pick-ctl button:hover:not(:disabled) { border-color: var(--accent, #FF9D45); }
+      border: 1px dashed rgba(255,157,69,0.55); border-radius: 3px; }
+
+    .spark-hint {
+      font-size: 13.5px; color: var(--text); margin: 14px 0 0; line-height: 1.55;
+      min-height: 1.55em; text-align: center; font-weight: 600;
+    }
+
+    /* ---- the picks ---- */
+    .spark-picks {
+      display: flex; flex-wrap: wrap; justify-content: center;
+      gap: 8px; margin: 14px 0 0; min-height: 0;
+    }
+    .spark-pick {
+      display: flex; align-items: center; gap: 10px; font-size: 13px;
+      border: 1px solid var(--line-2); border-radius: var(--r-md);
+      padding: 8px 10px 8px 13px; background: var(--raised);
+    }
+    .spark-pick-name { display: inline-flex; align-items: center; gap: 7px; font-weight: 750; }
+    .spark-pick-name i { width: 10px; height: 10px; border-radius: 3px; display: inline-block; }
+    .spark-pick-min { color: var(--dim); font-family: var(--mono); font-size: 12px; }
+    .spark-pick-ctl { display: inline-flex; gap: 4px; }
+    .spark-pick-ctl button {
+      border: 1px solid var(--line-2); border-radius: var(--r-sm);
+      background: rgba(255,255,255,0.05); color: var(--text); cursor: pointer;
+      min-width: 30px; height: 28px; font-size: 15px; line-height: 1;
+      transition: border-color .15s, background .15s;
+    }
+    .spark-pick-ctl button:hover:not(:disabled) { border-color: var(--amber); background: rgba(255,157,69,0.12); }
     .spark-pick-ctl button:disabled { opacity: 0.4; cursor: default; }
-    .spark-actions { display: flex; gap: 8px; margin: 12px 0 6px; flex-wrap: wrap; }
-    .spark-btn { border: 1px solid rgba(255,255,255,0.18); border-radius: 8px;
-      padding: 8px 14px; font-size: 12.5px; font-weight: 750; letter-spacing: 0.8px;
-      background: rgba(255,255,255,0.04); color: var(--text); cursor: pointer; }
-    .spark-btn:hover:not(:disabled) { border-color: var(--accent, #FF9D45); color: var(--accent, #FF9D45); }
-    .spark-btn:disabled { opacity: 0.4; cursor: default; }
-    .spark-btn.armed { border-color: var(--green); color: var(--green); }
-    .spark-verdict { margin-top: 14px; border: 1px solid rgba(255,255,255,0.12);
-      border-radius: 10px; padding: 14px; background: rgba(10,13,19,0.5); }
-    .spark-grade { font-size: 64px; font-weight: 800; line-height: 1; }
-    .spark-grade-label { font-size: 15px; font-weight: 750; margin-top: 4px; }
-    .spark-axis-line { font-size: 12.5px; color: var(--dim); margin-top: 8px; }
-    .spark-story { font-size: 12.5px; color: var(--muted, #8b93a7); margin-top: 10px; line-height: 1.5; }
-    .spark-share-row { margin-top: 12px; }
-    .spark-error { color: var(--red); font-size: 12.5px; margin: 8px 0 0; }
+
+    /* ---- actions: one primary, the rest quiet ---- */
+    .spark-actions {
+      display: flex; gap: 10px; margin: 18px 0 6px;
+      flex-wrap: wrap; justify-content: center;
+    }
+    .spark-btn {
+      border: 1px solid var(--line-2); border-radius: var(--r-md);
+      padding: 11px 18px; font-size: 13px; font-weight: 700; letter-spacing: 0.2px;
+      background: var(--raised); color: var(--text); cursor: pointer;
+      transition: border-color .15s, background .15s, color .15s, transform .12s;
+    }
+    .spark-btn:hover:not(:disabled) { border-color: var(--amber); color: var(--amber-2); background: rgba(255,157,69,0.08); }
+    .spark-btn:active:not(:disabled) { transform: translateY(1px); }
+    .spark-btn:disabled { opacity: 0.38; cursor: not-allowed; }
+    .spark-btn.armed { border-color: var(--green); color: var(--green); background: rgba(52,211,153,0.1); }
+    /* The one button that finishes the round reads as the one that does. */
+    .spark-btn.primary {
+      background: linear-gradient(180deg, var(--amber-2), var(--amber));
+      border-color: transparent; color: #2A1400; font-weight: 800;
+      box-shadow: 0 8px 22px -8px rgba(255,157,69,0.7);
+    }
+    .spark-btn.primary:hover:not(:disabled) {
+      color: #2A1400; background: linear-gradient(180deg, #FFD0A0, #FFA75A);
+      border-color: transparent;
+    }
+    .spark-btn.primary:disabled { box-shadow: none; }
+
+    /* ---- verdict ---- */
+    .spark-verdict {
+      margin-top: 18px; border: 1px solid var(--line-2);
+      border-radius: var(--r-lg); padding: 22px; background: rgba(6,8,12,0.6);
+      text-align: center; box-shadow: var(--shadow-md);
+    }
+    .spark-grade { font-size: 76px; font-weight: 800; line-height: 1; letter-spacing: -0.04em; }
+    .spark-grade-label { font-size: 16px; font-weight: 750; margin-top: 6px; }
+    .spark-axis-line { font-size: 13px; color: var(--dim); margin-top: 12px; }
+    .spark-story {
+      font-size: 13.5px; color: var(--text); margin: 12px auto 0;
+      line-height: 1.6; max-width: 52ch;
+    }
+    .spark-share-row { margin-top: 16px; }
+    .spark-error { color: var(--red); font-size: 13px; margin: 10px 0 0; text-align: center; }
 
     /* ---- Trench Wrapped (B1) ---- */
     .wr-head { margin: 4px 0 10px; }

--- a/extension/spark.js
+++ b/extension/spark.js
@@ -148,7 +148,13 @@
    */
   function chartGeom(w, h, nBars) {
     const pad = 8;
-    const laneFrac = 0.25;
+    // The lane is the PLAYING FIELD — every tap the game accepts lands in it,
+    // and it has to hold sixty distinct minutes. At a quarter of the width it
+    // was ~2.5px per minute on the shipped canvas: placing a specific minute
+    // meant nudging with the steppers because the tap could not be aimed.
+    // Giving it over a third makes the target real, and it also stops the
+    // board reading as "a chart, with a sliver of something at the end".
+    const laneFrac = 0.38;
     const tX = pad + (w - pad * 2) * (1 - laneFrac);
     return {
       w, h, pad, tX,
@@ -257,8 +263,20 @@
     } catch (err) {
       console.warn('PaperTrench: spark practice failed —', err && err.sparkReason ? err.sparkReason : err);
       if (el) {
-        el.innerHTML = '<p class="spark-error">Practice is unavailable right now — try again in a moment. '
-          + '<button type="button" class="linkish" id="spark-practice-retry">Try again</button></p>';
+        // "Try again in a moment" is only true for a TRANSIENT failure. When
+        // the grader answers 404/not-found the practice route is not there to
+        // be retried — the server is older than this build — and inviting a
+        // retry that can never work is how a broken feature reads as a flaky
+        // one. Say which it is, and only offer the retry when retrying can
+        // actually change the answer.
+        const reason = String((err && err.sparkReason) || '');
+        const missing = /404|not-found/.test(reason);
+        el.innerHTML = missing
+          ? '<p class="spark-error">Practice rounds aren\'t available on the server yet — '
+            + 'today\'s puzzle still works. <button type="button" class="linkish" '
+            + 'id="spark-practice-retry">Check again</button></p>'
+          : '<p class="spark-error">Couldn\'t load a practice round — the grader didn\'t answer. '
+            + '<button type="button" class="linkish" id="spark-practice-retry">Try again</button></p>';
         const retry = el.querySelector('#spark-practice-retry');
         if (retry) retry.addEventListener('click', () => loadPractice(el));
       }
@@ -272,46 +290,69 @@
     if (!el || !model) return;
     const practice = !!(opts && opts.practice);
     el.innerHTML = '';
+    const stage = document.createElement('div');
+    stage.className = 'spark-stage';
+    el.appendChild(stage);
+
     const head = document.createElement('div');
     head.className = 'spark-head';
     head.innerHTML = `
-      <div class="spark-title">DAILY SPARK</div>
-      <div class="spark-date">${practice
-        ? 'Practice round · seed ' + String(model.day).replace(/^practice-/, '')
+      <div class="spark-title">${practice ? 'Practice Round' : 'Daily Spark'}</div>
+      <div class="spark-date"><span class="dot"></span>${practice
+        ? 'Seed ' + String(model.day).replace(/^practice-/, '')
         : model.dateText}</div>
     `;
-    el.appendChild(head);
+    stage.appendChild(head);
 
+    // One sentence. The step rail below teaches the rest, in the order it is
+    // needed — the old paragraph explained the whole game up front and was
+    // the first thing standing between a player and the board.
     const about = document.createElement('p');
     about.className = 'spark-about';
-    about.textContent = practice
-      ? 'Same game as the daily, unlimited: a real launch with the name hidden, played blind. Tap the shaded lane where you\'d get in and out — you\'re graded on entry, exit and nerve, never on money.'
-      : 'One real launch a day, name hidden. The tape stops at the line — the shaded lane is the next hour, which you never get to see. Tap the lane where you\'d get in and out. You\'re graded on entry, exit and nerve — never on money. Want more than one a day? Practice rounds are unlimited.';
-    el.appendChild(about);
+    about.innerHTML = practice
+      ? 'A real launch with its name hidden. Guess <b>when you\'d buy</b> — and when you\'d sell — in the hour the chart doesn\'t show you.'
+      : 'One real launch a day, name hidden. Guess <b>when you\'d buy</b> — and when you\'d sell — in the hour the chart doesn\'t show you.';
+    stage.appendChild(about);
+
+    // The wait people fear does not exist: the tape is history the server
+    // already holds, so the grade is one request away. Saying so here is the
+    // difference between a daily puzzle and a daily errand.
+    const instant = document.createElement('div');
+    instant.style.textAlign = 'center';
+    instant.innerHTML = '<span class="spark-instant">'
+      + '<svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">'
+      + '<path d="M13 2 4.5 13.5H11l-1 8.5 8.5-11.5H12z"/></svg>'
+      + 'Graded the moment you commit — no waiting</span>';
+    stage.appendChild(instant);
 
     const body = document.createElement('div');
     body.className = 'spark-body';
     body.innerHTML = `
+      <div class="spark-steps">
+        <div class="spark-step" data-step="1"><span class="n">1</span><span>Pick your buy</span></div>
+        <div class="spark-step" data-step="2"><span class="n">2</span><span>Pick your sell <span style="opacity:.65">(optional)</span></span></div>
+        <div class="spark-step" data-step="3"><span class="n">3</span><span>See your grade</span></div>
+      </div>
       <div class="spark-chart">
-        <canvas class="spark-canvas" width="760" height="230" role="img"></canvas>
+        <canvas class="spark-canvas" width="1120" height="420" role="img"></canvas>
         <div class="spark-chart-legend">
-          <span class="spark-legend-item"><i style="background:${TONE.green.color}"></i> entry</span>
-          <span class="spark-legend-item"><i style="background:${EXIT_COLOR}"></i> exit</span>
-          <span class="spark-legend-item"><i class="spark-lane-key"></i> the unknown hour</span>
+          <span class="spark-legend-item"><i style="background:${TONE.green.color}"></i> your buy</span>
+          <span class="spark-legend-item"><i style="background:${EXIT_COLOR}"></i> your sell</span>
+          <span class="spark-legend-item"><i class="spark-lane-key"></i> the hidden hour — tap in here</span>
         </div>
       </div>
       <p class="spark-hint" role="status" aria-live="polite"></p>
       <div class="spark-picks"></div>
       <div class="spark-actions">
-        <button type="button" class="spark-btn spark-pass">I'D SIT THIS ONE OUT</button>
-        <button type="button" class="spark-btn spark-reset" hidden>START OVER</button>
-        <button type="button" class="spark-btn spark-reveal" disabled>REVEAL GRADE</button>
-        <button type="button" class="spark-btn spark-practice" title="${practice ? 'Another random blind chart' : 'Unlimited rounds on random blind charts'}">${practice ? 'NEXT PUZZLE' : 'PRACTICE'}</button>
+        <button type="button" class="spark-btn primary spark-reveal" disabled>SEE MY GRADE</button>
+        <button type="button" class="spark-btn spark-pass">I'd skip this one</button>
+        <button type="button" class="spark-btn spark-reset" hidden>Play again</button>
+        <button type="button" class="spark-btn spark-practice" title="${practice ? 'Another random blind chart' : 'Unlimited rounds on random blind charts'}">${practice ? 'New puzzle' : 'Practice round'}</button>
       </div>
       <p class="spark-error" hidden></p>
       <div class="spark-verdict" hidden></div>
     `;
-    el.appendChild(body);
+    stage.appendChild(body);
 
     const canvas = body.querySelector('.spark-canvas');
     const hintEl = body.querySelector('.spark-hint');
@@ -326,6 +367,7 @@
     const geom = chartGeom(canvas.width, canvas.height, model.bars.length);
     let plan = { pass: false, entryMin: null, exitMin: null };
     let aftermath = null; // bars revealed with the verdict
+    let locked = false;   // the round is committed; picks are final
 
     const paint = () => {
       drawChart(canvas, model.bars, model.tTs, {
@@ -344,18 +386,30 @@
     };
 
     const hintFor = () => {
-      if (aftermath) return 'The lane now shows the tape you didn\'t get — your call was graded against exactly this.';
-      if (plan.pass) return 'You\'d sit this one out. Reveal to see whether the pass was the right call.';
-      if (plan.entryMin === null) return 'Tap the shaded lane where you\'d get in — minute 1 is just after the line, 60 is the end. The +/- buttons work too.';
-      if (plan.exitMin === null) return `Entry +${plan.entryMin}m. Now tap when you'd get out — or leave it unset to hold to the end of the hour.`;
-      return `Entry +${plan.entryMin}m, exit +${plan.exitMin}m. Tap near a marker to move it, or reveal.`;
+      if (aftermath) return 'That\'s the hour you couldn\'t see — your call was graded against exactly this tape.';
+      if (plan.pass) return 'You\'re skipping this one. Hit SEE MY GRADE to find out whether that was the right call.';
+      if (plan.entryMin === null) return 'Tap anywhere in the shaded lane — that\'s the hidden hour. Where would you have bought?';
+      if (plan.exitMin === null) return `Buying ${plan.entryMin} min in. Now tap where you'd sell — or just hit SEE MY GRADE to hold to the end.`;
+      return `Buy at +${plan.entryMin} min, sell at +${plan.exitMin} min. Tap near a marker to move it.`;
     };
 
-    const setLocked = (locked) => {
+    /* Committed state, held as DATA rather than applied once.
+     *
+     * setLocked used to disable the controls directly, and every later sync()
+     * put them straight back: sync() rebuilds the pick rows from scratch, so
+     * the fresh +/-/x buttons came back enabled, and the grade handler's
+     * `finally` re-enabled the reveal button after setLocked(true) had just
+     * disabled it. The round was therefore never actually committed — you
+     * could nudge an entry after seeing the grade and re-reveal, fishing for
+     * a better one. Keeping it as state and applying it at the END of sync
+     * is what makes "committed" mean committed. */
+    const setLocked = (value) => { locked = value; };
+    const applyLock = () => {
       // The practice button is deliberately NOT locked: the loop is the
       // feature — a verdict never traps the player, another round is always
       // one click away.
-      for (const b of [passBtn, revealBtn, ...picksEl.querySelectorAll('button')]) b.disabled = locked;
+      for (const b of [passBtn, ...picksEl.querySelectorAll('button')]) b.disabled = locked;
+      if (locked) revealBtn.disabled = true;
       resetBtn.hidden = !locked;
     };
 
@@ -366,11 +420,11 @@
         row.className = 'spark-pick';
         row.innerHTML = `
           <span class="spark-pick-name"><i style="background:${color}"></i> ${name}</span>
-          <span class="spark-pick-min">+${minute}m after the line</span>
+          <span class="spark-pick-min">+${minute} min</span>
           <span class="spark-pick-ctl">
-            <button type="button" aria-label="${name} one minute earlier">−</button>
-            <button type="button" aria-label="${name} one minute later">+</button>
-            <button type="button" aria-label="Clear ${name.toLowerCase()}">×</button>
+            <button type="button" aria-label="${name} one minute earlier" title="One minute earlier">−</button>
+            <button type="button" aria-label="${name} one minute later" title="One minute later">+</button>
+            <button type="button" aria-label="Clear ${name.toLowerCase()}" title="Clear">×</button>
           </span>`;
         const [minus, plus, clear] = row.querySelectorAll('button');
         minus.addEventListener('click', () => onNudge(-1));
@@ -381,13 +435,13 @@
       if (plan.pass) {
         const row = document.createElement('div');
         row.className = 'spark-pick';
-        row.innerHTML = '<span class="spark-pick-name"><i style="background:#8b93a7"></i> No trade</span>'
-          + '<span class="spark-pick-min">sitting this one out</span>';
+        row.innerHTML = '<span class="spark-pick-name"><i style="background:#8b93a7"></i> Skipping</span>'
+          + '<span class="spark-pick-min">no trade</span>';
         picksEl.appendChild(row);
         return;
       }
       if (plan.entryMin !== null) {
-        picksEl.appendChild(mkRow('Entry', ENTRY_COLOR, plan.entryMin, (d) => {
+        picksEl.appendChild(mkRow('Buy', ENTRY_COLOR, plan.entryMin, (d) => {
           plan = plan.entryMin + d >= 1
             ? planWithEntry(plan, plan.entryMin + d)
             : plan;
@@ -395,19 +449,45 @@
         }, () => { plan = { ...plan, entryMin: null, exitMin: null }; sync(); }));
       }
       if (plan.exitMin !== null) {
-        picksEl.appendChild(mkRow('Exit', EXIT_COLOR, plan.exitMin, (d) => {
+        picksEl.appendChild(mkRow('Sell', EXIT_COLOR, plan.exitMin, (d) => {
           const next = planWithExit(plan, plan.exitMin + d);
           if (next && next.exitMin > plan.entryMin) { plan = next; sync(); }
         }, () => { plan = { ...plan, exitMin: null }; sync(); }));
       }
     };
 
+    /* Which step the player is actually on, so the rail says where they are
+     * rather than lighting everything at once. A pass skips straight to the
+     * commit — sitting out IS a complete answer. */
+    const syncSteps = () => {
+      const steps = body.querySelectorAll('.spark-step');
+      const state = aftermath ? 'done'
+        : plan.pass ? 'commit'
+          : plan.entryMin === null ? 'entry'
+            : plan.exitMin === null ? 'exit' : 'commit';
+      const at = { entry: 1, exit: 2, commit: 3, done: 4 }[state];
+      steps.forEach((s) => {
+        const n = Number(s.dataset.step);
+        s.classList.toggle('on', n === at);
+        s.classList.toggle('done', n < at);
+      });
+    };
+
     const sync = () => {
       passBtn.classList.toggle('armed', plan.pass);
-      revealBtn.disabled = !(plan.pass || plan.entryMin !== null);
+      const ready = plan.pass || plan.entryMin !== null;
+      revealBtn.disabled = !ready;
+      // A disabled control that will not say what it wants is a dead end.
+      revealBtn.title = ready
+        ? 'Grade this call now'
+        : 'Tap the shaded lane to pick your buy first — or choose "I\'d skip this one"';
       hintEl.textContent = hintFor();
       renderPicks();
+      syncSteps();
       paint();
+      // Last: renderPicks() has just built fresh controls, so the lock has to
+      // be applied after them or a committed round hands back live steppers.
+      applyLock();
     };
 
     canvas.addEventListener('click', (e) => {
@@ -448,7 +528,7 @@
       verdictBox.innerHTML = '';
       errorEl.hidden = true;
       setLocked(false);
-      revealBtn.textContent = 'REVEAL GRADE';
+      revealBtn.textContent = 'SEE MY GRADE';
       sync();
     });
 
@@ -485,8 +565,11 @@
         errorEl.textContent = gradeErrorCopy(isNetwork ? 'network' : (err && err.sparkReason) || '');
         errorEl.hidden = false;
       } finally {
-        revealBtn.textContent = 'REVEAL GRADE';
-        revealBtn.disabled = false;
+        // Restore the label, then let sync() decide whether the button may be
+        // pressed again. Forcing `disabled = false` here is what un-committed
+        // a graded round: a failed grade must be retryable, a successful one
+        // must not, and only the lock knows which happened.
+        revealBtn.textContent = 'SEE MY GRADE';
         sync();
       }
     });

--- a/server/core/spark.js
+++ b/server/core/spark.js
@@ -261,7 +261,17 @@ function gradePass(chart, tTs, endTs) {
   else if (rip < 1.15) tone = 'yellow';  // nothing was there — fair pass
   else tone = 'red';                     // it paid to be in
   return {
-    grade: letterForScore(AXIS_SCORE[tone]),
+    // letterForScore reads a THREE-axis sum (3..9). A pass is judged on one
+    // axis, so handing it AXIS_SCORE[tone] directly fed the table 1, 2 or 3 —
+    // and every value at or below 4 returns 'D'. Every pass therefore graded
+    // D, including the perfect one: the card printed a green "the pass dodged
+    // the bleed" next to a D, while TRADING the same trap scored a B. It made
+    // the one decision this product most wants to teach — not taking the
+    // trade — the only decision that could never be rewarded.
+    //
+    // A pass expresses on its single axis what a trade expresses on three, so
+    // it scales by three: green -> 9 (S), yellow -> 6 (C), red -> 3 (D).
+    grade: letterForScore(AXIS_SCORE[tone] * 3),
     passed: true, heldToEnd: false,
     axes: [{ key: 'read', tone, label: AXIS.read.label, emoji: EMOJI[tone], text: AXIS.read[tone] }],
     story: PASS_STORY[tone],

--- a/server/test/spark-passgrade.test.js
+++ b/server/test/spark-passgrade.test.js
@@ -1,0 +1,117 @@
+'use strict';
+/* Every pass graded D — including the perfect one.
+ *
+ * Field report while playtesting: "why is it always a bad grade — I get a D
+ * when I skip because I knew it was going down anyway".
+ *
+ * letterForScore reads a THREE-axis sum and its table only starts awarding
+ * above D at 5:
+ *
+ *   >=9 S | 8 A | 7 B | 6,5 C | else D
+ *
+ * gradePass judges ONE axis and handed that table AXIS_SCORE[tone] directly —
+ * 3, 2 or 1. All three fall into the `else`, so green, yellow and red all
+ * returned 'D'. The tone and the story were computed correctly the whole
+ * time, which is what made it so confusing to play: the card printed a green
+ * "the pass dodged the bleed" next to a big red D, while TRADING that same
+ * trap scored a B.
+ *
+ * That inverted the product's own doctrine. Not taking the trade is the
+ * discipline this thing exists to teach, and it was the one call that could
+ * never be rewarded.
+ *
+ * The existing rubric test asserted the pass's axis emoji and story but never
+ * its letter, which is exactly the gap this shipped through — so these tests
+ * are about the LETTER, and one of them pins that a pass can reach the top.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const S = require('../core/spark.js');
+
+const MIN = 60000;
+
+/** A chart that is flat until T, then dips to `dipTo` and rips to `ripTo`. */
+function chartWith({ dipTo, ripTo }) {
+  const bars = [];
+  const t0 = Date.UTC(2026, 0, 1);
+  for (let i = 0; i < 130; i++) {
+    bars.push({ ts: t0 + i * MIN, o: 100, h: 100, l: 100, c: 100 });
+  }
+  for (let i = 0; i <= 60; i++) {
+    bars.push({
+      ts: t0 + (130 + i) * MIN,
+      o: 100, c: 100,
+      h: i === 40 ? ripTo : 100,
+      l: i === 20 ? dipTo : 100,
+    });
+  }
+  return bars;
+}
+
+const gradePassOn = (shape) => {
+  const chart = chartWith(shape);
+  const tTs = chart[130].ts;
+  return S.gradeRun(
+    S.validateActions([{ type: 'pass', ts: tTs + MIN }], tTs), chart, tTs);
+};
+
+test('a pass that dodged a real bleed is the best read available, not a D', () => {
+  const g = gradePassOn({ dipTo: 60, ripTo: 100 });   // -40%
+  assert.equal(g.axes[0].emoji, S.EMOJI.green, 'the tone was always right');
+  assert.equal(g.grade, 'S',
+    'the letter must agree with the tone — a green read cannot print a D');
+});
+
+test('a pass on a chart where nothing happened is unremarkable, not failing', () => {
+  const g = gradePassOn({ dipTo: 98, ripTo: 105 });
+  assert.equal(g.axes[0].emoji, S.EMOJI.yellow);
+  assert.equal(g.grade, 'C', 'a fair pass sits in the middle of the scale');
+});
+
+test('a pass on a chart that ran without you is the one that deserves a D', () => {
+  const g = gradePassOn({ dipTo: 100, ripTo: 160 });  // +60%
+  assert.equal(g.axes[0].emoji, S.EMOJI.red);
+  assert.equal(g.grade, 'D');
+});
+
+test('the three pass tones produce three DIFFERENT letters', () => {
+  // The whole defect in one assertion: the outcomes must be distinguishable.
+  const letters = [
+    gradePassOn({ dipTo: 60, ripTo: 100 }).grade,
+    gradePassOn({ dipTo: 98, ripTo: 105 }).grade,
+    gradePassOn({ dipTo: 100, ripTo: 160 }).grade,
+  ];
+  assert.equal(new Set(letters).size, 3,
+    'a rubric that returns the same letter for every outcome grades nothing: '
+    + 'got ' + JSON.stringify(letters));
+});
+
+test('a correct pass is not out-scored by trading the same trap', () => {
+  // The doctrine check. Dodging a -40% trap must not be worth less than
+  // taking it — that is the lesson the product is built to teach.
+  const shape = { dipTo: 60, ripTo: 100 };
+  const chart = chartWith(shape);
+  const tTs = chart[130].ts;
+  const RANK = { S: 6, A: 5, B: 4, C: 3, D: 2, F: 1 };
+
+  const pass = gradePassOn(shape);
+  const traded = S.gradeRun(S.validateActions([
+    { type: 'buy', ts: tTs + 20 * MIN },
+    { type: 'sell', ts: tTs + 40 * MIN },
+  ], tTs), chart, tTs);
+
+  assert.ok(RANK[pass.grade] >= RANK[traded.grade],
+    `dodging the trap (${pass.grade}) must not score below trading it (${traded.grade})`);
+});
+
+test('a pass still reports exactly one axis and no numbers', () => {
+  // The fix changes the LETTER only — the shape of the verdict and the
+  // no-PnL doctrine are untouched.
+  const g = gradePassOn({ dipTo: 60, ripTo: 100 });
+  assert.equal(g.passed, true);
+  assert.equal(g.axes.length, 1);
+  assert.equal(g.axes[0].key, 'read');
+  assert.doesNotMatch(JSON.stringify(g), /pnl|profit|roi|[0-9]+\.[0-9]+%/i,
+    'a verdict never carries a money figure');
+});


### PR DESCRIPTION
Two findings from a playtest. One is a scoring defect that inverts the feature''s own doctrine.

---

## D-69 — every pass graded D, including the perfect one

Reported as *"why is it always a bad grade — I get a D when I skip because I knew it was going down anyway."* It was not variance.

`letterForScore` reads a **three-axis** sum, and its table only awards above D from 5 up:

```
>=9 S | 8 A | 7 B | 6,5 C | else D
```

`gradePass` judges **one** axis and handed that table `AXIS_SCORE[tone]` directly — `3`, `2` or `1`. All three land in the `else`:

```
PASS grades, before:
  D  🟩 the pass dodged the bleed     <- it BLED 40%
  D  🟨 nothing was there              <- flat
  D  🟥 it paid to be in               <- it RAN 60%
```

The tone and story were computed correctly the whole time, which is what made it unreadable to play: the card printed a green 🟩 **"the pass dodged the bleed"** beside a red **D**.

### It paid better to take the trap than to avoid it

Same chart, −40% after T:

| Call | Grade |
|---|---|
| Passed on it | **D** |
| Bought the dip, sold the bounce | **B** |

Not taking the trade is the discipline Spark exists to teach, and it was the only call that could never be rewarded.

### Fix

A pass expresses on one axis what a trade expresses on three, so it scales by three — green `9` = **S**, yellow `6` = **C**, red `3` = **D**. Verdict shape, axis count and the no-PnL law are untouched.

The existing rubric test asserted the pass''s axis emoji and story but **never its letter** — precisely the gap this shipped through. `server/test/spark-passgrade.test.js` (6 tests) is about the letter, and pins two things directly: that the three tones produce three *different* letters, and that a correct pass is never out-scored by trading the same trap.

**Negative control:** restoring the bug fails 4 of 6. Fix passes 6/6.

---

## The interface

Reported as *"a small playing box someone pasted in"* — fair.

- **The board** was `760x230` rendered into the section''s left-aligned prose column. Now a centred 980px stage with an `1120x420` canvas.
- **The title** was 13px. A game''s title is sized like one.
- **Three lines of rules** came before you could touch anything. One sentence now, plus a numbered step rail that lights only the step you''re on — teaching the rest in the order it''s needed.
- **The tap lane** was a quarter of the width: ~2.5px per minute, so placing a specific minute meant giving up and using the steppers. Now 38% — the lane is the playing field, not a sliver at the end.
- **Four identical ghost buttons**, one of which finished the round. One primary now, and the disabled state says what it wants instead of sitting dead.
- Entry/exit → **"your buy"/"your sell"**; "the unknown hour" → **"the hidden hour — tap in here"**.
- Added a line stating the grade is immediate. It always was — the tape is history the server already holds — but nothing said so, and "daily puzzle" reads like something you wait on.

## Also fixed, found while testing every button

**The committed state did not hold.** `setLocked()` disabled the controls once and every later `sync()` undid it: `sync()` rebuilds the pick rows from scratch, and the grade handler''s `finally` re-enabled the reveal button. You could nudge an entry **after** seeing your grade and re-reveal — fishing for a better one. The lock is state now, applied at the end of `sync`.

**Practice failure copy.** "Try again in a moment" is only true for a transient fault. On a 404 the route is not there to be retried, and inviting a retry that cannot work makes a missing feature read as a flaky one.

## Verification

Server **306/306** (6 new), extension **2406/2406**, all site guards pass. Played end to end against a local harness running the real `spark.js` and the real grading core: buy, sell, skip, grade, play again, practice, and the committed-state lock.

---

> ### Unrelated but blocking: the Worker needs a deploy
>
> Production predates `12da58f` (Aug 31), which added **both** the practice route and the grade-origin exemption. Live right now:
>
> | Endpoint | Status |
> |---|---|
> | `/api/spark/today` | ✅ |
> | `/api/spark/practice` | ❌ 404 `not-found` |
> | `/api/spark/grade` | ❌ 403 `bad-origin` |
>
> So Daily Spark is currently unplayable in production — the chart loads, but it cannot be graded and practice does not exist. Nothing to write; it just needs `npx wrangler deploy`. That is why this PR was tested against a local mock of the three endpoints.